### PR TITLE
fix for subtotals greater than 100%

### DIFF
--- a/R/simplifyArtifactData.R
+++ b/R/simplifyArtifactData.R
@@ -1,0 +1,179 @@
+# code for dealing with human artifacts
+
+.artifactSieve <- function(x) {
+  # convert to lower case: NASIS metadata usese upper for labels, lower for values
+  x$huartco <- tolower(x$huartco)
+  x$huartshp <- tolower(x$huartshp)
+  
+  ## assumptions
+  # missing hardness = rock fragment
+  x$huartco[which(is.na(x$huartco))] <- 'cohesive'
+  # missing shape = Nonflat
+  x$huartshp[which(is.na(x$huartshp))] <- 'irregular'
+  
+  ## split flat/nonflat
+  idx <- grep('^flat', x$huartshp, ignore.case = TRUE, invert=TRUE)
+  arts <- x[idx, ]
+  
+  idx <- grep('^flat', x$huartshp, ignore.case = TRUE)
+  farts <- x[idx, ]
+  
+  ## sieve
+  # non-flat fragments
+  d <- ifelse(is.na(arts$huartsize_h), arts$huartsize_r, arts$huartsize_h)
+  arts$class <- .sieve(d, new.names = c('art_fgr', 'art_gr', 'art_cb', 
+                                        'art_st', 'art_by'))
+  
+  # flat artifacts
+  d <- ifelse(is.na(farts$huartsize_h), farts$huartsize_r, farts$huartsize_h)
+  farts$class <- .sieve(d, flat = TRUE, new.names = c('art_ch','art_fl', 'art_st', 'art_by'))
+  
+  # combine pieces, note may contain  RF classes == NA
+  res <- rbind(arts, farts)
+  
+  # what does an NA fragment class mean?
+  # 
+  # typically, fragment size missing
+  # or, worst-case, .sieve() rules are missing criteria 
+  # 
+  # keep track of these for QC in an 'unspecified' column
+  # but only when there is a fragment volume specified
+  idx <- which(is.na(res$class) & !is.na(res$huartvol))
+  if( length(idx) > 0 ) {
+    res$class[idx] <- 'art_unspecified'
+  }
+  
+  # done
+  return(res)
+}
+
+simplifyArtifactData <- function(art, id.var, nullFragsAreZero = nullFragsAreZero) {
+  
+  # nasty hack to trick R CMD check
+  huartvol <- NULL
+  
+  # artifact size classes, using fragment breaks, are used in this function
+  # note that we are adding a catch-all for those strange phfrags records missing fragment size
+  art.classes <- c('art_fgr', 'art_gr', 'art_cb', 'art_st', 'art_by', 'art_ch', 'art_fl', 'art_unspecified')
+  
+  result.columns <- c('phiid', art.classes, "total_art_pct",  "huartvol_cohesive","huartvol_penetrable", "huartvol_innocuous", "huartvol_persistent")
+  
+  # first of all, we can't do anything if the fragment volume is NA
+  # warn the user and remove the offending records
+  if(any(is.na(art$huartvol))) {
+    warning('some records are missing artifact volume, these have been removed', call. = FALSE)
+  }
+  
+  # if all fragvol are NA then rf is an empty data.frame and we are done
+  if(nrow(art[which(!is.na(art$huartvol)), ]) == 0) {
+    warning('all records are missing artifact volume (NULL). buffering result with NA. will be converted to zero if nullFragsAreZero = TRUE.', call. = FALSE)
+    dat <- as.data.frame(t(rep(NA, length(result.columns))))
+    for(i in 1:length(art$phiid)) {
+      dat[i,] <- dat[1,]
+      dat[i,which(result.columns == "phiid")] <- art$phiid[i]
+    }
+    colnames(dat) <- result.columns
+    return(dat)
+  }
+  
+  art <- art[which(!is.na(art$huartvol)), ]
+  
+  
+  # extract classes
+  # note: these will put any fragments without fragsize into an 'unspecified' class
+  artifact.classes <- .artifactSieve(art)
+  
+  ## this is incredibly slow (~ 5 seconds for 30k records)
+  ## NOTE: this is performed on the data, as-is: not over all possible classes as enforced by factor levels
+  # sum volume by id and class
+  # rf.sums <- ddply(rf.classes, c(id.var, 'class'), plyr::summarise, volume=sum(fragvol, na.rm=TRUE))
+  
+  ## NOTE: this is performed on the data, as-is: not over all possible classes as enforced by factor levels
+  # sum volume by id and class
+  # much faster than ddply
+  # class cannot contain NA
+  art.sums <- aggregate(artifact.classes$huartvol, by=list(artifact.classes[[id.var]], artifact.classes[['class']]), FUN=sum, na.rm=TRUE)
+  # fix defualt names from aggregate()
+  names(art.sums) <- c(id.var, 'class', 'volume')
+  
+  
+  ## NOTE: we set factor levels here because the reshaping (long->wide) needs to account for all possible classes
+  ## NOTE: this must include all classes that related functions return
+  # set levels of classes
+  art.sums$class <- factor(art.sums$class, levels=art.classes)
+  
+  # convert to wide format
+  fm <- as.formula(paste0(id.var, ' ~ class'))
+  art.wide <- reshape2::dcast(art.sums, fm, value.var = 'volume', drop = FALSE)
+  
+  # must determine the index to the ID column in the wide format
+  id.col.idx <- which(names(art.wide) == id.var)
+  
+  ## optionally convert NULL frags -> 0
+  if(nullFragsAreZero & ncol(art.wide) > 1) {
+    art.wide <- as.data.frame(
+      cbind(art.wide[, id.col.idx, drop=FALSE], 
+            lapply(art.wide[, -id.col.idx], function(i) ifelse(is.na(i), 0, i))
+      ), stringsAsFactors=FALSE)
+  }
+  
+  # final sanity check: are there any fractions or the total >= 100%
+  # note: sapply() was previously used here
+  #       1 row in rf.wide --> result is a vector
+  #       >1 row in rf.wide --> result is a matrix
+  # solution: keep as a list
+  gt.100 <- lapply(art.wide[, -id.col.idx, drop=FALSE], FUN=function(i) i >= 100)
+  
+  # check each size fraction and report id.var if there are any
+  gt.100.matches <- sapply(gt.100, any, na.rm=TRUE)
+  if(any(gt.100.matches)) {
+    # search within each fraction
+    class.idx <- which(gt.100.matches)
+    idx <- unique(unlist(lapply(gt.100[class.idx], which)))
+    flagged.ids <- art.wide[[id.var]][idx]
+    
+    warning(sprintf("artifact volume >= 100%%\n%s:\n%s", id.var, paste(flagged.ids, collapse = "\n")), call. = FALSE)
+  }
+  
+  ## TODO: 0 is returned when all NA and nullFragsAreZero=FALSE
+  ## https://github.com/ncss-tech/soilDB/issues/57
+  # compute total fragments
+  # trap no frag condition
+  # includes unspecified class
+  if(ncol(art.wide) > 1) {
+    # calculate another column for total RF, ignoring parafractions
+    # index of columns to ignore, para*
+    #idx.pf <- grep(names(art.wide), pattern="para")
+    # also remove ID column
+    idx <- c(id.col.idx)#, idx.pf)
+    # this could result in an error if all fragments are para*
+    art.wide$total_art_pct <- rowSums(art.wide[, -idx], na.rm=TRUE)
+  }
+  
+  ## TODO: 0 is returned when all NA and nullFragsAreZero=FALSE
+  ## https://github.com/ncss-tech/soilDB/issues/57
+  # corrections:
+  # 1. fine gravel is a subset of gravel, therefore: gravel = gravel + fine_gravel
+  art.wide$art_gr <- rowSums(cbind(art.wide$art_gr, art.wide$art_fgr), na.rm = TRUE)
+  
+  # now, do some summaries of cohesion, shape, roundess, penetrability, safety and persistence
+  
+  art.wide$huartvol_cohesive <- as.numeric(lapply(split(art, art[[id.var]]), function(art.sub) {
+    sum(art.sub$huartvol[art.sub$huartco == "cohesive"], na.rm = TRUE)
+  }))
+  art.wide$huartvol_penetrable <- as.numeric(lapply(split(art, art[[id.var]]), function(art.sub) {
+    sum(art.sub$huartvol[art.sub$huartpen == "penetrable"], na.rm = TRUE)
+  }))
+  art.wide$huartvol_noxious <- as.numeric(lapply(split(art, art[[id.var]]), function(art.sub) {
+    sum(art.sub$huartvol[art.sub$huartsafety == "noxious artifacts"], na.rm = TRUE)
+  }))
+  art.wide$huartvol_persistent <- as.numeric(lapply(split(art, art[[id.var]]), function(art.sub) {
+    sum(art.sub$huartvol[art.sub$huartper == "persistent"], na.rm = TRUE)
+  }))
+  
+  # TODO: somehow summarize shape and roundness? we don't do that for regular frags
+  
+  # done
+  return(art.wide)
+}
+

