### PR TITLE
adding basic support for human artifact summaries in fetchNASIS_pedons()

### DIFF
--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -32,6 +32,9 @@ fetchNASIS_pedons <- function(SS=TRUE, rmHzErrors=TRUE, nullFragsAreZero=TRUE, s
   # there is a record for each phiid
   h <- join(h, extended_data$frag_summary, by='phiid', type='left')
   
+  # join hz + artifact
+  h <- join(h, extended_data$art_summary, by='phiid', type='left')
+  
   ## fix some common problems
   
   # replace missing lower boundaries
@@ -109,6 +112,9 @@ fetchNASIS_pedons <- function(SS=TRUE, rmHzErrors=TRUE, nullFragsAreZero=TRUE, s
     # this is computed by soilDB::simplifyFragmentData()
     # no para-frags
     h$total_frags_pct_nopf <- ifelse(is.na(h$total_frags_pct_nopf), 0, h$total_frags_pct_nopf)
+    
+    # this is computed by soilDB::simplifyArtifactData()
+    h$total_art_pct <- ifelse(is.na(h$total_art_pct), 0, h$total_art_pct)
   }
   
   # upgrade to SoilProfilecollection

--- a/R/humanArtifacts.R
+++ b/R/humanArtifacts.R
@@ -38,7 +38,7 @@
   # 
   # keep track of these for QC in an 'unspecified' column
   # but only when there is a fragment volume specified
-  idx <- which(is.na(res$class) & !is.na(res$fragvol))
+  idx <- which(is.na(res$class) & !is.na(res$huartvol))
   if( length(idx) > 0 ) {
     res$class[idx] <- 'art_unspecified'
   }

--- a/R/humanArtifacts.R
+++ b/R/humanArtifacts.R
@@ -1,0 +1,184 @@
+# code for dealing with human artifacts
+
+get_phhuart_from_NASIS_db <- function(SS=TRUE, stringsAsFactors = FALSE) {
+  # must have RODBC installed
+  if(!requireNamespace('RODBC'))
+    stop('please install the `RODBC` package', call.=FALSE)
+
+  # setup connection local NASIS
+  channel <- RODBC::odbcDriverConnect(connection=getOption('soilDB.NASIS.credentials'))
+  
+  # define query
+  q <- paste0("SELECT phiidref, seqnum, huartvol, huartsize_l, huartsize_r, huartsize_h,
+              huartkind, huartco, huartshp, huartrnd, huartpen, huartsafety, huartper, 
+              recwlupdated, recuseriidref, phhuartiid 
+              FROM phhuarts", ifelse(SS, "_View_1",""), ";")
+  
+  # exec query
+  d <- RODBC::sqlQuery(channel, q, stringsAsFactors=FALSE)
+  
+  # uncode metadata domains
+  d <- uncode(d, stringsAsFactors = stringsAsFactors)
+  return(d)
+}
+
+.artifactSieve <- function(x) {
+  # convert to lower case: NASIS metadata usese upper for labels, lower for values
+  x$huartco <- tolower(x$huartco)
+  x$huartshp <- tolower(x$huartshp)
+  
+  ## assumptions
+  # missing hardness = rock fragment
+  x$huartco[which(is.na(x$huartco))] <- 'cohesive'
+  # missing shape = Nonflat
+  x$huartshp[which(is.na(x$huartshp))] <- 'irregular'
+  
+  ## split flat/nonflat
+  idx <- grep('^flat', x$huartshp, ignore.case = TRUE, invert=TRUE)
+  arts <- x[idx, ]
+  
+  idx <- grep('^flat', x$huartshp, ignore.case = TRUE)
+  farts <- x[idx, ]
+  
+  ## sieve
+  # non-flat fragments
+  d <- ifelse(is.na(arts$huartsize_h), arts$huartsize_r, arts$huartsize_h)
+  arts$class <- .sieve(d, new.names = c('art_fgr', 'art_gr', 'art_cb', 
+                                        'art_st', 'art_by'))
+  
+  # flat artifacts
+  d <- ifelse(is.na(farts$huartsize_h), farts$huartsize_r, farts$huartsize_h)
+  farts$class <- .sieve(d, flat = TRUE, new.names = c('art_ch','art_fl', 'art_st', 'art_by'))
+  
+  # combine pieces, note may contain  RF classes == NA
+  res <- rbind(arts, farts)
+  
+  # what does an NA fragment class mean?
+  # 
+  # typically, fragment size missing
+  # or, worst-case, .sieve() rules are missing criteria 
+  # 
+  # keep track of these for QC in an 'unspecified' column
+  # but only when there is a fragment volume specified
+  idx <- which(is.na(res$class) & !is.na(res$fragvol))
+  if( length(idx) > 0 ) {
+    res$class[idx] <- 'art_unspecified'
+  }
+  
+  # done
+  return(res)
+}
+
+simplifyArtifactData <- function(art, id.var, nullFragsAreZero=TRUE) {
+  
+  # nasty hack to trick R CMD check
+  huartvol <- NULL
+  
+  # artifact size classes, using fragment breaks, are used in this function
+  # note that we are adding a catch-all for those strange phfrags records missing fragment size
+  art.classes <- c('art_fgr', 'art_gr', 'art_cb', 'art_st', 'art_by', 'art_ch', 'art_fl', 'art_unspecified')
+  
+  # first of all, we can't do anything if the fragment volume is NA
+  # warn the user and remove the offending records
+  if(any(is.na(art$huartvol))) {
+    warning('some records are missing artifact volume, these have been removed', call. = FALSE)
+  }
+  art <- art[which(!is.na(art$huartvol)), ]
+  
+  # if all fragvol are NA then rf is an empty data.frame and we are done
+  if(nrow(art) == 0) {
+    warning('all records are missing artifact volume, returing NULL', call. = FALSE)
+    return(NULL)
+  }
+  
+  
+  # extract classes
+  # note: these will put any fragments without fragsize into an 'unspecified' class
+  artifact.classes <- .artifactSieve(art)
+  
+  ## this is incredibly slow (~ 5 seconds for 30k records)
+  ## NOTE: this is performed on the data, as-is: not over all possible classes as enforced by factor levels
+  # sum volume by id and class
+  # rf.sums <- ddply(rf.classes, c(id.var, 'class'), plyr::summarise, volume=sum(fragvol, na.rm=TRUE))
+  
+  ## NOTE: this is performed on the data, as-is: not over all possible classes as enforced by factor levels
+  # sum volume by id and class
+  # much faster than ddply
+  # class cannot contain NA
+  art.sums <- aggregate(artifact.classes$huartvol, by=list(artifact.classes[[id.var]], artifact.classes[['class']]), FUN=sum, na.rm=TRUE)
+  # fix defualt names from aggregate()
+  names(art.sums) <- c(id.var, 'class', 'volume')
+  
+  
+  ## NOTE: we set factor levels here because the reshaping (long->wide) needs to account for all possible classes
+  ## NOTE: this must include all classes that related functions return
+  # set levels of classes
+  art.sums$class <- factor(art.sums$class, levels=art.classes)
+  
+  # convert to wide format
+  fm <- as.formula(paste0(id.var, ' ~ class'))
+  art.wide <- reshape2::dcast(art.sums, fm, value.var = 'volume', drop = FALSE)
+  
+  # must determine the index to the ID column in the wide format
+  id.col.idx <- which(names(art.wide) == id.var)
+  
+  ## optionally convert NULL frags -> 0
+  if(nullFragsAreZero & ncol(art.wide) > 1) {
+    art.wide <- as.data.frame(
+      cbind(art.wide[, id.col.idx, drop=FALSE], 
+            lapply(art.wide[, -id.col.idx], function(i) ifelse(is.na(i), 0, i))
+      ), stringsAsFactors=FALSE)
+  }
+  
+  # final sanity check: are there any fractions or the total >= 100%
+  # note: sapply() was previously used here
+  #       1 row in rf.wide --> result is a vector
+  #       >1 row in rf.wide --> result is a matrix
+  # solution: keep as a list
+  gt.100 <- lapply(art.wide[, -id.col.idx, drop=FALSE], FUN=function(i) i >= 100)
+  
+  # check each size fraction and report id.var if there are any
+  gt.100.matches <- sapply(gt.100, any, na.rm=TRUE)
+  if(any(gt.100.matches)) {
+    # search within each fraction
+    class.idx <- which(gt.100.matches)
+    idx <- unique(unlist(lapply(gt.100[class.idx], which)))
+    flagged.ids <- art.wide[[id.var]][idx]
+    
+    warning(sprintf("artifact volume >= 100%%\n%s:\n%s", id.var, paste(flagged.ids, collapse = "\n")), call. = FALSE)
+  }
+  
+  ## TODO: 0 is returned when all NA and nullFragsAreZero=FALSE
+  ## https://github.com/ncss-tech/soilDB/issues/57
+  # compute total fragments
+  # trap no frag condition
+  # includes unspecified class
+  if(ncol(art.wide) > 1) {
+    # calculate another column for total RF, ignoring parafractions
+    # index of columns to ignore, para*
+    #idx.pf <- grep(names(art.wide), pattern="para")
+    # also remove ID column
+    idx <- c(id.col.idx)#, idx.pf)
+    # this could result in an error if all fragments are para*
+    art.wide$total_art_pct <- rowSums(art.wide[, -idx], na.rm=TRUE)
+  }
+  
+  ## TODO: 0 is returned when all NA and nullFragsAreZero=FALSE
+  ## https://github.com/ncss-tech/soilDB/issues/57
+  # corrections:
+  # 1. fine gravel is a subset of gravel, therefore: gravel = gravel + fine_gravel
+  art.wide$art_gr <- rowSums(cbind(art.wide$art_gr, art.wide$art_fgr), na.rm = TRUE)
+  
+  # now, do some summaries of cohesion, shape, roundess, penetrability, safety and persistence
+  
+  art.wide$huartvol_cohesive <- sum(art$huartvol[art$huartco == "cohesive"], na.rm = TRUE)
+  art.wide$huartvol_penetrable <- sum(art$huartvol[art$huartpen == "penetrable"], na.rm = TRUE)
+  art.wide$huartvol_innocuous <- sum(art$huartvol[art$huartsafety == "innocuous artifacts"], na.rm = TRUE)
+  art.wide$huartvol_persistent <- sum(art$huartvol[art$huartper == "persistent"], na.rm = TRUE)
+  
+  # TODO: somehow summarize shape and roundness? we don't do that for regular frags
+  
+  # done
+  return(art.wide)
+}
+

--- a/R/simplfyFragmentData.R
+++ b/R/simplfyFragmentData.R
@@ -128,19 +128,27 @@ simplifyFragmentData <- function(rf, id.var, nullFragsAreZero=TRUE) {
   # note that we are adding a catch-all for those strange phfrags records missing fragment size
   frag.classes <- c('fine_gravel', 'gravel', 'cobbles', 'stones', 'boulders', 'channers', 'flagstones', 'parafine_gravel', 'paragravel', 'paracobbles', 'parastones', 'paraboulders', 'parachanners', 'paraflagstones', 'unspecified')
   
+  result.columns <- c('phiid', frag.classes, "total_frags_pct", "total_frags_pct_nopf")
+  
   # first of all, we can't do anything if the fragment volume is NA
   # warn the user and remove the offending records
   if(any(is.na(rf$fragvol))) {
     warning('some records are missing rock fragment volume, these have been removed', call. = FALSE)
   }
-  rf <- rf[which(!is.na(rf$fragvol)), ]
   
   # if all fragvol are NA then rf is an empty data.frame and we are done
-  if(nrow(rf) == 0) {
-    warning('all records are missing rock fragment volume, returing NULL', call. = FALSE)
-    return(NULL)
+  if(nrow(rf[which(!is.na(rf$fragvol)),]) == 0) {
+    warning('all records are missing rock fragment volume (NULL). buffering result with NA. will be converted to zero if nullFragsAreZero = TRUE.', call. = FALSE)
+    dat <- as.data.frame(t(rep(NA, length(result.columns))))
+    for(i in 1:length(rf$phiid)) {
+      dat[i,] <- dat[1,]
+      dat[i,which(result.columns == "phiid")] <- rf$phiid[i]
+    }
+    colnames(dat) <- result.columns
+    return(dat)
   }
   
+  rf <- rf[which(!is.na(rf$fragvol)), ]
   
   # extract classes
   # note: these will put any fragments without fragsize into an 'unspecified' class

--- a/R/simplfyFragmentData.R
+++ b/R/simplfyFragmentData.R
@@ -3,7 +3,7 @@
 # internally-used function to test size classes
 # diameter is in mm
 # NA diameter results in NA class
-.sieve <- function(diameter, flat=FALSE, para=FALSE) {
+.sieve <- function(diameter, flat=FALSE, para=FALSE, new.names = NULL) {
 
   # flat fragments
   if(flat == TRUE)
@@ -13,6 +13,9 @@
   # non-flat fragments
   if(flat == FALSE)
     sieves <- c(fine_gravel=5, gravel=76, cobbles=250, stones=600, boulders=10000000000)
+  
+  if(!is.null(new.names))
+    names(sieves) <- new.names
   
   # test for NA, and filter-out
   res <- vector(mode='character', length = length(diameter))

--- a/tests/testthat/test-simplifyArtifactData.R
+++ b/tests/testthat/test-simplifyArtifactData.R
@@ -1,0 +1,175 @@
+context("Simplification of artifact data (from NASIS)")
+
+## some complex data from NASIS phhuart table
+d.single.hz <- structure(list(phiid = c(10101, 10101, 10101), 
+                              huartvol = c(4, 5, 6), 
+                              huartsize_l = c(2, 76, 2), 
+                              huartsize_r = c(39, 163, 39), 
+                              huartsize_h = c(75, 250, 75), 
+                              huartkind = c("boiler slag", "boiler slag", "boiler slag"), 
+                              huartco = c("cohesive", "cohesive", "noncohesive"), 
+                              huartshp = c("irregular", "irregular", "flat"), 
+                              huartrnd = c("subrounded", "subrounded", "angular"), 
+                              huartpen = c("nonpenetrable", "nonpenetrable", "penetrable"), 
+                              huartsafety = c("innocuous artifacts","innocuous artifacts", "innocuous artifacts"), 
+                              huartper = c("persistent", "persistent", "persistent"), 
+                              recwlupdated = structure(c(NA_real_, NA_real_, NA_real_), class = c("POSIXct", "POSIXt"), tzone = ""), 
+                              recuseriidref = c(NA_integer_, NA_integer_, NA_integer_), 
+                              phhuartiid = c(NA_integer_, NA_integer_, NA_integer_)), 
+                              row.names = c(NA, 3L), class = "data.frame")
+
+## new tests for rockFragmentSieve: missing frag sizes / unspecified class
+test_that("artifactSieve puts artifacts without huartsize into 'unspecified' class", {
+  
+  d <- data.frame(huartvol=25, huartsize_l=NA, huartsize_r=NA, huartsize_h=NA, 
+                  huartshp=NA, huartco=NA, huartshp=NA, huartrnd=NA, huartpen=NA, 
+                  huartsafety=NA, huartper=NA)
+  res <- soilDB:::.artifactSieve(d)
+  
+  expect_equal(res$class, 'art_unspecified')
+  
+})
+
+
+test_that("artifactSieve assumptions are applied, results correct", {
+  
+  d <- data.frame(huartvol=25, huartsize_l=NA, huartsize_r=50, huartsize_h=NA, 
+                  huartshp=NA, huartco=NA, huartshp=NA, huartrnd=NA, huartpen=NA, 
+                  huartsafety=NA, huartper=NA)
+  res <- soilDB:::.artifactSieve(d)
+  
+  # assumptions in the absence of fragment shape / hardness
+  expect_equal(res$huartshp, 'irregular')
+  expect_equal(res$huartco, 'cohesive')
+  
+})
+
+
+test_that("artifactSieve assumptions are applied when all NA", {
+  
+  d <- data.frame(huartvol=NA, huartsize_l=NA, huartsize_r=NA, huartsize_h=NA, 
+                  huartshp=NA, huartco=NA, huartshp=NA, huartrnd=NA, huartpen=NA, 
+                  huartsafety=NA, huartper=NA)
+  res <- soilDB:::.artifactSieve(d)
+  
+  # assumptions in the absence of fragment shape / hardness
+  expect_equal(res$huartshp, 'irregular')
+  expect_equal(res$huartco, 'cohesive')
+  
+  # class should be NA
+  expect_true(is.na(res$class))
+  
+})
+
+
+test_that("artifactSieve safe fall-back from high to rv fragsize", {
+  
+  # full specification
+  d <- data.frame(huartvol=10, huartsize_l=15, huartsize_r=50, huartsize_h=75, 
+                  huartshp="irregular", huartco="cohesive", huartshp=NA, huartrnd=NA, huartpen=NA, 
+                  huartsafety=NA, huartper=NA)
+  res <- soilDB:::.artifactSieve(d)
+  
+  # assumptions in the absence of fragment shape / hardness
+  expect_equal(res$huartshp, 'irregular')
+  expect_equal(res$huartco, 'cohesive')
+  
+  # correct class in the absence of fragment shape / hardness
+  expect_equal(res$class, 'art_gr')
+  
+  # only RV available
+  d <- data.frame(huartvol=10, huartsize_l=NA, huartsize_r=50, huartsize_h=NA, 
+                  huartshp="irregular", huartco="cohesive", huartshp=NA, huartrnd=NA, huartpen=NA, 
+                  huartsafety=NA, huartper=NA)
+  res <- soilDB:::.artifactSieve(d)
+  
+  # assumptions in the absence of fragment shape / hardness
+  expect_equal(res$huartshp, 'irregular')
+  expect_equal(res$huartco, 'cohesive')
+  
+  # correct class in the absence of fragment shape / hardness
+  expect_equal(res$class, 'art_gr')
+  
+})
+
+
+
+
+test_that("artifactSieve complex sample data from NASIS, single horizon", {
+  
+  # pretty common, many fragments specified for a single horizon
+  res <- soilDB:::.artifactSieve(d.single.hz)
+  
+  # correct classes
+  expect_equal(res$class, c('art_gr', 'art_cb', 'art_ch'))
+  
+})
+
+
+test_that("simplifyArtifactData complex sample data from NASIS, single horizon", {
+  
+  # pretty common, many fragments specified for a single horizon
+  res <- soilDB::simplifyArtifactData(d.single.hz, id.var = 'phiid', nullFragsAreZero = TRUE)
+  
+  # correct class totals
+  expect_equal(res$art_fgr, 0)
+  expect_equal(res$art_gr, 4)
+  expect_equal(res$art_cb, 5)
+  expect_equal(res$art_ch, 6)
+  expect_equal(res$art_fl, 0)
+  expect_equal(res$art_st, 0)
+  
+  # correct total 
+  expect_equal(res$total_art_pct, 15)
+  
+  # correct subtotal cohesive
+  expect_equal(res$huartvol_cohesive, 9)  
+  
+  # correct subtotal penetrable
+  expect_equal(res$huartvol_penetrable, 6)  
+  
+  # correct subtotal innocuous
+  expect_equal(res$huartvol_innocuous, 15)
+  
+  # correct subtotal persistent
+  expect_equal(res$huartvol_persistent, 15)
+  
+})
+
+
+
+test_that("simplifyArtifactData when missing fragment sizes, low/rv/high", {
+  
+  # all fragments are coallated into the unspecified column
+  # totals should be correct
+  # some horizons have no fragment records, should generate a warning
+  d.missing.size <- d.single.hz
+  d.missing.size[,c("huartsize_l", "huartsize_r", "huartsize_h")] <- NA
+  d.missing.size[4,] <- d.missing.size[3,]
+  d.missing.size[4,] <- NA
+  d.missing.size[4,'phiid'] <- "10102"
+  expect_warning(res <- simplifyArtifactData(d.missing.size, id.var = 'phiid', nullFragsAreZero = TRUE))
+  
+  # rows missing fragvol should be removed from the simplified result
+  expect_true(nrow(d.missing.size) == 4)
+  expect_true(nrow(res) == 1)
+  
+  # unspecified total should match RF sums
+  expect_equal(res$art_unspecified, res$total_art_pct)
+})
+
+
+test_that("simplifyArtifactData warning generated when NA in huartvol", {
+  d.missing.artvol <- d.single.hz
+  d.missing.artvol$huartvol <- NA
+  d.missing.artvol[1,'huartvol'] <- 10
+  expect_warning(simplifyArtifactData(d.missing.artvol, id.var = 'phiid', nullFragsAreZero = TRUE), regexp = 'some records are missing artifact volume, these have been removed')
+})
+
+
+test_that("simplifyArtifactData warning generated when all fragvol are NA", {
+  d.all.NA.artvol <- d.single.hz
+  d.all.NA.artvol$huartvol <- NA
+  expect_warning(simplifyFragmentData(d.all.NA.artvol, id.var = 'phiid', nullFragsAreZero = TRUE), regexp = 'all records are missing rock fragment volume')
+})
+


### PR DESCRIPTION
This is a shameless ripoff of simplifyFragmentData() in all its glory ;)

This was helpful for me to learn a bit more about how the flattening steps work in the fetch functions.  I saw some opportunities for generalizing these approaches going forward.

Feature requested by Sarah Smith & Kristine Ryan in the 11-AUR office.

Please test it out. 

```r
remotes::install_github(“ncss-tech/soilDB@anthro”, 
                                     dependencies=FALSE, upgrade=FALSE, build=FALSE)
```

## New attributes that are calculated and stored in the fetchNASIS result

### Size classes, subsets based on artifact size High value. 

Splits flat versus all other shapes to determine volume in channer and flag (art_ch, art_fl) size classes

> art_fgr, art_gr, art_cb, art_st, art_by, art_ch, art_fl, art_unspecified

### Summaries of child records, subsets based on categorical attributes. 

> total_art_pct, huartvol_cohesive, huartvol_penetrable, huartvol_innocuous, huartvol_persistent

For instance, `total_art_pct` is the total volume of artifacts in a horizon. `huartvol_cohesive` is the volume of _cohesive_ artifacts in a horizon. To calculate _non-cohesive_, subtract `huartvol_cohesive` from `total_art_pct`. And so on.

I didn’t do anything for the choice lists that had more than two options (roundness, shape) – but those could be added easily. Just separate flat/non-flat at the beginning for size classes -- this differs from fragments because the domain for artifact shape has four classes.

### New functions
```
simplifyArtifactData()
.artifactSieve()
```