### PR TITLE
SCAN_sensor_metadata works in 32-bit R

### DIFF
--- a/R/fetchSCAN.R
+++ b/R/fetchSCAN.R
@@ -81,10 +81,6 @@
 # site.code: vector of SCAN site codes
 SCAN_sensor_metadata <- function(site.code) {
 
-  # check for 64bit mode
-  if(.Machine$sizeof.pointer != 8)
-    stop("Sorry! For some reason this function crashes in 32bit mode, I don't know why!", call. = FALSE)
-
   # check for required packages
   if(!requireNamespace('httr', quietly = TRUE) | !requireNamespace('rvest', quietly = TRUE))
     stop('please install the `httr` and `rvest` packages', call.=FALSE)


### PR DESCRIPTION
The `stop()` call seems to not be needed anymore. Works fine on 32-bit R 4.0.2

```
> sessionInfo()
R version 4.0.2 (2020-06-22)
Platform: i386-w64-mingw32/i386 (32-bit)
Running under: Windows 10 x64 (build 18363)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] plyr_1.8.6

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.6        cluster_2.1.0     knitr_1.30        xml2_1.3.2       
 [5] raster_3.4-5      magrittr_2.0.1    rvest_0.3.6       lattice_0.20-41  
 [9] R6_2.5.0          rlang_0.4.10      stringr_1.4.0     httr_1.4.2       
[13] tools_4.0.2       grid_4.0.2        packrat_0.5.0     data.table_1.14.0
[17] xfun_0.20         DBI_1.1.1         selectr_0.4-2     soilDB_2.6.1     
[21] htmltools_0.5.0   yaml_2.2.1        digest_0.6.27     reshape2_1.4.4   
[25] codetools_0.2-16  curl_4.3          evaluate_0.14     rmarkdown_2.4    
[29] aqp_1.29          sp_1.4-5          stringi_1.5.3     compiler_4.0.2  
```