--- a/tests/testthat/test-simplifyArtifactData.R
+++ b/tests/testthat/test-simplifyArtifactData.R
@@ -1,8 +1,8 @@
 context("Simplification of artifact data (from NASIS)")
 
 ## some complex data from NASIS phhuart table
-d.single.hz <- structure(list(phiid = c(10101, 10101, 10101), 
-                              huartvol = c(4, 5, 6), 
+d.single.hz <- structure(list(phiid = c(10101, 10101, 10102), 
+                              huartvol = c(10, 5, 95), 
                               huartsize_l = c(2, 76, 2), 
                               huartsize_r = c(39, 163, 39), 
                               huartsize_h = c(75, 250, 75), 
@@ -112,27 +112,27 @@ test_that("simplifyArtifactData complex sample data from NASIS, single horizon",
   res <- soilDB::simplifyArtifactData(d.single.hz, id.var = 'phiid', nullFragsAreZero = TRUE)
   
   # correct class totals
-  expect_equal(res$art_fgr, 0)
-  expect_equal(res$art_gr, 4)
-  expect_equal(res$art_cb, 5)
-  expect_equal(res$art_ch, 6)
-  expect_equal(res$art_fl, 0)
-  expect_equal(res$art_st, 0)
+  expect_equal(res$art_fgr, c(0,0))
+  expect_equal(res$art_gr, c(10,0))
+  expect_equal(res$art_cb, c(5,0))
+  expect_equal(res$art_ch, c(0,95))
+  expect_equal(res$art_fl, c(0,0))
+  expect_equal(res$art_st, c(0,0))
   
   # correct total 
-  expect_equal(res$total_art_pct, 15)
+  expect_equal(res$total_art_pct, c(15,95))
   
   # correct subtotal cohesive
-  expect_equal(res$huartvol_cohesive, 9)  
+  expect_equal(res$huartvol_cohesive, c(15, 0))  
   
   # correct subtotal penetrable
-  expect_equal(res$huartvol_penetrable, 6)  
+  expect_equal(res$huartvol_penetrable,  c(0,95))  
   
-  # correct subtotal innocuous
-  expect_equal(res$huartvol_innocuous, 15)
+  # correct subtotal noxious
+  expect_equal(res$huartvol_noxious, c(0,0))
   
   # correct subtotal persistent
-  expect_equal(res$huartvol_persistent, 15)
+  expect_equal(res$huartvol_persistent, c(15,95))
   
 })
 
@@ -152,10 +152,18 @@ test_that("simplifyArtifactData when missing fragment sizes, low/rv/high", {
   
   # rows missing fragvol should be removed from the simplified result
   expect_true(nrow(d.missing.size) == 4)
-  expect_true(nrow(res) == 1)
+  expect_true(nrow(res) == 2)
   
   # unspecified total should match RF sums
   expect_equal(res$art_unspecified, res$total_art_pct)
+  
+  # totals lesss than or equal to 100
+  expect_equal(all(res$total_art_pct <= 100), TRUE)
+  expect_equal(all(res$huartvol_cohesive <= 100), TRUE)  
+  expect_equal(all(res$huartvol_penetrable <= 100), TRUE)  
+  expect_equal(all(res$huartvol_noxious <= 100), TRUE)
+  expect_equal(all(res$huartvol_persistent <= 100), TRUE)
+  
 })
 
 


### PR DESCRIPTION
simplifyArtifactData now respects id.var when calculating the subtotal summary values for cohesive, noxious, persistent, etc.; 

also renamed phhuart_inocuous -> phhuart_noxious for parity with other summary subtotals; added new tests that catch a case I had neglected to test.

Thanks to Sarah Smith for showing the output that made me realize my mistake.