### PR TITLE
minor enhancements for WCS SSURGO MUKEY interface

### DIFF
--- a/R/WCS-utils.R
+++ b/R/WCS-utils.R
@@ -1,53 +1,66 @@
 
 
-# obj: list(aoi, crs) or Spatial* object
+# obj: list(aoi, crs) or Spatial*, sf, sfc, bbox object
 # res: grid resolution in native CRS (meters) [ISSR-800: 800, gNATSGO: 30]
 .prepare_AEA_AOI <- function(obj, res) {
-  
-  # simple AOI object, a list(aoi, crs)
-  # convert to SpatialPolygons object and assign CRS
-  if(!inherits(obj, 'Spatial')) {
-    
-    # note that vector is re-arranged to form a legal extent: xmin, xmax, ymin, ymax
-    # craft an extent object
-    e <- extent(
-      obj$aoi[1], 
-      obj$aoi[3], 
-      obj$aoi[2], 
-      obj$aoi[4]
-      )
-    
-    # convert to BBOX polygon and set CRS
-    p <- as(e, 'SpatialPolygons')
-    proj4string(p) <- obj$crs
-    
-  } else {
+
+  # convert AOI to SpatialPolygons object and assign CRS
+  if(inherits(obj, c('sf', 'sfc', 'bbox'))) {
+
+    if(!requireNamespace("sf"))
+      stop("package 'sf' is required to use an sf, sfc or bbox object as an AOI", call. = FALSE)
+
+    # create bbox around sf/sfc/bbox, create simple feature collection, cast to Spatial
+    p <- sf::as_Spatial(sf::st_as_sfc(sf::st_bbox(obj)))
+    rm(obj)
+
+  } else if(inherits(obj, 'Spatial'))  {
+    # note: the spatial inherits method will bug out with a bbox, so it must come second
+
     # re-name for simpler code
     p <- obj
     rm(obj)
+
+  # explicitly check the presence of the two list elements, and length/type of aoi
+  } else if (!is.null(obj$aoi) & !is.null(obj$crs) &
+             is.numeric(obj$aoi) & (length(obj$aoi) == 4)) {
+    # note that vector is re-arranged to form a legal extent: xmin, xmax, ymin, ymax
+    # craft an extent object
+    e <- extent(
+      obj$aoi[1],
+      obj$aoi[3],
+      obj$aoi[2],
+      obj$aoi[4]
+      )
+
+    # convert to BBOX polygon and set CRS
+    p <- as(e, 'SpatialPolygons')
+    proj4string(p) <- obj$crs
+
+  } else {
+   stop('invalid `aoi` specification', call. = FALSE)
   }
-  
-  
+
   # ISSR-800 and gNATSGO CRS
   # EPSG:6350
   crs <- '+proj=aea +lat_0=23 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs'
-  
+
   # double-check, likely a better approach
   p <- suppressWarnings(spTransform(p, crs))
-  
+
   # AOI and image calculations in native CRS
   e.native <- extent(p)
-  
+
   # create BBOX used for WMS
   # xmin, ymin, xmax, ymax
   aoi.native <- round(c(e.native[1], e.native[3], e.native[2], e.native[4]))
-  
+
   # these are useful for testing image dimensions > allowed image dimensions
   # xmax - xmin
   w <- round(abs(e.native[2] - e.native[1]) / res)
   # ymax - ymin
   h <- round(abs(e.native[4] - e.native[3]) / res)
-  
+
   return(
     list(
       bbox = aoi.native,
@@ -60,7 +73,7 @@
 
 # ISSR-800 layers and basic metadata
 .ISSR800.spec <- list(
-  
+
   'ph_05cm' = list(
     dsn = 'ph_05cm',
     type = 'GEOTIFF_FLOAT',
@@ -68,7 +81,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'ph_025cm' = list(
     dsn = 'ph_025cm',
     type = 'GEOTIFF_FLOAT',
@@ -76,7 +89,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'ph_2550cm' = list(
     dsn = 'ph_2550cm',
     type = 'GEOTIFF_FLOAT',
@@ -84,7 +97,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'ph_3060cm' = list(
     dsn = 'ph_3060cm',
     type = 'GEOTIFF_FLOAT',
@@ -92,7 +105,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'clay_05cm' = list(
     dsn = 'clay_05cm',
     type = 'GEOTIFF_FLOAT',
@@ -100,7 +113,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'clay_025cm' = list(
     dsn = 'clay_025cm',
     type = 'GEOTIFF_FLOAT',
@@ -108,7 +121,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'clay_2550cm' = list(
     dsn = 'clay_2550cm',
     type = 'GEOTIFF_FLOAT',
@@ -116,7 +129,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'clay_3060cm' = list(
     dsn = 'clay_3060cm',
     type = 'GEOTIFF_FLOAT',
@@ -124,7 +137,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'sand_05cm' = list(
     dsn = 'sand_05cm',
     type = 'GEOTIFF_FLOAT',
@@ -132,7 +145,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'sand_025cm' = list(
     dsn = 'sand_025cm',
     type = 'GEOTIFF_FLOAT',
@@ -140,7 +153,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'sand_2550cm' = list(
     dsn = 'sand_2550cm',
     type = 'GEOTIFF_FLOAT',
@@ -148,7 +161,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'sand_3060cm' = list(
     dsn = 'sand_3060cm',
     type = 'GEOTIFF_FLOAT',
@@ -156,7 +169,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'silt_05cm' = list(
     dsn = 'silt_05cm',
     type = 'GEOTIFF_FLOAT',
@@ -164,7 +177,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'silt_025cm' = list(
     dsn = 'silt_025cm',
     type = 'GEOTIFF_FLOAT',
@@ -172,7 +185,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'silt_2550cm' = list(
     dsn = 'silt_2550cm',
     type = 'GEOTIFF_FLOAT',
@@ -180,7 +193,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'silt_3060cm' = list(
     dsn = 'silt_3060cm',
     type = 'GEOTIFF_FLOAT',
@@ -188,7 +201,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'sar' = list(
     dsn = 'sar',
     type = 'GEOTIFF_FLOAT',
@@ -196,7 +209,7 @@
     na = -9999,
     rat = NULL
   ),
-  
+
   'drainage_class' = list(
     dsn = 'drainage_class',
     type = 'GEOTIFF_BYTE',
@@ -204,7 +217,7 @@
     na = 0,
     rat = 'http://soilmap2-1.lawr.ucdavis.edu/800m_grids/RAT/drainage_class.csv'
   ),
-  
+
   'weg' = list(
     dsn = 'weg',
     type = 'GEOTIFF_BYTE',
@@ -212,7 +225,7 @@
     na = 0,
     rat = 'http://soilmap2-1.lawr.ucdavis.edu/800m_grids/RAT/weg.csv'
   ),
-  
+
   'wei' = list(
     dsn = 'wei',
     type = 'GEOTIFF_16',
@@ -220,7 +233,7 @@
     desc = 'Wind Erodibility Index',
     rat = NULL
   ),
-  
+
   'str' = list(
     dsn = 'str',
     type = 'GEOTIFF_BYTE',
@@ -228,13 +241,13 @@
     na = 0,
     rat = 'http://soilmap2-1.lawr.ucdavis.edu/800m_grids/RAT/str.csv'
   )
-  
-  
+
+
 )
 
 
 .mukey.spec <- list(
-  
+
   'gnatsgo' = list(
     dsn = 'gnatsgo',
     type = 'GEOTIFF_FLOAT',
@@ -242,7 +255,7 @@
     na = 2147483647,
     rat = NULL
   ),
-  
+
   'gssurgo' = list(
     dsn = 'gssurgo',
     type = 'GEOTIFF_FLOAT',

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -2,7 +2,7 @@
 
 #' @title gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 #'
-#' @param aoi area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details
+#' @param aoi area of interest (AOI) defined using a \code{Spatial*}, a \code{sf}, \code{sfc} or \code{bbox} object or a \code{list}, see details
 #'
 #' @param db name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'
 #'
@@ -12,7 +12,7 @@
 #'
 #' @note The gNATSGO grid includes raster soil survey map unit keys which are not in SDA.
 #'
-#' @details \code{aoi} should be specified as either a \code{Spatial*} object (with defined \code{CRS}) or a \code{list} containing:
+#' @details \code{aoi} should be specified as either a \code{Spatial*}, \code{sf}, \code{sfc} or \code{bbox} object or a \code{list} containing:
 #'
 #' \describe{
 #'   \item{\code{aoi}}{bounding-box specified as (xmin, ymin, xmax, ymax) e.g. c(-114.16, 47.65, -114.08, 47.68)}
@@ -33,7 +33,7 @@ mukey.wcs <- function(aoi, db = c('gnatsgo', 'gssurgo'), res = 30, quiet = FALSE
   db <- match.arg(db)
 
   # sanity check: aoi specification
-  if(!inherits(aoi, c('list', 'Spatial'))) {
+  if(!inherits(aoi, c('list', 'Spatial', 'sf', 'sfc', 'bbox'))) { # TODO:  'wk_rct'?
     stop('invalid `aoi` specification', call. = FALSE)
   }
 

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -3,83 +3,80 @@
 #' @title gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 #'
 #' @param db name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'
-#' 
+#'
 #' @param aoi area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details.
-#' 
+#'
 #' @param res grid resolution, units of meters. The native resolution of gNATSGO and gSSURGO (this WCS) is 30m.
-#' 
+#'
 #' @param quiet logical, passed to \code{download.file} to enable / suppress URL and progress bar for download.
-#' 
+#'
 #' @note The gNATSGO grid includes raster soil survey map unit keys which are not in SDA.
-#' 
+#'
 #' @details \code{aoi} should be specified as either a \code{Spatial*} object (with defined \code{CRS}) or a \code{list} containing:
-#' 
+#'
 #' \describe{
 #'   \item{\code{aoi}}{bounding-box specified as (xmin, ymin, xmax, ymax) e.g. c(-114.16, 47.65, -114.08, 47.68)}
-#'   \item{\code{crs}}{coordinate reference system of BBOX, e.g. '+init=EPSG:4326'}
+#'   \item{\code{crs}}{coordinate reference system of BBOX, e.g. '+init=epsg:4326'}
 #' }
-#' 
+#'
 #' The WCS query is parameterized using \code{raster::extent} derived from the above AOI specification, after conversion to the native CRS (EPSG:6350) of the gNATSGO / gSSURGO grid.
-#' 
-#' Future versions of this function will accept other spatial data + CRS containers such as {sf} or {wk} objects.
-#' 
 #' @return \code{raster} object containing indexed map unit keys and associated raster attribute table
-#' 
+#'
 #' @export
 #'
 mukey.wcs <- function(db = c('gnatsgo', 'gssurgo'), aoi, res = 30, quiet = FALSE) {
-  
+
   if(!requireNamespace('rgdal', quietly=TRUE))
     stop('please install the `rgdal` package', call.=FALSE)
-  
+
   # sanity check: db name
   db <- match.arg(db)
-  
+
   # sanity check: aoi specification
   if(!inherits(aoi, c('list', 'Spatial'))) {
     stop('invalid `aoi` specification', call. = FALSE)
   }
-  
+
   # reasonable resolution
   if(res < 30 | res > 3000) {
     stop('`res` should be within 30 <= res <= 3000 meters')
   }
-  
-  
+
+
   # prepare WCS details
   var.spec <- .mukey.spec[[db]]
   # prepare AOI in native CRS
   wcs.geom <- .prepare_AEA_AOI(obj = aoi, res = res)
-  
-  
+
+
   # sanity check: keep output images within a reasonable limit
   # limits set in the MAPFILE
   max.img.dim <- 5000
-  
+
   # check image size > max.img.dim
   if(wcs.geom$height > max.img.dim | wcs.geom$width > max.img.dim) {
     msg <- sprintf(
-      'AOI is too large: %sx%s pixels requested (%sx%s pixels max)', 
-      wcs.geom$width, 
-      wcs.geom$height, 
+      'AOI is too large: %sx%s pixels requested (%sx%s pixels max)',
+      wcs.geom$width,
+      wcs.geom$height,
       max.img.dim,
       max.img.dim
     )
-    
+
     stop(msg, call. = FALSE)
   }
-  
-  
+
+
   # base URL + parameters
   base.url <- 'http://soilmap2-1.lawr.ucdavis.edu/cgi-bin/mapserv?'
   service.url <- 'map=/soilmap2/website/wcs/mukey.map&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage'
-  
+
   # unpack BBOX for WCS 2.0
   xmin <- wcs.geom$bbox[1]
   xmax <- wcs.geom$bbox[3]
   ymin <- wcs.geom$bbox[2]
   ymax <- wcs.geom$bbox[4]
-  
+
   # compile WCS 2.0 style URL
   u <- paste0(
     base.url,
@@ -94,7 +91,7 @@ mukey.wcs <- function(db = c('gnatsgo', 'gssurgo'), aoi, res = 30, quiet = FALSE
     '&RESOLUTION=x(', res, ')',
     '&RESOLUTION=y(', res, ')'
   )
-  
+
   # get data
   tf <- tempfile()
   dl.try <- try(
@@ -103,42 +100,42 @@ mukey.wcs <- function(db = c('gnatsgo', 'gssurgo'), aoi, res = 30, quiet = FALSE
     ),
     silent = TRUE
   )
-  
+
   if(inherits(dl.try, 'try-error')) {
-   stop('bad WCS request', call. = FALSE) 
+   stop('bad WCS request', call. = FALSE)
   }
-  
+
   # load pointer to file and return
   r <- try(
     raster(tf),
     silent = TRUE
   )
-  
+
   if(inherits(r, 'try-error')) {
     stop('result is not a valid GeoTiff, why?', call. = FALSE)
   }
-  
+
   # source data are UINT32 (INT4U in raster pkg) data
   # converted to FLOAT32 by WCS
   dataType(r) <- 'INT4U'
-  
+
   ## TODO: this isn't quite right... '0' is returned by the WCS sometimes
   # specification of NODATA
   # this doesn't seem to make it through the WCS
   # value is derived from the original UINT32 grid
   NAvalue(r) <- 2147483647
-  
+
   ## TODO: should probably save to a file and return a pointer
   r <- readAll(r)
-  
+
   # set layer name in object
   names(r) <- var.spec$desc
   # and as an attribute
   attr(r, 'layer name') <- var.spec$desc
-  
+
   # init RAT
   r <- ratify(r)
-  
+
   return(r)
 }
 

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -2,9 +2,9 @@
 
 #' @title gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 #'
-#' @param db name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'
+#' @param aoi area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details
 #'
-#' @param aoi area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details.
+#' @param db name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'
 #'
 #' @param res grid resolution, units of meters. The native resolution of gNATSGO and gSSURGO (this WCS) is 30m.
 #'
@@ -24,7 +24,7 @@
 #'
 #' @export
 #'
-mukey.wcs <- function(db = c('gnatsgo', 'gssurgo'), aoi, res = 30, quiet = FALSE) {
+mukey.wcs <- function(aoi, db = c('gnatsgo', 'gssurgo'), res = 30, quiet = FALSE) {
 
   if(!requireNamespace('rgdal', quietly=TRUE))
     stop('please install the `rgdal` package', call.=FALSE)

--- a/man/mukey.wcs.Rd
+++ b/man/mukey.wcs.Rd
@@ -7,7 +7,7 @@
 mukey.wcs(aoi, db = c("gnatsgo", "gssurgo"), res = 30, quiet = FALSE)
 }
 \arguments{
-\item{aoi}{area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details}
+\item{aoi}{area of interest (AOI) defined using a \code{Spatial*}, a \code{sf}, \code{sfc} or \code{bbox} object or a \code{list}, see details}
 
 \item{db}{name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'}
 
@@ -22,7 +22,7 @@ mukey.wcs(aoi, db = c("gnatsgo", "gssurgo"), res = 30, quiet = FALSE)
 gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 }
 \details{
-\code{aoi} should be specified as either a \code{Spatial*} object (with defined \code{CRS}) or a \code{list} containing:
+\code{aoi} should be specified as either a \code{Spatial*}, \code{sf}, \code{sfc} or \code{bbox} object or a \code{list} containing:
 
 \describe{
   \item{\code{aoi}}{bounding-box specified as (xmin, ymin, xmax, ymax) e.g. c(-114.16, 47.65, -114.08, 47.68)}

--- a/man/mukey.wcs.Rd
+++ b/man/mukey.wcs.Rd
@@ -26,7 +26,7 @@ gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 
 \describe{
   \item{\code{aoi}}{bounding-box specified as (xmin, ymin, xmax, ymax) e.g. c(-114.16, 47.65, -114.08, 47.68)}
-  \item{\code{crs}}{coordinate reference system of BBOX, e.g. '+init=EPSG:4326'}
+  \item{\code{crs}}{coordinate reference system of BBOX, e.g. '+init=epsg:4326'}
 }
 
 The WCS query is parameterized using \code{raster::extent} derived from the above AOI specification, after conversion to the native CRS (EPSG:6350) of the gNATSGO / gSSURGO grid.

--- a/man/mukey.wcs.Rd
+++ b/man/mukey.wcs.Rd
@@ -4,12 +4,12 @@
 \alias{mukey.wcs}
 \title{gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)}
 \usage{
-mukey.wcs(db = c("gnatsgo", "gssurgo"), aoi, res = 30, quiet = FALSE)
+mukey.wcs(aoi, db = c("gnatsgo", "gssurgo"), res = 30, quiet = FALSE)
 }
 \arguments{
-\item{db}{name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'}
+\item{aoi}{area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details}
 
-\item{aoi}{area of interest (AOI) defined using a \code{list} or \code{Spatial*} object, see details.}
+\item{db}{name of the gridded map unit key grid to access, should be either 'gnatsgo' or 'gssurgo'}
 
 \item{res}{grid resolution, units of meters. The native resolution of gNATSGO and gSSURGO (this WCS) is 30m.}
 
@@ -30,8 +30,6 @@ gNATSGO / gSSURGO Map Unit Key Web Coverage Service (WCS)
 }
 
 The WCS query is parameterized using \code{raster::extent} derived from the above AOI specification, after conversion to the native CRS (EPSG:6350) of the gNATSGO / gSSURGO grid.
-
-Future versions of this function will accept other spatial data + CRS containers such as {sf} or {wk} objects.
 }
 \note{
 The gNATSGO grid includes raster soil survey map unit keys which are not in SDA.

--- a/misc/WCS-SDA-example.R
+++ b/misc/WCS-SDA-example.R
@@ -5,13 +5,26 @@ library(raster)
 library(rasterVis)
 library(viridis)
 
-
 # AOI corners in WGS84 GCS
 # xmin, ymin, xmax, ymax
 a <- list(
   aoi = c(-114.16, 47.65, -114.08, 47.68),
   crs = '+init=epsg:4326'
 )
+
+### The following are valid (and equivalent to mukey.wcs()) {sf} object based AOIs
+
+# # bbox, with WKT CRS
+# a1 <- sf::st_bbox(c(xmin = -114.16, xmax = -114.08, ymax = 47.65, ymin = 47.68), crs = sf::st_crs(4326))
+
+# # sfc_POLYGON
+# a2 <- sf::st_as_sfc(a1)
+
+# # sf
+# a3 <- sf::st_as_sf(a2)
+
+### And this is a {sp} SpatialPolygons AOI (created from the sf object)
+# a4 <- sf::as_Spatial(a3)
 
 # too big for SDA geometry (>32Mb WKT serialization)
 # but will work just fine with WCS

--- a/misc/WCS-SDA-example.R
+++ b/misc/WCS-SDA-example.R
@@ -10,7 +10,7 @@ library(viridis)
 # xmin, ymin, xmax, ymax
 a <- list(
   aoi = c(-114.16, 47.65, -114.08, 47.68),
-  crs = '+init=EPSG:4326'
+  crs = '+init=epsg:4326'
 )
 
 # too big for SDA geometry (>32Mb WKT serialization)
@@ -18,7 +18,7 @@ a <- list(
 
 # a <- list(
 #   aoi = c(-114.5, 47, -114, 47.5),
-#   crs = '+init=EPSG:4326'
+#   crs = '+init=epsg:4326'
 # )
 
 # fetch gNATSGO map unit keys at native resolution (30m)
@@ -28,7 +28,7 @@ a <- list(
 # OK
 levelplot(x, att = 'ID', margin = FALSE, colorkey = FALSE, col.regions = viridis)
 
-# convert raster extent into vector 
+# convert raster extent into vector
 g <- as(extent(x), 'SpatialPolygons')
 proj4string(g) <- projection(x)
 
@@ -77,10 +77,10 @@ x
 
 # graphical check
 levelplot(
-  aws, 
+  aws,
   main = 'gNATSGO WCS + SDA',
-  margin = FALSE, 
-  scales = list(draw = FALSE), 
+  margin = FALSE,
+  scales = list(draw = FALSE),
   col.regions = viridis,
   panel = function(...) {
     panel.levelplot(...)

--- a/misc/WCS-SDA-example.R
+++ b/misc/WCS-SDA-example.R
@@ -23,7 +23,7 @@ a <- list(
 
 # fetch gNATSGO map unit keys at native resolution (30m)
 # get gSSURGO grid with db = 'gssurgo'
-(x <- mukey.wcs(db = 'gnatsgo', aoi = a))
+(x <- mukey.wcs(aoi = a, db = 'gnatsgo'))
 
 # OK
 levelplot(x, att = 'ID', margin = FALSE, colorkey = FALSE, col.regions = viridis)

--- a/tests/testthat/test-mukey-WCS.R
+++ b/tests/testthat/test-mukey-WCS.R
@@ -1,0 +1,14 @@
+test_that("mukey.wcs works", {
+
+  x <- NULL
+
+  expect_silent(suppressWarnings({
+
+    x <- mukey.wcs(aoi = list(aoi = c(-114.16, 47.655, -114.155, 47.66),
+                              crs = '+init=epsg:4326'),
+                   db = 'gnatsgo', quiet = TRUE)
+
+  }))
+
+  expect_true(inherits(x, 'RasterLayer'))
+})


### PR DESCRIPTION
These commits are grouped so @dylanbeaudette can take 'em or leave em.

1. proj4 safe examples -- not controversial
2. reverse order of db and aoi arguments -- does not affect example, I think aoi in first position is more pipe friendly and is just my preference
3. add sf support; this passes R CMD CHECK -- we already have sf in suggests; appears to be equivalent to list-based
4. very small extent test; downloads something like 500 bytes of data from WCS