### PR TITLE
Function `SDA_spatialQuery()` gains new argument `db`

### DIFF
--- a/man/SDA_spatialQuery.Rd
+++ b/man/SDA_spatialQuery.Rd
@@ -4,7 +4,7 @@
 \alias{SDA_spatialQuery}
 \title{SDA Spatial Query}
 \usage{
-SDA_spatialQuery(geom, what = "mukey", geomIntersection = FALSE)
+SDA_spatialQuery(geom, what = "mukey", geomIntersection = FALSE, db = c("SSURGO", "STATSGO"))
 }
 \arguments{
 \item{geom}{a Spatial* object, with valid CRS. May contain multiple features.}
@@ -12,6 +12,10 @@ SDA_spatialQuery(geom, what = "mukey", geomIntersection = FALSE)
 \item{what}{a character vector specifting what to return. `mukey`: `data.frame` with intersecting map unit keys and names, `geom` overlapping or intersecting map unit polygons}
 
 \item{geomIntersection}{logical; FALSE: overlapping map unit polygons returned, TRUE: intersection of `geom` + map unit polygons is returned.}
+
+\item{db}{a character vector identifying the Soil Geographic Databases
+  (`SSURGO` or `STATSGO`) to query. Option `STATSGO` currently works only
+  in combination with `what = "geom"`}
 }
 \value{
 A `data.frame` if `what` is 'mukey', otherwise `SpatialPolygonsDataFrame` object.

--- a/tests/testthat/test-SDA_query.R
+++ b/tests/testthat/test-SDA_query.R
@@ -107,11 +107,21 @@ test_that("SDA_spatialQuery() simple spatial query, spatial results", {
     skip("in-house testing only")
   }
 
+  # test with default db = "SSURGO"
   res <- suppressWarnings(SDA_spatialQuery(p, what = 'geom'))
 
   # testing known values
   expect_true(inherits(res, 'SpatialPolygonsDataFrame'))
   expect_equal(nrow(res), 1)
+
+
+  # test with db = "STATSGO"
+  res <- suppressWarnings(SDA_spatialQuery(p, what = 'geom', db = "STATSGO"))
+
+  # testing known values
+  expect_true(inherits(res, 'SpatialPolygonsDataFrame'))
+  res_mukey <- unique(as.data.frame(res)[, "mukey"])
+  expect_equal(length(res_mukey), 1)
 
 })
 


### PR DESCRIPTION
- addressing issue #141

- function `SDA_spatialQuery()` gains new argument `db` to select whether geometries should be queried from Soil Geographic Database SSURGO or STATSGO
- default value of `db` is "SSURGO"; the new argument is backwards compatible
- updated roxygen-style function documentation in source file and in man/*.Rd object
- updated unit tests to include a simple check for the new argument with default ("SSURGO") and new "STATSGO" values