### PR TITLE
get_SDA_interpretation/get_SDA_property: Add "NONE" aggregation method and improve details for arguments

### DIFF
--- a/R/SDA_interpretations.R
+++ b/R/SDA_interpretations.R
@@ -4,17 +4,648 @@
 
 #' Get map unit interpretations from Soil Data Access by rule name
 #'
-#' @param mrulename rule name of interpretation (matching a `mrulename` in `cointerp` table)
+#' @param rulename rule name of interpretation (matching a `mrulename` in `cointerp` table)
 #' @param method aggregation method. One of: "Dominant Component", "Dominant Condition", "Weighted Average", "None". If "None" is selected one row will be returned per component, otherwise one row will be returned per map unit.
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
-
+#' @details 
+#'  
+#' ## Rule Names in `cointerp` table
+#' 
+#' - AGR-Agronomic Concerns (ND)
+#' - AGR-Available Water Capacity (ND)
+#' - AGR-Natural Fertility (ND)
+#' - AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
+#' - AGR-Pesticide and Nutrient Runoff Potential (ND)
+#' - AGR-Physical Limitations (ND)
+#' - AGR-Rooting Depth (ND)
+#' - AGR-Sodicity (ND)
+#' - AGR-Subsurface Salinity (ND)
+#' - AGR-Surface Crusting (ND)
+#' - AGR-Surface Salinity (ND)
+#' - AGR-Water Erosion (ND)
+#' - AGR-Wind Erosion (ND)
+#' - AGR - Air Quality; PM10 (TX)
+#' - AGR - Air Quality; PM2_5 (TX)
+#' - AGR - Avocado Root Rot Hazard (CA)
+#' - AGR - Barley Yield (MT)
+#' - AGR - California Revised Storie Index (CA)
+#' - AGR - Conventional Tillage (TX)
+#' - AGR - Filter Strips (TX)
+#' - AGR - Grape non-irrigated (MO)
+#' - AGR - Hops Site Suitability (WA)
+#' - AGR - Index for alfalfa hay, irrigated (NV)
+#' - AGR - Map Unit Cropland Productivity (MN)
+#' - AGR - Mulch Till (TX)
+#' - AGR - Nitrate Leaching Potential, Irrigated (WA)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (MA)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (MT)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (WA)
+#' - AGR - No Till (TX)
+#' - AGR - No Till (VT)
+#' - AGR - No Till, Tile Drained (TX)
+#' - AGR - Oats Yield (MT)
+#' - AGR - Orchard Groups (TX)
+#' - AGR - Pasture hayland (MO)
+#' - AGR - Pesticide Loss Potential-Leaching
+#' - AGR - Pesticide Loss Potential-Leaching (NE)
+#' - AGR - Pesticide Loss Potential-Soil Surface Runoff
+#' - AGR - Pesticide Loss Potential-Soil Surface Runoff (NE)
+#' - AGR - Plant Growth Index PGI no Climate Adj. (TX)
+#' - AGR - Plant Growth Index PGI with Climate Adj. (TX)
+#' - AGR - Plant Growth Index PGI with Climate Adj. MAP,MAAT (TX)
+#' - AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
+#' - AGR - Ridge Till (TX)
+#' - AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
+#' - AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
+#' - AGR - Selenium Leaching Potential (CO)
+#' - AGR - Spring Wheat Yield (MT)
+#' - AGR - Water Erosion Potential (TX)
+#' - AGR - Water Erosion Potential Wide Ratings Array (TX)
+#' - AGR - Wind Erosion Potential (TX)
+#' - AGR - Wind Erosion Potential Wide Ratings Array (TX)
+#' - AGR - Wine Grape Site Suitability (WA)
+#' - AGR - Winter Wheat Yield (MT)
+#' - Alaska Exempt Wetland Potential (AK)
+#' - American Wine Grape Varieties Site Desirability (Long)
+#' - American Wine Grape Varieties Site Desirability (Medium)
+#' - American Wine Grape Varieties Site Desirability (Short)
+#' - American Wine Grape Varieties Site Desirability (Very Long)
+#' - AWM - Animal Mortality Disposal (Catastrophic) (MO)
+#' - AWM - Filter Group (OH)
+#' - AWM - Irrigation Disposal of Wastewater
+#' - AWM - Irrigation Disposal of Wastewater (DE)
+#' - AWM - Irrigation Disposal of Wastewater (MD)
+#' - AWM - Irrigation Disposal of Wastewater (OH)
+#' - AWM - Irrigation Disposal of Wastewater (VT)
+#' - AWM - Land App of Municipal Sewage Sludge (DE)
+#' - AWM - Land App of Municipal Sewage Sludge (MD)
+#' - AWM - Land Application of Dry and Slurry Manure (TX)
+#' - AWM - Land Application of Milk (CT)
+#' - AWM - Land Application of Municipal Biosolids, spring (OR)
+#' - AWM - Land Application of Municipal Biosolids, summer (OR)
+#' - AWM - Land Application of Municipal Biosolids, winter (OR)
+#' - AWM - Land Application of Municipal Sewage Sludge
+#' - AWM - Land Application of Municipal Sewage Sludge (OH)
+#' - AWM - Land Application of Municipal Sewage Sludge (VT)
+#' - AWM - Large Animal Disposal, Pit (MN)
+#' - AWM - Manure and Food Processing Waste
+#' - AWM - Manure and Food Processing Waste (DE)
+#' - AWM - Manure and Food Processing Waste (MD)
+#' - AWM - Manure and Food Processing Waste (OH)
+#' - AWM - Manure and Food Processing Waste (VT)
+#' - AWM - Manure Stacking - Site Evaluation (TX)
+#' - AWM - Overland Flow Process Treatment of Wastewater
+#' - AWM - Overland Flow Process Treatment of Wastewater (VT)
+#' - AWM - Phosphorus Management (TX)
+#' - AWM - Rapid Infil Disposal of Wastewater (DE)
+#' - AWM - Rapid Infil Disposal of Wastewater (MD)
+#' - AWM - Rapid Infiltration Disposal of Wastewater
+#' - AWM - Rapid Infiltration Disposal of Wastewater (VT)
+#' - AWM - Sensitive Soil Features (MN)
+#' - AWM - Slow Rate Process Treatment of Wastewater
+#' - AWM - Slow Rate Process Treatment of Wastewater (VT)
+#' - AWM - Vegetated Treatment Area (PIA)
+#' - AWM - Waste Field Storage Area (VT)
+#' - BLM-Reclamation Suitability (MT)
+#' - BLM - Chaining Suitability
+#' - BLM - Fencing
+#' - BLM - Fire Damage Susceptibility
+#' - BLM - Fugitive Dust Resistance
+#' - BLM - Mechanical Treatment, Rolling Drum
+#' - BLM - Mechanical Treatment, Shredder
+#' - BLM - Medusahead Invasion Susceptibility
+#' - BLM - Pygmy Rabbit Habitat Potential
+#' - BLM - Rangeland Drill
+#' - BLM - Rangeland Seeding, Colorado Plateau Ecoregion
+#' - BLM - Rangeland Seeding, Great Basin Ecoregion
+#' - BLM - Rangeland Tillage
+#' - BLM - Site Degradation Susceptibility
+#' - BLM - Soil Compaction Resistance
+#' - BLM - Soil Restoration Potential
+#' - BLM - Yellow Star-thistle Invasion Susceptibility
+#' - CA Prime Farmland (CA)
+#' - Capping Fill Gravity Septic System (DE)
+#' - CLASS RULE - Depth to any bedrock kind (5 classes) (NPS)
+#' - CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
+#' - CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
+#' - CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
+#' - CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
+#' - CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
+#' - CLR-cropland limitation for corn and soybeans (IN)
+#' - CLR-pastureland limitation (IN)
+#' - Commodity Crop Productivity Index (Corn) (WI)
+#' - CPI - Alfalfa Hay, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Alfalfa Hay, IRR - Klamath Valley and Basins (OR)
+#' - CPI - Alfalfa Hay, IRR - Snake River Plains (ID)
+#' - CPI - Alfalfa Hay, NIRR- Eastern Idaho Plateaus (ID)
+#' - CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+#' - CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+#' - CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Barley, NIRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Grass Hay, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
+#' - CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
+#' - CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+#' - CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+#' - CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Potatoes, IRR - Snake River Plains (ID)
+#' - CPI - Small Grains Productivity Index (AK)
+#' - CPI - Small Grains, IRR - Snake River Plains (ID)
+#' - CPI - Small Grains, NIRR - Palouse Prairies (ID)
+#' - CPI - Small Grains, NIRR - Palouse Prairies (OR)
+#' - CPI - Small Grains, NIRR - Palouse Prairies (WA)
+#' - CPI - Small Grains, NIRR - Snake River Plains (ID)
+#' - CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Wheat, NIRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Wild Hay, NIRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+#' - CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+#' - Deep Infiltration Systems
+#' - DHS - Catastrophic Event, Large Animal Mortality, Burial
+#' - DHS - Catastrophic Event, Large Animal Mortality, Incinerate
+#' - DHS - Catastrophic Mortality, Large Animal Disposal, Pit
+#' - DHS - Catastrophic Mortality, Large Animal Disposal, Trench
+#' - DHS - Emergency Animal Mortality Disposal by Shallow Burial
+#' - DHS - Emergency Land Disposal of Milk
+#' - DHS - Potential for Radioactive Bioaccumulation
+#' - DHS - Potential for Radioactive Sequestration
+#' - DHS - Rubble and Debris Disposal, Large-Scale Event
+#' - DHS - Site for Composting Facility - Subsurface
+#' - DHS - Site for Composting Facility - Surface
+#' - DHS - Suitability for Clay Liner Material
+#' - DHS - Suitability for Composting Medium and Final Cover
+#' - Elevated Sand Mound Septic System (DE)
+#' - ENG - Animal Disposal by Composting (Catastrophic) (WV)
+#' - ENG - Application of Municipal Sludge (TX)
+#' - ENG - Aquifer Assessment - 7081 (MN)
+#' - ENG - Closed-Loop Horizontal Geothermal Heat Pump (CT)
+#' - ENG - Cohesive Soil Liner (MN)
+#' - ENG - Construction Materials - Gravel Source (MN)
+#' - ENG - Construction Materials - Sand Source (MN)
+#' - ENG - Construction Materials; Gravel Source
+#' - ENG - Construction Materials; Gravel Source (AK)
+#' - ENG - Construction Materials; Gravel Source (CT)
+#' - ENG - Construction Materials; Gravel Source (ID)
+#' - ENG - Construction Materials; Gravel Source (IN)
+#' - ENG - Construction Materials; Gravel Source (MI)
+#' - ENG - Construction Materials; Gravel Source (NE)
+#' - ENG - Construction Materials; Gravel Source (NY)
+#' - ENG - Construction Materials; Gravel Source (OH)
+#' - ENG - Construction Materials; Gravel Source (OR)
+#' - ENG - Construction Materials; Gravel Source (VT)
+#' - ENG - Construction Materials; Gravel Source (WA)
+#' - ENG - Construction Materials; Reclamation
+#' - ENG - Construction Materials; Reclamation (DE)
+#' - ENG - Construction Materials; Reclamation (MD)
+#' - ENG - Construction Materials; Reclamation (MI)
+#' - ENG - Construction Materials; Reclamation (OH)
+#' - ENG - Construction Materials; Roadfill
+#' - ENG - Construction Materials; Roadfill (AK)
+#' - ENG - Construction Materials; Roadfill (GA)
+#' - ENG - Construction Materials; Roadfill (OH)
+#' - ENG - Construction Materials; Sand Source
+#' - ENG - Construction Materials; Sand Source (AK)
+#' - ENG - Construction Materials; Sand Source (CT)
+#' - ENG - Construction Materials; Sand Source (GA)
+#' - ENG - Construction Materials; Sand Source (ID)
+#' - ENG - Construction Materials; Sand Source (IN)
+#' - ENG - Construction Materials; Sand Source (NY)
+#' - ENG - Construction Materials; Sand Source (OH)
+#' - ENG - Construction Materials; Sand Source (OR)
+#' - ENG - Construction Materials; Sand Source (VT)
+#' - ENG - Construction Materials; Sand Source (WA)
+#' - ENG - Construction Materials; Topsoil
+#' - ENG - Construction Materials; Topsoil (AK)
+#' - ENG - Construction Materials; Topsoil (DE)
+#' - ENG - Construction Materials; Topsoil (GA)
+#' - ENG - Construction Materials; Topsoil (ID)
+#' - ENG - Construction Materials; Topsoil (MD)
+#' - ENG - Construction Materials; Topsoil (MI)
+#' - ENG - Construction Materials; Topsoil (OH)
+#' - ENG - Construction Materials; Topsoil (OR)
+#' - ENG - Construction Materials; Topsoil (WA)
+#' - ENG - Daily Cover for Landfill
+#' - ENG - Daily Cover for Landfill (AK)
+#' - ENG - Daily Cover for Landfill (OH)
+#' - ENG - Disposal Field (NJ)
+#' - ENG - Disposal Field Gravity (DE)
+#' - ENG - Disposal Field Suitability Class (NJ)
+#' - ENG - Disposal Field Type Inst (NJ)
+#' - ENG - Dwellings W/O Basements
+#' - ENG - Dwellings W/O Basements (OH)
+#' - ENG - Dwellings With Basements
+#' - ENG - Dwellings with Basements (AK)
+#' - ENG - Dwellings With Basements (OH)
+#' - ENG - Dwellings without Basements (AK)
+#' - ENG - Large Animal Disposal, Pit (CT)
+#' - ENG - Large Animal Disposal, Trench (CT)
+#' - ENG - Lawn and Landscape (OH)
+#' - ENG - Lawn, Landscape, Golf Fairway
+#' - ENG - Lawn, landscape, golf fairway (CT)
+#' - ENG - Lawn, Landscape, Golf Fairway (MI)
+#' - ENG - Lawn, Landscape, Golf Fairway (VT)
+#' - ENG - Local Roads and Streets
+#' - ENG - Local Roads and Streets (AK)
+#' - ENG - Local Roads and Streets (GA)
+#' - ENG - Local Roads and Streets (OH)
+#' - ENG - New Ohio Septic Rating (OH)
+#' - ENG - On-Site Waste Water Absorption Fields (MO)
+#' - ENG - On-Site Waste Water Lagoons (MO)
+#' - ENG - OSHA Soil Types (TX)
+#' - ENG - Pier Beam Building Foundations (TX)
+#' - ENG - Sanitary Landfill (Area)
+#' - ENG - Sanitary Landfill (Area) (AK)
+#' - ENG - Sanitary Landfill (Area) (OH)
+#' - ENG - Sanitary Landfill (Trench)
+#' - ENG - Sanitary Landfill (Trench) (AK)
+#' - ENG - Sanitary Landfill (Trench) (OH)
+#' - ENG - Septage Application - Incorporation or Injection (MN)
+#' - ENG - Septage Application - Surface (MN)
+#' - ENG - Septic System; Disinfection, Surface Application (TX)
+#' - ENG - Septic Tank Absorption Fields
+#' - ENG - Septic Tank Absorption Fields - At-Grade (MN)
+#' - ENG - Septic Tank Absorption Fields - Mound (MN)
+#' - ENG - Septic Tank Absorption Fields - Trench (MN)
+#' - ENG - Septic Tank Absorption Fields (AK)
+#' - ENG - Septic Tank Absorption Fields (DE)
+#' - ENG - Septic Tank Absorption Fields (FL)
+#' - ENG - Septic Tank Absorption Fields (MD)
+#' - ENG - Septic Tank Absorption Fields (NY)
+#' - ENG - Septic Tank Absorption Fields (OH)
+#' - ENG - Septic Tank Absorption Fields (TX)
+#' - ENG - Septic Tank Leaching Chamber (TX)
+#' - ENG - Septic Tank, Gravity Disposal (TX)
+#' - ENG - Septic Tank, Subsurface Drip Irrigation (TX)
+#' - ENG - Sewage Lagoons
+#' - ENG - Sewage Lagoons (AK)
+#' - ENG - Sewage Lagoons (OH)
+#' - ENG - Shallow Excavations
+#' - ENG - Shallow Excavations (AK)
+#' - ENG - Shallow Excavations (MI)
+#' - ENG - Shallow Excavations (OH)
+#' - ENG - Small Commercial Buildings
+#' - ENG - Small Commercial Buildings (OH)
+#' - ENG - Soil Potential of Road Salt Applications (CT)
+#' - ENG - Soil Potential Ratings of SSDS (CT)
+#' - ENG - Source of Caliche (TX)
+#' - ENG - Stormwater Management / Infiltration (NY)
+#' - ENG - Stormwater Management / Ponds (NY)
+#' - ENG - Stormwater Management / Wetlands (NY)
+#' - ENG - Unpaved Local Roads and Streets
+#' - Farm and Garden Composting Facility - Surface
+#' - FOR-Biomass Harvest (WI)
+#' - FOR-Construction Limitations for Haul Roads/Log Landings(ME)
+#' - FOR - Biomass Harvest (MA)
+#' - FOR - Black Walnut Suitability Index (KS)
+#' - FOR - Black Walnut Suitability Index (MO)
+#' - FOR - Compaction Potential (WA)
+#' - FOR - Construction Limitations - Haul Roads/Log Landing (OH)
+#' - FOR - Construction Limitations For Haul Roads (MI)
+#' - FOR - Construction Limitations for Haul Roads/Log Landings
+#' - FOR - Damage by Fire (OH)
+#' - FOR - Displacement Hazard
+#' - FOR - Displacement Potential (WA)
+#' - FOR - General Harvest Season (ME)
+#' - FOR - General Harvest Season (VT)
+#' - FOR - Hand Planting Suitability
+#' - FOR - Hand Planting Suitability (ME)
+#' - FOR - Hand Planting Suitability, MO13 (DE)
+#' - FOR - Hand Planting Suitability, MO13 (MD)
+#' - FOR - Harvest Equipment Operability
+#' - FOR - Harvest Equipment Operability (DE)
+#' - FOR - Harvest Equipment Operability (MD)
+#' - FOR - Harvest Equipment Operability (ME)
+#' - FOR - Harvest Equipment Operability (MI)
+#' - FOR - Harvest Equipment Operability (OH)
+#' - FOR - Harvest Equipment Operability (VT)
+#' - FOR - Log Landing Suitability
+#' - FOR - Log Landing Suitability (ID)
+#' - FOR - Log Landing Suitability (ME)
+#' - FOR - Log Landing Suitability (MI)
+#' - FOR - Log Landing Suitability (OR)
+#' - FOR - Log Landing Suitability (VT)
+#' - FOR - Log Landing Suitability (WA)
+#' - FOR - Mechanical Planting Suitability
+#' - FOR - Mechanical Planting Suitability (CT)
+#' - FOR - Mechanical Planting Suitability (ME)
+#' - FOR - Mechanical Planting Suitability (OH)
+#' - FOR - Mechanical Planting Suitability, MO13 (DE)
+#' - FOR - Mechanical Planting Suitability, MO13 (MD)
+#' - FOR - Mechanical Site Preparation (Deep)
+#' - FOR - Mechanical Site Preparation (Deep) (DE)
+#' - FOR - Mechanical Site Preparation (Deep) (MD)
+#' - FOR - Mechanical Site Preparation (Surface)
+#' - FOR - Mechanical Site Preparation (Surface) (DE)
+#' - FOR - Mechanical Site Preparation (Surface) (MD)
+#' - FOR - Mechanical Site Preparation (Surface) (MI)
+#' - FOR - Mechanical Site Preparation (Surface) (OH)
+#' - FOR - Mechanical Site Preparation; Deep (CT)
+#' - FOR - Mechanical Site Preparation; Surface (ME)
+#' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+#' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (MI)
+#' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (OH)
+#' - FOR - Potential Erosion Hazard (Road/Trail)
+#' - FOR - Potential Erosion Hazard (Road/Trail) (PIA)
+#' - FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
+#' - FOR - Potential Fire Damage Hazard
+#' - FOR - Potential Seedling Mortality
+#' - FOR - Potential Seedling Mortality (FL)
+#' - FOR - Potential Seedling Mortality (MI)
+#' - FOR - Potential Seedling Mortality (OH)
+#' - FOR - Potential Seedling Mortality (PIA)
+#' - FOR - Potential Seedling Mortality (VT)
+#' - FOR - Potential Seedling Mortality(ME)
+#' - FOR - Potential Windthrow Hazard (ME)
+#' - FOR - Potential Windthrow Hazard (MI)
+#' - FOR - Potential Windthrow Hazard (NY)
+#' - FOR - Potential Windthrow Hazard (VT)
+#' - FOR - Puddling Hazard
+#' - FOR - Puddling Potential (WA)
+#' - FOR - Road Suitability (Natural Surface)
+#' - FOR - Road Suitability (Natural Surface) (ID)
+#' - FOR - Road Suitability (Natural Surface) (ME)
+#' - FOR - Road Suitability (Natural Surface) (OH)
+#' - FOR - Road Suitability (Natural Surface) (OR)
+#' - FOR - Road Suitability (Natural Surface) (VT)
+#' - FOR - Road Suitability (Natural Surface) (WA)
+#' - FOR - Rutting Hazard by Month
+#' - FOR - Rutting Hazard by Season
+#' - FOR - Shortleaf pine littleleaf disease susceptibility
+#' - FOR - Soil Compactibility Risk
+#' - FOR - Soil Rutting Hazard
+#' - FOR - Soil Rutting Hazard (ME)
+#' - FOR - Soil Rutting Hazard (OH)
+#' - FOR - Soil Sustainability Forest Biomass Harvesting (CT)
+#' - FOR - White Oak Suitability (MO)
+#' - FOR - Windthrow Hazard
+#' - FOR - Windthrow Hazard (WA)
+#' - FOR (USFS) - Road Construction/Maintenance (Natural Surface)
+#' - FOTG - Indiana Corn Yield Calculation (IN)
+#' - FOTG - Indiana Slippage Potential (IN)
+#' - FOTG - Indiana Soy Bean Yield Calculation (IN)
+#' - FOTG - Indiana Wheat Yield Calculation (IN)
+#' - Fragile Soil Index
+#' - Gravity Full Depth Septic System (DE)
+#' - GRL-FSG-NP-W (MT)
+#' - GRL - Excavations to 24 inches for Plastic Pipelines (TX)
+#' - GRL - Fencing, 24 inch Post Depth (MT)
+#' - GRL - Fencing, Post Depth =<24 inches
+#' - GRL - Fencing, Post Depth =<36 inches
+#' - GRL - Fencing, Post Depth Less Than 24 inches (TX)
+#' - GRL - Fencing, Post Depth Less Than 36 inches (TX)
+#' - GRL - Juniper Encroachment Potential (NM)
+#' - GRL - NV range seeding (Wind C = 10) (NV)
+#' - GRL - NV range seeding (Wind C = 100) (NV)
+#' - GRL - NV range seeding (Wind C = 20) (NV)
+#' - GRL - NV range seeding (Wind C = 30) (NV)
+#' - GRL - NV range seeding (Wind C = 40) (NV)
+#' - GRL - NV range seeding (Wind C = 50) (NV)
+#' - GRL - NV range seeding (Wind C = 60) (NV)
+#' - GRL - NV range seeding (Wind C = 80) (NV)
+#' - GRL - NV range seeding (Wind C >= 160) (NV)
+#' - GRL - Pasture and Hayland SG (OH)
+#' - GRL - Ranch Access Roads (TX)
+#' - GRL - Rangeland Chaining (TX)
+#' - GRL - Rangeland Disking (TX)
+#' - GRL - Rangeland Dozing/Grubbing (TX)
+#' - GRL - Rangeland Planting by Mechanical Seeding (TX)
+#' - GRL - Rangeland Prescribed Burning (TX)
+#' - GRL - Rangeland Roller Chopping (TX)
+#' - GRL - Rangeland Root Plowing (TX)
+#' - GRL - Utah Juniper Encroachment Potential
+#' - GRL - Western Juniper Encroachment Potential (OR)
+#' - Ground-based Solar Arrays, Ballast Anchor Systems
+#' - Ground-based Solar Arrays, Soil-penetrating Anchor Systems
+#' - Ground Penetrating Radar Penetration
+#' - Hybrid Wine Grape Varieties Site Desirability (Long)
+#' - Hybrid Wine Grape Varieties Site Desirability (Medium)
+#' - Hybrid Wine Grape Varieties Site Desirability (Short)
+#' - Inland Wetlands (CT)
+#' - IRR-restrictive features for irrigation (OH)
+#' - ISDH Septic Tank Interpretation (IN)
+#' - Land Application of Municipal Sewage Sludge (PA)
+#' - Lined Retention Systems
+#' - Low Pressure Pipe Septic System (DE)
+#' - MIL - Bivouac Areas (DOD)
+#' - MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
+#' - MIL - Excavations for Individual Fighting Position (DOD)
+#' - MIL - Excavations for Vehicle Fighting Position (DOD)
+#' - MIL - Helicopter Landing Zones (DOD)
+#' - MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 1 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 2 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 3 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 3 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 4 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 5 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 5 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 6 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 7 dry season (DOD)
+#' - MT - Conservation Tree/Shrub Groups (MT)
+#' - Muscadine Wine Grape Site Desirability (Very Long)
+#' - NCCPI - Irrigated National Commodity Crop Productivity Index
+#' - NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
+#' - NCCPI - NCCPI Corn Submodel (I)
+#' - NCCPI - NCCPI Cotton Submodel (II)
+#' - NCCPI - NCCPI Small Grains Submodel (II)
+#' - NCCPI - NCCPI Soybeans Submodel (I)
+#' - Nitrogen Loss Potential (ND)
+#' - Permafrost Sensitivity (AK)
+#' - Pressure Dose Capping Fill Septic System (DE)
+#' - Pressure Dose Full Depth Septic System (DE)
+#' - REC - Camp and Picnic Areas (AK)
+#' - REC - Camp Areas (CT)
+#' - REC - Camp Areas; Primitive (AK)
+#' - REC - Foot and ATV Trails (AK)
+#' - REC - Off-Road Motorcycle Trails (CT)
+#' - REC - Paths and Trails (CT)
+#' - REC - Picnic Areas (CT)
+#' - REC - Playgrounds (AK)
+#' - REC - Playgrounds (CT)
+#' - RSK-risk assessment for manure application (OH)
+#' - Salinity Risk Index, Discharge Model (ND)
+#' - SAS - CMECS Substrate Class
+#' - SAS - CMECS Substrate Origin
+#' - SAS - CMECS Substrate Subclass
+#' - SAS - CMECS Substrate Subclass/Group
+#' - SAS - CMECS Substrate Subclass/Group/Subgroup
+#' - SAS - Eastern Oyster Habitat Restoration Suitability
+#' - SAS - Eelgrass Restoration Suitability
+#' - SAS - Land Utilization of Dredged Materials
+#' - SAS - Mooring Anchor - Deadweight
+#' - SAS - Mooring Anchor - Mushroom
+#' - SAS - Northern Quahog (Hard Clam) Habitat Suitability
+#' - Septic System A/B Soil System (Alternate) (PA)
+#' - Septic System At-Grade Bed (Alternate) (PA)
+#' - Septic System At Grade Shallow Field (alternative) (WV)
+#' - Septic System CO-OP RFS III w/At-Grade Bed (PA)
+#' - Septic System CO-OP RFS III w/Drip Irrigation (PA)
+#' - Septic System CO-OP RFS III w/Spray Irrigation (PA)
+#' - Septic System Drip Irrigation (Alternate) (PA)
+#' - Septic System Drip Irrigation (alternative) (WV)
+#' - Septic System Dual Field Trench (conventional) (WV)
+#' - Septic System Elevated Field (alternative) (WV)
+#' - Septic System Free Access Sand Filter w/At-Grade Bed (PA)
+#' - Septic System Free Access Sand Filter w/Drip Irrigation (PA)
+#' - Septic System Free Access Sand Filterw/Spray Irrigation (PA)
+#' - Septic System In Ground Bed (conventional) (PA)
+#' - Septic System In Ground Trench (conventional) (PA)
+#' - Septic System In Ground Trench (conventional) (WV)
+#' - Septic System Low Pressure Pipe (alternative) (WV)
+#' - Septic System Modified Subsurface Sand Filter (Alt.) (PA)
+#' - Septic System Mound (alternative) (WV)
+#' - Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
+#' - Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
+#' - Septic System Peat Based Option2 w/Spray Irrigation (PA)
+#' - Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
+#' - Septic System Sand Mound Bed or Trench (PA)
+#' - Septic System Shallow In Ground Trench (conventional) (WV)
+#' - Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
+#' - Septic System Spray Irrigation (PA)
+#' - Septic System Steep Slope Mound (alternative) (WV)
+#' - Septic System Steep Slope Sand Mound (Alternate) (PA)
+#' - Septic System Subsurface Sand Filter Bed (conventional) (PA)
+#' - Septic System Subsurface Sand Filter Trench (standard) (PA)
+#' - Shallow Infiltration Systems
+#' - SOH -  Suitability for Aerobic Soil Organisms
+#' - SOH - Agricultural Organic Soil Subsidence
+#' - SOH - Concentration of Salts- Soil Surface
+#' - SOH - Organic Matter Depletion
+#' - SOH - Soil Surface Sealing
+#' - SOH - Soil Susceptibility to Compaction
+#' - Soil Habitat for Saprophyte Stage of Coccidioides
+#' - SOIL HEALTH ASSESSMENT (NJ)
+#' - Soil Vegetative Groups (CA)
+#' - Surface Runoff Class (CA)
+#' - Unlined Retention Systems
+#' - URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
+#' - URB - Commercial Brick Buildings w/Concrete Slab (TX)
+#' - URB - Commercial Metal Bldg; w/Concrete Slab (TX)
+#' - URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
+#' - URB - Commercial Metal Buildings w/o Concrete Slab (TX)
+#' - URB - Concrete Driveways and Sidewalks (TX)
+#' - URB - Dwellings on Concrete Slab (TX)
+#' - URB - Dwellings With Basements (TX)
+#' - URB - Lawns and Ornamental Plantings (TX)
+#' - URB - Reinforced Concrete Slab (TX)
+#' - URB - Rural Residential Development on Concrete Slab (TX)
+#' - URB - Rural Residential Development w/Basement (TX)
+#' - URB - Urban Residential Development on Concrete Slab (TX)
+#' - URB - Urban Residential Development w/Basement (TX)
+#' - URB/REC - Camp Areas
+#' - URB/REC - Camp Areas (GA)
+#' - URB/REC - Camp Areas (HI)
+#' - URB/REC - Camp Areas (MI)
+#' - URB/REC - Camp Areas (OH)
+#' - URB/REC - Golf Fairways (OH)
+#' - URB/REC - Off-Road Motorcycle Trails
+#' - URB/REC - Off-Road Motorcycle Trails (OH)
+#' - URB/REC - Paths and Trails
+#' - URB/REC - Paths and Trails (GA)
+#' - URB/REC - Paths and Trails (MI)
+#' - URB/REC - Paths and Trails (OH)
+#' - URB/REC - Picnic Areas
+#' - URB/REC - Picnic Areas (GA)
+#' - URB/REC - Picnic Areas (MI)
+#' - URB/REC - Picnic Areas (OH)
+#' - URB/REC - Playgrounds
+#' - URB/REC - Playgrounds (GA)
+#' - URB/REC - Playgrounds (MI)
+#' - URB/REC - Playgrounds (OH)
+#' - Vinifera Wine Grape Site Desirability (Long to Medium)
+#' - Vinifera Wine Grape Site Desirability (Long)
+#' - Vinifera Wine Grape Site Desirability (Short to Medium)
+#' - Vinifera Wine Grape Site Desirability (Short)
+#' - WAQ - Soil Pesticide Absorbed Runoff Potential (TX)
+#' - WAQ - Soil Pesticide Leaching Potential (TX)
+#' - WAQ - Soil Pesticide Solution Runoff Potential (TX)
+#' - WLF-Soil Suitability - Karner Blue Butterfly (WI)
+#' - WLF - Burrowing Mammals & Reptiles (TX)
+#' - WLF - Chufa for Turkey Forage (LA)
+#' - WLF - Crawfish Aquaculture (TX)
+#' - WLF - Desert Tortoise (CA)
+#' - WLF - Desertic Herbaceous Plants (TX)
+#' - WLF - Domestic Grasses & Legumes for Food and Cover (TX)
+#' - WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
+#' - WLF - Freshwater Wetland Plants (TX)
+#' - WLF - Gopher Tortoise Burrowing Suitability
+#' - WLF - Grain & Seed Crops for Food and Cover (TX)
+#' - WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
+#' - WLF - Irrigated Freshwater Wetland Plants (TX)
+#' - WLF - Irrigated Grain & Seed Crops for Food & Cover (TX)
+#' - WLF - Irrigated Saline Water Wetland Plants (TX)
+#' - WLF - Riparian Herbaceous Plants (TX)
+#' - WLF - Riparian Shrubs, Vines, & Trees (TX)
+#' - WLF - Saline Water Wetland Plants (TX)
+#' - WLF - Upland Coniferous Trees (TX)
+#' - WLF - Upland Deciduous Trees (TX)
+#' - WLF - Upland Desertic Shrubs & Trees (TX)
+#' - WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
+#' - WLF - Upland Native Herbaceous Plants (TX)
+#' - WLF - Upland Shrubs & Vines (TX)
+#' - WMS-Subsurface Water Management, Installation (ND)
+#' - WMS-Subsurface Water Management, Outflow Quality (ND)
+#' - WMS-Subsurface Water Management, Performance (ND)
+#' - WMS - Constructing Grassed Waterways (OH)
+#' - WMS - Constructing Grassed Waterways (TX)
+#' - WMS - Constructing Terraces & Diversions (TX)
+#' - WMS - Constructing Terraces and Diversions (OH)
+#' - WMS - Drainage - (MI)
+#' - WMS - Drainage (IL)
+#' - WMS - Drainage (OH)
+#' - WMS - Embankments, Dikes, and Levees
+#' - WMS - Embankments, Dikes, and Levees (OH)
+#' - WMS - Embankments, Dikes, and Levees (VT)
+#' - WMS - Excavated Ponds (Aquifer-fed)
+#' - WMS - Excavated Ponds (Aquifer-fed) (OH)
+#' - WMS - Excavated Ponds (Aquifer-fed) (VT)
+#' - WMS - Grape Production with Drip Irrigation (TX)
+#' - WMS - Grassed Waterways - (MI)
+#' - WMS - Irrigation, General
+#' - WMS - Irrigation, Micro (above ground)
+#' - WMS - Irrigation, Micro (above ground) (VT)
+#' - WMS - Irrigation, Micro (subsurface drip)
+#' - WMS - Irrigation, Micro (subsurface drip) (VT)
+#' - WMS - Irrigation, Sprinkler (close spaced outlet drops)
+#' - WMS - Irrigation, Sprinkler (general)
+#' - WMS - Irrigation, Sprinkler (general) (VT)
+#' - WMS - Irrigation, Surface (graded)
+#' - WMS - Irrigation, Surface (level)
+#' - WMS - Pond Reservoir Area
+#' - WMS - Pond Reservoir Area (GA)
+#' - WMS - Pond Reservoir Area (MI)
+#' - WMS - Pond Reservoir Area (OH)
+#' - WMS - Sprinkler Irrigation (MT)
+#' - WMS - Sprinkler Irrigation RDC (IL)
+#' - WMS - Subsurface Drains - Installation (VT)
+#' - WMS - Subsurface Drains - Performance (VT)
+#' - WMS - Subsurface Drains < 3 Feet Deep (TX)
+#' - WMS - Subsurface Drains > 3 Feet Deep (TX)
+#' - WMS - Subsurface Water Management, Outflow Quality
+#' - WMS - Subsurface Water Management, System Installation
+#' - WMS - Subsurface Water Management, System Performance
+#' - WMS - Surface Drains (TX)
+#' - WMS - Surface Irrigation Intake Family (TX)
+#' - WMS - Surface Water Management, System
+#' 
 #' @author Jason Nemecek, Chad Ferguson, Andrew Brown
 #' @return a data.frame
 #' @export
 #' @importFrom soilDB format_SQL_in_statement SDA_query
 #' 
-get_SDA_interpretation <- function(mrulename, 
+get_SDA_interpretation <- function(rulename, 
                                    method = c("Dominant Component", 
                                               "Dominant Condition", 
                                               "Weighted Average", 
@@ -22,7 +653,7 @@ get_SDA_interpretation <- function(mrulename,
                                    areasymbols = NULL, mukeys = NULL) {
   q <- .constructInterpQuery(
       method = method,
-      interp = mrulename,
+      interp = rulename,
       areasymbols = areasymbols,
       mukeys = mukeys
     )

--- a/R/SDA_properties.R
+++ b/R/SDA_properties.R
@@ -5,20 +5,107 @@
 #' Get map unit properties from Soil Data Access
 #'
 #' @param property a label or column name from property dictionary
-#' @param method one of: "Dominant Component (Category)", "Weighted Average", "Min/Max", "Dominant Component (Numeric)", "Dominant Condition"#'
+#' @param method one of: "Dominant Component (Category)", "Weighted Average", "Min/Max", "Dominant Component (Numeric)", "Dominant Condition", or "None". If "None" is selected, the number of rows returned will depend on whether a component or horizon level property was selected, otherwise the result will be 1:1 with the number of map units.
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
 #' @param top_depth Optional: a numeric value for upper boundary (top depth) used for method="weighted average" and "dominant component (numeric)"
 #' @param bottom_depth Optional: a numeric value for lower boundary (bottom depth) used for method="weighted average and "dominant component (numeric)"
 #' @param FUN Optional: character representing SQL aggregation function either "MIN" or "MAX" for method="min/max"
+#' @details 
+#' 
+#' The `property` argument refers to one of the property names or columns specified in the tables below.
+#' 
+#'  ## Selected Component-level Properties
+#'  
+#'  |**Property (Component)**                         |**Column**         |
+#'  |:------------------------------------------------|:------------------|
+#'  |Range Production - Favorable Year                |rsprod_h           |
+#'  |Range Production - Normal Year                   |rsprod_r           |
+#'  |Range Production - Unfavorable Year              |rsprod_l           |
+#'  |Corrosion of Steel                               |corsteel           |
+#'  |Corrosion of Concrete                            |corcon             |
+#'  |Drainage Class                                   |drainagecl         |
+#'  |Hydrologic Group                                 |hydgrp             |
+#'  |Taxonomic Class Name                             |taxclname          |
+#'  |Taxonomic Order                                  |taxorder           |
+#'  |Taxonomic Suborder                               |taxsuborder        |
+#'  |Taxonomic Temperature Regime                     |taxtempregime      |
+#'  |Wind Erodibility Group                           |weg                |
+#'  |Wind Erodibility Index                           |wei                |
+#'  |t Factor                                         |tfact              |
+#'  
+#'  ## Selected Horizon-level Properties
+#'  
+#'  |**Property (Horizon)**                           |**Column**         |
+#'  |:------------------------------------------------|:------------------|
+#'  |0.1 bar H2O - Rep Value                          |wtenthbar_r        |
+#'  |0.33 bar H2O - Rep Value                         |wthirdbar_r        |
+#'  |15 bar H2O - Rep Value                           |wfifteenbar_r      |
+#'  |Available Water Capacity - Rep Value             |awc_r              |
+#'  |Bray 1 Phosphate - Rep Value                     |pbray1_r           |
+#'  |Bulk Density 0.1 bar H2O - Rep Value             |dbtenthbar_r       |
+#'  |Bulk Density 0.33 bar H2O - Rep Value            |dbthirdbar_r       |
+#'  |Bulk Density 15 bar H2O - Rep Value              |dbfifteenbar_r     |
+#'  |Bulk Density oven dry - Rep Value                |dbovendry_r        |
+#'  |CaCO3 Clay - Rep Value                           |claysizedcarb_r    |
+#'  |Calcium Carbonate - Rep Value                    |caco3_r            |
+#'  |Cation Exchange Capcity - Rep Value              |cec7_r             |
+#'  |Coarse Sand - Rep Value                          |sandco_r           |
+#'  |Coarse Silt - Rep Value                          |siltco_r           |
+#'  |Effective Cation Exchange Capcity - Rep Value    |ecec_r             |
+#'  |Electrial Conductivity 1:5 by volume - Rep Value |ec15_r             |
+#'  |Electrical Conductivity - Rep Value              |ec_r               |
+#'  |Exchangeable Sodium Percentage - Rep Value       |esp_r              |
+#'  |Extract Aluminum - Rep Value                     |extral_r           |
+#'  |Extractable Acidity - Rep Value                  |extracid_r         |
+#'  |Fine Sand - Rep Value                            |sandfine_r         |
+#'  |Fine Silt - Rep Value                            |siltfine_r         |
+#'  |Free Iron - Rep Value                            |freeiron_r         |
+#'  |Gypsum - Rep Value                               |gypsum_r           |
+#'  |Kf                                               |kffact             |
+#'  |Ki                                               |kifact             |
+#'  |Kr                                               |krfact             |
+#'  |Kw                                               |kwfact             |
+#'  |LEP - Rep Value                                  |lep_r              |
+#'  |Liquid Limit - Rep Value                         |ll_r               |
+#'  |Medium Sand - Rep Value                          |sandmed_r          |
+#'  |Organic Matter - Rep Value                       |om_r               |
+#'  |Oxalate Aluminum - Rep Value                     |aloxalate_r        |
+#'  |Oxalate Iron - Rep Value                         |feoxalate_r        |
+#'  |Oxalate Phosphate - Rep Value                    |poxalate_r         |
+#'  |Plasticity Index - Rep Value                     |pi_r               |
+#'  |Rock Fragments 3 - 10 cm - Rep Value             |frag3to10_r        |
+#'  |Rock Fragments > 10 cm - Rep Value               |fraggt10_r         |
+#'  |Rubbed Fiber % - Rep Value                       |fiberrubbedpct_r   |
+#'  |Satiated H2O - Rep Value                         |wsatiated_r        |
+#'  |Saturated Hydraulic Conductivity - Rep Value     |ksat_r             |
+#'  |Sodium Adsorption Ratio - Rep Value              |sar_r              |
+#'  |Sum of Bases - Rep Value                         |sumbases_r         |
+#'  |Total Clay - Rep Value                           |claytotal_r        |
+#'  |Total Phosphate - Rep Value                      |ptotal_r           |
+#'  |Total Rock Fragment Volume - Rep Value           |fragvoltot         |
+#'  |Total Sand - Rep Value                           |sandtotal_r        |
+#'  |Total Silt - Rep Value                           |silttotal_r        |
+#'  |Unrubbed Fiber % - Rep Value                     |fiberunrubbedpct_r |
+#'  |Very Coarse Sand - Rep Value                     |sandvc_r           |
+#'  |Very Fine Sand - Rep Value                       |sandvf_r           |
+#'  |Water Soluble Phosphate - Rep Value              |ph2osoluble_r      |
+#'  |no. 10 sieve - Rep Value                         |sieveno10_r        |
+#'  |no. 200 sieve - Rep Value                        |sieveno200_r       |
+#'  |no. 4 sieve - Rep Value                          |sieveno4_r         |
+#'  |no. 40 sieve - Rep Value                         |sieveno40_r        |
+#'  |pH .01M CaCl2 - Rep Value                        |ph01mcacl2_r       |
+#'  |pH 1:1 water - Rep Value                         |ph1to1h2o_r        |
+#'  |pH Oxidized - Rep Value                          |phoxidized_r       |
 #' @author Jason Nemecek, Chad Ferguson, Andrew Brown
 #' @return a data.frame with result
 #' @export
 #' @importFrom soilDB format_SQL_in_statement SDA_query
 get_SDA_property <-
   function(property, # property -- a label or column name from property dictionary
-           method, # method one of: "Dominant Component (Category)", "Weighted Average",
-                   #                "Min/Max", "Dominant Component (Numeric)", "Dominant Condition"
+           method = c("Dominant Component (Category)", "Weighted Average",
+                      "Min/Max", "Dominant Component (Numeric)", "Dominant Condition", 
+                      "None"),
            areasymbols = NULL, # vector of areasymbols
            mukeys = NULL, # vector of mukeys
            top_depth = NULL, # used for method="weighted average" and "dominant component (numeric)"
@@ -55,15 +142,16 @@ get_SDA_property <-
               "Weighted Average",
               "Min/Max",
               "Dominant Component (Numeric)",
-              "Dominant Condition")
+              "Dominant Condition",
+              "None", "None_Horizon")
   method <- match.arg(toupper(method), toupper(labels))
 
-  # determine column name suffix for method
+  # determine column name prefix/suffix for method
   suffixes <- c('_dom_comp_cat',
                 '_wtd_avg',
                 '_min_max',
                 '_dom_comp_num',
-                '_dom_cond')
+                '_dom_cond', '', 'chorizon_')
   modifier <- suffixes[match(method, toupper(labels))]
 
   # return list with method and modifier
@@ -167,8 +255,26 @@ get_SDA_property <-
   where_clause <- switch(as.character(is.null(areasymbols)),
                          "TRUE" = sprintf("mu.mukey IN %s", mukeys),
                          "FALSE" = sprintf("l.areasymbol IN %s", areasymbols))
-
+  
+  # check property, case insensitive, against dictionary
+  property <- toupper(property)
+  lut <- .propertyDictionary()
+  names(lut) <- toupper(names(lut))
+  agg_property <- lut[[property]]
+  
+  if(is.null(agg_property)) {
+    names(lut) <- toupper(.propertyDictionary())
+    agg_property <- lut[[property]]
+    if(is.null(agg_property))
+      stop("property must be a label or column name from SDA property dictionary (.propertyDictonary())", call. = FALSE)
+  }
+  
   method <- toupper(method)
+  
+  if (method == "NONE")
+    if (agg_property %in% colnames(suppressMessages(SDA_query("SELECT TOP 1 * FROM chorizon"))))
+      method <- "NONE_HORIZON"
+  
   mmC <- toupper(mmC)
 
   # check mmC arg for min max method
@@ -184,19 +290,6 @@ get_SDA_property <-
   }
 
   agg_method <- .propertyAggMethod(method)
-
-  # check property, case insensitive, against dictionary
-  property <- toupper(property)
-  lut <- .propertyDictionary()
-  names(lut) <- toupper(names(lut))
-  agg_property <- lut[[property]]
-
-  if(is.null(agg_property)) {
-    names(lut) <- toupper(.propertyDictionary())
-    agg_property <- lut[[property]]
-    if(is.null(agg_property))
-      stop("property must be a label or column name from SDA property dictionary (.propertyDictonary())", call. = FALSE)
-  }
 
   switch(toupper(agg_method$method),
     # dominant component (category)
@@ -373,7 +466,28 @@ get_SDA_property <-
                                                       ORDER BY c1.comppct_r DESC, c1.cokey)
               GROUP BY areasymbol, musym, muname, mu.mukey, c.cokey,  compname, comppct_r
               ORDER BY areasymbol, musym, muname, mu.mukey, comppct_r DESC, c.cokey",
-              agg_property, agg_property, agg_property, agg_property, where_clause)
+              agg_property, agg_property, agg_property, agg_property, where_clause),
+    
+    # NO AGGREGATION (component properties)
+  "NONE" = sprintf("SELECT areasymbol, musym, muname, mu.mukey/1 AS mukey, 
+                           c.compname AS compname, c.comppct_r AS comppct_r, c.cokey AS cokey, c.%s AS %s
+             FROM legend AS l
+              INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
+              INNER JOIN component AS c ON c.mukey = mu.mukey
+              ORDER BY areasymbol, musym, muname, mu.mukey, c.comppct_r DESC, c.cokey",
+            agg_property, agg_property, where_clause),
+  
+  # NO AGGREGATION (horizon properties)
+  "NONE_HORIZON" = sprintf("SELECT areasymbol, musym, muname, mu.mukey/1 AS mukey, 
+                                   c.cokey AS cokey, ch.chkey AS chkey,
+                                   c.compname AS compname, c.comppct_r AS comppct_r,
+                                   ch.%s AS %s
+             FROM legend  AS l
+              INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
+              INNER JOIN component AS c ON c.mukey = mu.mukey
+              INNER JOIN chorizon AS ch ON ch.cokey = c.cokey
+              ORDER BY areasymbol, musym, muname, mu.mukey, c.comppct_r DESC, c.cokey",
+            agg_property, agg_property, where_clause)
   )
 
 }

--- a/R/SDA_properties.R
+++ b/R/SDA_properties.R
@@ -481,12 +481,13 @@ get_SDA_property <-
   "NONE_HORIZON" = sprintf("SELECT areasymbol, musym, muname, mu.mukey/1 AS mukey, 
                                    c.cokey AS cokey, ch.chkey AS chkey,
                                    c.compname AS compname, c.comppct_r AS comppct_r,
+                                   ch.hzdept_r AS hzdept_r, ch.hzdepb_r AS hzdepb_r,
                                    ch.%s AS %s
              FROM legend  AS l
               INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
               INNER JOIN component AS c ON c.mukey = mu.mukey
               INNER JOIN chorizon AS ch ON ch.cokey = c.cokey
-              ORDER BY areasymbol, musym, muname, mu.mukey, c.comppct_r DESC, c.cokey",
+              ORDER BY areasymbol, musym, muname, mu.mukey, c.comppct_r DESC, c.cokey, hzdept_r",
             agg_property, agg_property, where_clause)
   )
 

--- a/man/get_SDA_interpretation.Rd
+++ b/man/get_SDA_interpretation.Rd
@@ -4,12 +4,17 @@
 \alias{get_SDA_interpretation}
 \title{Get map unit interpretations from Soil Data Access by rule name}
 \usage{
-get_SDA_interpretation(rulename, method, areasymbols = NULL, mukeys = NULL)
+get_SDA_interpretation(
+  mrulename,
+  method = c("Dominant Component", "Dominant Condition", "Weighted Average", "None"),
+  areasymbols = NULL,
+  mukeys = NULL
+)
 }
 \arguments{
-\item{rulename}{rule name of interpretation}
+\item{mrulename}{rule name of interpretation (matching a \code{mrulename} in \code{cointerp} table)}
 
-\item{method}{aggregation method. One of: "Dominant Component", "Dominant Condition", "Weighted Average"}
+\item{method}{aggregation method. One of: "Dominant Component", "Dominant Condition", "Weighted Average", "None"}
 
 \item{areasymbols}{vector of soil survey area symbols}
 

--- a/man/get_SDA_interpretation.Rd
+++ b/man/get_SDA_interpretation.Rd
@@ -5,16 +5,16 @@
 \title{Get map unit interpretations from Soil Data Access by rule name}
 \usage{
 get_SDA_interpretation(
-  mrulename,
+  rulename,
   method = c("Dominant Component", "Dominant Condition", "Weighted Average", "None"),
   areasymbols = NULL,
   mukeys = NULL
 )
 }
 \arguments{
-\item{mrulename}{rule name of interpretation (matching a \code{mrulename} in \code{cointerp} table)}
+\item{rulename}{rule name of interpretation (matching a \code{mrulename} in \code{cointerp} table)}
 
-\item{method}{aggregation method. One of: "Dominant Component", "Dominant Condition", "Weighted Average", "None"}
+\item{method}{aggregation method. One of: "Dominant Component", "Dominant Condition", "Weighted Average", "None". If "None" is selected one row will be returned per component, otherwise one row will be returned per map unit.}
 
 \item{areasymbols}{vector of soil survey area symbols}
 
@@ -25,6 +25,639 @@ a data.frame
 }
 \description{
 Get map unit interpretations from Soil Data Access by rule name
+}
+\details{
+\subsection{Rule Names in \code{cointerp} table}{
+\itemize{
+\item AGR-Agronomic Concerns (ND)
+\item AGR-Available Water Capacity (ND)
+\item AGR-Natural Fertility (ND)
+\item AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
+\item AGR-Pesticide and Nutrient Runoff Potential (ND)
+\item AGR-Physical Limitations (ND)
+\item AGR-Rooting Depth (ND)
+\item AGR-Sodicity (ND)
+\item AGR-Subsurface Salinity (ND)
+\item AGR-Surface Crusting (ND)
+\item AGR-Surface Salinity (ND)
+\item AGR-Water Erosion (ND)
+\item AGR-Wind Erosion (ND)
+\item AGR - Air Quality; PM10 (TX)
+\item AGR - Air Quality; PM2_5 (TX)
+\item AGR - Avocado Root Rot Hazard (CA)
+\item AGR - Barley Yield (MT)
+\item AGR - California Revised Storie Index (CA)
+\item AGR - Conventional Tillage (TX)
+\item AGR - Filter Strips (TX)
+\item AGR - Grape non-irrigated (MO)
+\item AGR - Hops Site Suitability (WA)
+\item AGR - Index for alfalfa hay, irrigated (NV)
+\item AGR - Map Unit Cropland Productivity (MN)
+\item AGR - Mulch Till (TX)
+\item AGR - Nitrate Leaching Potential, Irrigated (WA)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (MA)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (MT)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (WA)
+\item AGR - No Till (TX)
+\item AGR - No Till (VT)
+\item AGR - No Till, Tile Drained (TX)
+\item AGR - Oats Yield (MT)
+\item AGR - Orchard Groups (TX)
+\item AGR - Pasture hayland (MO)
+\item AGR - Pesticide Loss Potential-Leaching
+\item AGR - Pesticide Loss Potential-Leaching (NE)
+\item AGR - Pesticide Loss Potential-Soil Surface Runoff
+\item AGR - Pesticide Loss Potential-Soil Surface Runoff (NE)
+\item AGR - Plant Growth Index PGI no Climate Adj. (TX)
+\item AGR - Plant Growth Index PGI with Climate Adj. (TX)
+\item AGR - Plant Growth Index PGI with Climate Adj. MAP,MAAT (TX)
+\item AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
+\item AGR - Ridge Till (TX)
+\item AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
+\item AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
+\item AGR - Selenium Leaching Potential (CO)
+\item AGR - Spring Wheat Yield (MT)
+\item AGR - Water Erosion Potential (TX)
+\item AGR - Water Erosion Potential Wide Ratings Array (TX)
+\item AGR - Wind Erosion Potential (TX)
+\item AGR - Wind Erosion Potential Wide Ratings Array (TX)
+\item AGR - Wine Grape Site Suitability (WA)
+\item AGR - Winter Wheat Yield (MT)
+\item Alaska Exempt Wetland Potential (AK)
+\item American Wine Grape Varieties Site Desirability (Long)
+\item American Wine Grape Varieties Site Desirability (Medium)
+\item American Wine Grape Varieties Site Desirability (Short)
+\item American Wine Grape Varieties Site Desirability (Very Long)
+\item AWM - Animal Mortality Disposal (Catastrophic) (MO)
+\item AWM - Filter Group (OH)
+\item AWM - Irrigation Disposal of Wastewater
+\item AWM - Irrigation Disposal of Wastewater (DE)
+\item AWM - Irrigation Disposal of Wastewater (MD)
+\item AWM - Irrigation Disposal of Wastewater (OH)
+\item AWM - Irrigation Disposal of Wastewater (VT)
+\item AWM - Land App of Municipal Sewage Sludge (DE)
+\item AWM - Land App of Municipal Sewage Sludge (MD)
+\item AWM - Land Application of Dry and Slurry Manure (TX)
+\item AWM - Land Application of Milk (CT)
+\item AWM - Land Application of Municipal Biosolids, spring (OR)
+\item AWM - Land Application of Municipal Biosolids, summer (OR)
+\item AWM - Land Application of Municipal Biosolids, winter (OR)
+\item AWM - Land Application of Municipal Sewage Sludge
+\item AWM - Land Application of Municipal Sewage Sludge (OH)
+\item AWM - Land Application of Municipal Sewage Sludge (VT)
+\item AWM - Large Animal Disposal, Pit (MN)
+\item AWM - Manure and Food Processing Waste
+\item AWM - Manure and Food Processing Waste (DE)
+\item AWM - Manure and Food Processing Waste (MD)
+\item AWM - Manure and Food Processing Waste (OH)
+\item AWM - Manure and Food Processing Waste (VT)
+\item AWM - Manure Stacking - Site Evaluation (TX)
+\item AWM - Overland Flow Process Treatment of Wastewater
+\item AWM - Overland Flow Process Treatment of Wastewater (VT)
+\item AWM - Phosphorus Management (TX)
+\item AWM - Rapid Infil Disposal of Wastewater (DE)
+\item AWM - Rapid Infil Disposal of Wastewater (MD)
+\item AWM - Rapid Infiltration Disposal of Wastewater
+\item AWM - Rapid Infiltration Disposal of Wastewater (VT)
+\item AWM - Sensitive Soil Features (MN)
+\item AWM - Slow Rate Process Treatment of Wastewater
+\item AWM - Slow Rate Process Treatment of Wastewater (VT)
+\item AWM - Vegetated Treatment Area (PIA)
+\item AWM - Waste Field Storage Area (VT)
+\item BLM-Reclamation Suitability (MT)
+\item BLM - Chaining Suitability
+\item BLM - Fencing
+\item BLM - Fire Damage Susceptibility
+\item BLM - Fugitive Dust Resistance
+\item BLM - Mechanical Treatment, Rolling Drum
+\item BLM - Mechanical Treatment, Shredder
+\item BLM - Medusahead Invasion Susceptibility
+\item BLM - Pygmy Rabbit Habitat Potential
+\item BLM - Rangeland Drill
+\item BLM - Rangeland Seeding, Colorado Plateau Ecoregion
+\item BLM - Rangeland Seeding, Great Basin Ecoregion
+\item BLM - Rangeland Tillage
+\item BLM - Site Degradation Susceptibility
+\item BLM - Soil Compaction Resistance
+\item BLM - Soil Restoration Potential
+\item BLM - Yellow Star-thistle Invasion Susceptibility
+\item CA Prime Farmland (CA)
+\item Capping Fill Gravity Septic System (DE)
+\item CLASS RULE - Depth to any bedrock kind (5 classes) (NPS)
+\item CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
+\item CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
+\item CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
+\item CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
+\item CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
+\item CLR-cropland limitation for corn and soybeans (IN)
+\item CLR-pastureland limitation (IN)
+\item Commodity Crop Productivity Index (Corn) (WI)
+\item CPI - Alfalfa Hay, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Alfalfa Hay, IRR - Klamath Valley and Basins (OR)
+\item CPI - Alfalfa Hay, IRR - Snake River Plains (ID)
+\item CPI - Alfalfa Hay, NIRR- Eastern Idaho Plateaus (ID)
+\item CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+\item CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+\item CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Barley, NIRR - Eastern Idaho Plateaus (ID)
+\item CPI - Grass Hay, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
+\item CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
+\item CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+\item CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+\item CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Potatoes, IRR - Snake River Plains (ID)
+\item CPI - Small Grains Productivity Index (AK)
+\item CPI - Small Grains, IRR - Snake River Plains (ID)
+\item CPI - Small Grains, NIRR - Palouse Prairies (ID)
+\item CPI - Small Grains, NIRR - Palouse Prairies (OR)
+\item CPI - Small Grains, NIRR - Palouse Prairies (WA)
+\item CPI - Small Grains, NIRR - Snake River Plains (ID)
+\item CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Wheat, NIRR - Eastern Idaho Plateaus (ID)
+\item CPI - Wild Hay, NIRR - Eastern Idaho Plateaus (ID)
+\item CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
+\item CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+\item Deep Infiltration Systems
+\item DHS - Catastrophic Event, Large Animal Mortality, Burial
+\item DHS - Catastrophic Event, Large Animal Mortality, Incinerate
+\item DHS - Catastrophic Mortality, Large Animal Disposal, Pit
+\item DHS - Catastrophic Mortality, Large Animal Disposal, Trench
+\item DHS - Emergency Animal Mortality Disposal by Shallow Burial
+\item DHS - Emergency Land Disposal of Milk
+\item DHS - Potential for Radioactive Bioaccumulation
+\item DHS - Potential for Radioactive Sequestration
+\item DHS - Rubble and Debris Disposal, Large-Scale Event
+\item DHS - Site for Composting Facility - Subsurface
+\item DHS - Site for Composting Facility - Surface
+\item DHS - Suitability for Clay Liner Material
+\item DHS - Suitability for Composting Medium and Final Cover
+\item Elevated Sand Mound Septic System (DE)
+\item ENG - Animal Disposal by Composting (Catastrophic) (WV)
+\item ENG - Application of Municipal Sludge (TX)
+\item ENG - Aquifer Assessment - 7081 (MN)
+\item ENG - Closed-Loop Horizontal Geothermal Heat Pump (CT)
+\item ENG - Cohesive Soil Liner (MN)
+\item ENG - Construction Materials - Gravel Source (MN)
+\item ENG - Construction Materials - Sand Source (MN)
+\item ENG - Construction Materials; Gravel Source
+\item ENG - Construction Materials; Gravel Source (AK)
+\item ENG - Construction Materials; Gravel Source (CT)
+\item ENG - Construction Materials; Gravel Source (ID)
+\item ENG - Construction Materials; Gravel Source (IN)
+\item ENG - Construction Materials; Gravel Source (MI)
+\item ENG - Construction Materials; Gravel Source (NE)
+\item ENG - Construction Materials; Gravel Source (NY)
+\item ENG - Construction Materials; Gravel Source (OH)
+\item ENG - Construction Materials; Gravel Source (OR)
+\item ENG - Construction Materials; Gravel Source (VT)
+\item ENG - Construction Materials; Gravel Source (WA)
+\item ENG - Construction Materials; Reclamation
+\item ENG - Construction Materials; Reclamation (DE)
+\item ENG - Construction Materials; Reclamation (MD)
+\item ENG - Construction Materials; Reclamation (MI)
+\item ENG - Construction Materials; Reclamation (OH)
+\item ENG - Construction Materials; Roadfill
+\item ENG - Construction Materials; Roadfill (AK)
+\item ENG - Construction Materials; Roadfill (GA)
+\item ENG - Construction Materials; Roadfill (OH)
+\item ENG - Construction Materials; Sand Source
+\item ENG - Construction Materials; Sand Source (AK)
+\item ENG - Construction Materials; Sand Source (CT)
+\item ENG - Construction Materials; Sand Source (GA)
+\item ENG - Construction Materials; Sand Source (ID)
+\item ENG - Construction Materials; Sand Source (IN)
+\item ENG - Construction Materials; Sand Source (NY)
+\item ENG - Construction Materials; Sand Source (OH)
+\item ENG - Construction Materials; Sand Source (OR)
+\item ENG - Construction Materials; Sand Source (VT)
+\item ENG - Construction Materials; Sand Source (WA)
+\item ENG - Construction Materials; Topsoil
+\item ENG - Construction Materials; Topsoil (AK)
+\item ENG - Construction Materials; Topsoil (DE)
+\item ENG - Construction Materials; Topsoil (GA)
+\item ENG - Construction Materials; Topsoil (ID)
+\item ENG - Construction Materials; Topsoil (MD)
+\item ENG - Construction Materials; Topsoil (MI)
+\item ENG - Construction Materials; Topsoil (OH)
+\item ENG - Construction Materials; Topsoil (OR)
+\item ENG - Construction Materials; Topsoil (WA)
+\item ENG - Daily Cover for Landfill
+\item ENG - Daily Cover for Landfill (AK)
+\item ENG - Daily Cover for Landfill (OH)
+\item ENG - Disposal Field (NJ)
+\item ENG - Disposal Field Gravity (DE)
+\item ENG - Disposal Field Suitability Class (NJ)
+\item ENG - Disposal Field Type Inst (NJ)
+\item ENG - Dwellings W/O Basements
+\item ENG - Dwellings W/O Basements (OH)
+\item ENG - Dwellings With Basements
+\item ENG - Dwellings with Basements (AK)
+\item ENG - Dwellings With Basements (OH)
+\item ENG - Dwellings without Basements (AK)
+\item ENG - Large Animal Disposal, Pit (CT)
+\item ENG - Large Animal Disposal, Trench (CT)
+\item ENG - Lawn and Landscape (OH)
+\item ENG - Lawn, Landscape, Golf Fairway
+\item ENG - Lawn, landscape, golf fairway (CT)
+\item ENG - Lawn, Landscape, Golf Fairway (MI)
+\item ENG - Lawn, Landscape, Golf Fairway (VT)
+\item ENG - Local Roads and Streets
+\item ENG - Local Roads and Streets (AK)
+\item ENG - Local Roads and Streets (GA)
+\item ENG - Local Roads and Streets (OH)
+\item ENG - New Ohio Septic Rating (OH)
+\item ENG - On-Site Waste Water Absorption Fields (MO)
+\item ENG - On-Site Waste Water Lagoons (MO)
+\item ENG - OSHA Soil Types (TX)
+\item ENG - Pier Beam Building Foundations (TX)
+\item ENG - Sanitary Landfill (Area)
+\item ENG - Sanitary Landfill (Area) (AK)
+\item ENG - Sanitary Landfill (Area) (OH)
+\item ENG - Sanitary Landfill (Trench)
+\item ENG - Sanitary Landfill (Trench) (AK)
+\item ENG - Sanitary Landfill (Trench) (OH)
+\item ENG - Septage Application - Incorporation or Injection (MN)
+\item ENG - Septage Application - Surface (MN)
+\item ENG - Septic System; Disinfection, Surface Application (TX)
+\item ENG - Septic Tank Absorption Fields
+\item ENG - Septic Tank Absorption Fields - At-Grade (MN)
+\item ENG - Septic Tank Absorption Fields - Mound (MN)
+\item ENG - Septic Tank Absorption Fields - Trench (MN)
+\item ENG - Septic Tank Absorption Fields (AK)
+\item ENG - Septic Tank Absorption Fields (DE)
+\item ENG - Septic Tank Absorption Fields (FL)
+\item ENG - Septic Tank Absorption Fields (MD)
+\item ENG - Septic Tank Absorption Fields (NY)
+\item ENG - Septic Tank Absorption Fields (OH)
+\item ENG - Septic Tank Absorption Fields (TX)
+\item ENG - Septic Tank Leaching Chamber (TX)
+\item ENG - Septic Tank, Gravity Disposal (TX)
+\item ENG - Septic Tank, Subsurface Drip Irrigation (TX)
+\item ENG - Sewage Lagoons
+\item ENG - Sewage Lagoons (AK)
+\item ENG - Sewage Lagoons (OH)
+\item ENG - Shallow Excavations
+\item ENG - Shallow Excavations (AK)
+\item ENG - Shallow Excavations (MI)
+\item ENG - Shallow Excavations (OH)
+\item ENG - Small Commercial Buildings
+\item ENG - Small Commercial Buildings (OH)
+\item ENG - Soil Potential of Road Salt Applications (CT)
+\item ENG - Soil Potential Ratings of SSDS (CT)
+\item ENG - Source of Caliche (TX)
+\item ENG - Stormwater Management / Infiltration (NY)
+\item ENG - Stormwater Management / Ponds (NY)
+\item ENG - Stormwater Management / Wetlands (NY)
+\item ENG - Unpaved Local Roads and Streets
+\item Farm and Garden Composting Facility - Surface
+\item FOR-Biomass Harvest (WI)
+\item FOR-Construction Limitations for Haul Roads/Log Landings(ME)
+\item FOR - Biomass Harvest (MA)
+\item FOR - Black Walnut Suitability Index (KS)
+\item FOR - Black Walnut Suitability Index (MO)
+\item FOR - Compaction Potential (WA)
+\item FOR - Construction Limitations - Haul Roads/Log Landing (OH)
+\item FOR - Construction Limitations For Haul Roads (MI)
+\item FOR - Construction Limitations for Haul Roads/Log Landings
+\item FOR - Damage by Fire (OH)
+\item FOR - Displacement Hazard
+\item FOR - Displacement Potential (WA)
+\item FOR - General Harvest Season (ME)
+\item FOR - General Harvest Season (VT)
+\item FOR - Hand Planting Suitability
+\item FOR - Hand Planting Suitability (ME)
+\item FOR - Hand Planting Suitability, MO13 (DE)
+\item FOR - Hand Planting Suitability, MO13 (MD)
+\item FOR - Harvest Equipment Operability
+\item FOR - Harvest Equipment Operability (DE)
+\item FOR - Harvest Equipment Operability (MD)
+\item FOR - Harvest Equipment Operability (ME)
+\item FOR - Harvest Equipment Operability (MI)
+\item FOR - Harvest Equipment Operability (OH)
+\item FOR - Harvest Equipment Operability (VT)
+\item FOR - Log Landing Suitability
+\item FOR - Log Landing Suitability (ID)
+\item FOR - Log Landing Suitability (ME)
+\item FOR - Log Landing Suitability (MI)
+\item FOR - Log Landing Suitability (OR)
+\item FOR - Log Landing Suitability (VT)
+\item FOR - Log Landing Suitability (WA)
+\item FOR - Mechanical Planting Suitability
+\item FOR - Mechanical Planting Suitability (CT)
+\item FOR - Mechanical Planting Suitability (ME)
+\item FOR - Mechanical Planting Suitability (OH)
+\item FOR - Mechanical Planting Suitability, MO13 (DE)
+\item FOR - Mechanical Planting Suitability, MO13 (MD)
+\item FOR - Mechanical Site Preparation (Deep)
+\item FOR - Mechanical Site Preparation (Deep) (DE)
+\item FOR - Mechanical Site Preparation (Deep) (MD)
+\item FOR - Mechanical Site Preparation (Surface)
+\item FOR - Mechanical Site Preparation (Surface) (DE)
+\item FOR - Mechanical Site Preparation (Surface) (MD)
+\item FOR - Mechanical Site Preparation (Surface) (MI)
+\item FOR - Mechanical Site Preparation (Surface) (OH)
+\item FOR - Mechanical Site Preparation; Deep (CT)
+\item FOR - Mechanical Site Preparation; Surface (ME)
+\item FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+\item FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (MI)
+\item FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (OH)
+\item FOR - Potential Erosion Hazard (Road/Trail)
+\item FOR - Potential Erosion Hazard (Road/Trail) (PIA)
+\item FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
+\item FOR - Potential Fire Damage Hazard
+\item FOR - Potential Seedling Mortality
+\item FOR - Potential Seedling Mortality (FL)
+\item FOR - Potential Seedling Mortality (MI)
+\item FOR - Potential Seedling Mortality (OH)
+\item FOR - Potential Seedling Mortality (PIA)
+\item FOR - Potential Seedling Mortality (VT)
+\item FOR - Potential Seedling Mortality(ME)
+\item FOR - Potential Windthrow Hazard (ME)
+\item FOR - Potential Windthrow Hazard (MI)
+\item FOR - Potential Windthrow Hazard (NY)
+\item FOR - Potential Windthrow Hazard (VT)
+\item FOR - Puddling Hazard
+\item FOR - Puddling Potential (WA)
+\item FOR - Road Suitability (Natural Surface)
+\item FOR - Road Suitability (Natural Surface) (ID)
+\item FOR - Road Suitability (Natural Surface) (ME)
+\item FOR - Road Suitability (Natural Surface) (OH)
+\item FOR - Road Suitability (Natural Surface) (OR)
+\item FOR - Road Suitability (Natural Surface) (VT)
+\item FOR - Road Suitability (Natural Surface) (WA)
+\item FOR - Rutting Hazard by Month
+\item FOR - Rutting Hazard by Season
+\item FOR - Shortleaf pine littleleaf disease susceptibility
+\item FOR - Soil Compactibility Risk
+\item FOR - Soil Rutting Hazard
+\item FOR - Soil Rutting Hazard (ME)
+\item FOR - Soil Rutting Hazard (OH)
+\item FOR - Soil Sustainability Forest Biomass Harvesting (CT)
+\item FOR - White Oak Suitability (MO)
+\item FOR - Windthrow Hazard
+\item FOR - Windthrow Hazard (WA)
+\item FOR (USFS) - Road Construction/Maintenance (Natural Surface)
+\item FOTG - Indiana Corn Yield Calculation (IN)
+\item FOTG - Indiana Slippage Potential (IN)
+\item FOTG - Indiana Soy Bean Yield Calculation (IN)
+\item FOTG - Indiana Wheat Yield Calculation (IN)
+\item Fragile Soil Index
+\item Gravity Full Depth Septic System (DE)
+\item GRL-FSG-NP-W (MT)
+\item GRL - Excavations to 24 inches for Plastic Pipelines (TX)
+\item GRL - Fencing, 24 inch Post Depth (MT)
+\item GRL - Fencing, Post Depth =<24 inches
+\item GRL - Fencing, Post Depth =<36 inches
+\item GRL - Fencing, Post Depth Less Than 24 inches (TX)
+\item GRL - Fencing, Post Depth Less Than 36 inches (TX)
+\item GRL - Juniper Encroachment Potential (NM)
+\item GRL - NV range seeding (Wind C = 10) (NV)
+\item GRL - NV range seeding (Wind C = 100) (NV)
+\item GRL - NV range seeding (Wind C = 20) (NV)
+\item GRL - NV range seeding (Wind C = 30) (NV)
+\item GRL - NV range seeding (Wind C = 40) (NV)
+\item GRL - NV range seeding (Wind C = 50) (NV)
+\item GRL - NV range seeding (Wind C = 60) (NV)
+\item GRL - NV range seeding (Wind C = 80) (NV)
+\item GRL - NV range seeding (Wind C >= 160) (NV)
+\item GRL - Pasture and Hayland SG (OH)
+\item GRL - Ranch Access Roads (TX)
+\item GRL - Rangeland Chaining (TX)
+\item GRL - Rangeland Disking (TX)
+\item GRL - Rangeland Dozing/Grubbing (TX)
+\item GRL - Rangeland Planting by Mechanical Seeding (TX)
+\item GRL - Rangeland Prescribed Burning (TX)
+\item GRL - Rangeland Roller Chopping (TX)
+\item GRL - Rangeland Root Plowing (TX)
+\item GRL - Utah Juniper Encroachment Potential
+\item GRL - Western Juniper Encroachment Potential (OR)
+\item Ground-based Solar Arrays, Ballast Anchor Systems
+\item Ground-based Solar Arrays, Soil-penetrating Anchor Systems
+\item Ground Penetrating Radar Penetration
+\item Hybrid Wine Grape Varieties Site Desirability (Long)
+\item Hybrid Wine Grape Varieties Site Desirability (Medium)
+\item Hybrid Wine Grape Varieties Site Desirability (Short)
+\item Inland Wetlands (CT)
+\item IRR-restrictive features for irrigation (OH)
+\item ISDH Septic Tank Interpretation (IN)
+\item Land Application of Municipal Sewage Sludge (PA)
+\item Lined Retention Systems
+\item Low Pressure Pipe Septic System (DE)
+\item MIL - Bivouac Areas (DOD)
+\item MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
+\item MIL - Excavations for Individual Fighting Position (DOD)
+\item MIL - Excavations for Vehicle Fighting Position (DOD)
+\item MIL - Helicopter Landing Zones (DOD)
+\item MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 1 dry season (DOD)
+\item MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 2 dry season (DOD)
+\item MIL - Trafficability Veh. Type 3 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 3 dry season (DOD)
+\item MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 4 dry season (DOD)
+\item MIL - Trafficability Veh. Type 5 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 5 dry season (DOD)
+\item MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 6 dry season (DOD)
+\item MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 7 dry season (DOD)
+\item MT - Conservation Tree/Shrub Groups (MT)
+\item Muscadine Wine Grape Site Desirability (Very Long)
+\item NCCPI - Irrigated National Commodity Crop Productivity Index
+\item NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
+\item NCCPI - NCCPI Corn Submodel (I)
+\item NCCPI - NCCPI Cotton Submodel (II)
+\item NCCPI - NCCPI Small Grains Submodel (II)
+\item NCCPI - NCCPI Soybeans Submodel (I)
+\item Nitrogen Loss Potential (ND)
+\item Permafrost Sensitivity (AK)
+\item Pressure Dose Capping Fill Septic System (DE)
+\item Pressure Dose Full Depth Septic System (DE)
+\item REC - Camp and Picnic Areas (AK)
+\item REC - Camp Areas (CT)
+\item REC - Camp Areas; Primitive (AK)
+\item REC - Foot and ATV Trails (AK)
+\item REC - Off-Road Motorcycle Trails (CT)
+\item REC - Paths and Trails (CT)
+\item REC - Picnic Areas (CT)
+\item REC - Playgrounds (AK)
+\item REC - Playgrounds (CT)
+\item RSK-risk assessment for manure application (OH)
+\item Salinity Risk Index, Discharge Model (ND)
+\item SAS - CMECS Substrate Class
+\item SAS - CMECS Substrate Origin
+\item SAS - CMECS Substrate Subclass
+\item SAS - CMECS Substrate Subclass/Group
+\item SAS - CMECS Substrate Subclass/Group/Subgroup
+\item SAS - Eastern Oyster Habitat Restoration Suitability
+\item SAS - Eelgrass Restoration Suitability
+\item SAS - Land Utilization of Dredged Materials
+\item SAS - Mooring Anchor - Deadweight
+\item SAS - Mooring Anchor - Mushroom
+\item SAS - Northern Quahog (Hard Clam) Habitat Suitability
+\item Septic System A/B Soil System (Alternate) (PA)
+\item Septic System At-Grade Bed (Alternate) (PA)
+\item Septic System At Grade Shallow Field (alternative) (WV)
+\item Septic System CO-OP RFS III w/At-Grade Bed (PA)
+\item Septic System CO-OP RFS III w/Drip Irrigation (PA)
+\item Septic System CO-OP RFS III w/Spray Irrigation (PA)
+\item Septic System Drip Irrigation (Alternate) (PA)
+\item Septic System Drip Irrigation (alternative) (WV)
+\item Septic System Dual Field Trench (conventional) (WV)
+\item Septic System Elevated Field (alternative) (WV)
+\item Septic System Free Access Sand Filter w/At-Grade Bed (PA)
+\item Septic System Free Access Sand Filter w/Drip Irrigation (PA)
+\item Septic System Free Access Sand Filterw/Spray Irrigation (PA)
+\item Septic System In Ground Bed (conventional) (PA)
+\item Septic System In Ground Trench (conventional) (PA)
+\item Septic System In Ground Trench (conventional) (WV)
+\item Septic System Low Pressure Pipe (alternative) (WV)
+\item Septic System Modified Subsurface Sand Filter (Alt.) (PA)
+\item Septic System Mound (alternative) (WV)
+\item Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
+\item Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
+\item Septic System Peat Based Option2 w/Spray Irrigation (PA)
+\item Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
+\item Septic System Sand Mound Bed or Trench (PA)
+\item Septic System Shallow In Ground Trench (conventional) (WV)
+\item Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
+\item Septic System Spray Irrigation (PA)
+\item Septic System Steep Slope Mound (alternative) (WV)
+\item Septic System Steep Slope Sand Mound (Alternate) (PA)
+\item Septic System Subsurface Sand Filter Bed (conventional) (PA)
+\item Septic System Subsurface Sand Filter Trench (standard) (PA)
+\item Shallow Infiltration Systems
+\item SOH -  Suitability for Aerobic Soil Organisms
+\item SOH - Agricultural Organic Soil Subsidence
+\item SOH - Concentration of Salts- Soil Surface
+\item SOH - Organic Matter Depletion
+\item SOH - Soil Surface Sealing
+\item SOH - Soil Susceptibility to Compaction
+\item Soil Habitat for Saprophyte Stage of Coccidioides
+\item SOIL HEALTH ASSESSMENT (NJ)
+\item Soil Vegetative Groups (CA)
+\item Surface Runoff Class (CA)
+\item Unlined Retention Systems
+\item URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
+\item URB - Commercial Brick Buildings w/Concrete Slab (TX)
+\item URB - Commercial Metal Bldg; w/Concrete Slab (TX)
+\item URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
+\item URB - Commercial Metal Buildings w/o Concrete Slab (TX)
+\item URB - Concrete Driveways and Sidewalks (TX)
+\item URB - Dwellings on Concrete Slab (TX)
+\item URB - Dwellings With Basements (TX)
+\item URB - Lawns and Ornamental Plantings (TX)
+\item URB - Reinforced Concrete Slab (TX)
+\item URB - Rural Residential Development on Concrete Slab (TX)
+\item URB - Rural Residential Development w/Basement (TX)
+\item URB - Urban Residential Development on Concrete Slab (TX)
+\item URB - Urban Residential Development w/Basement (TX)
+\item URB/REC - Camp Areas
+\item URB/REC - Camp Areas (GA)
+\item URB/REC - Camp Areas (HI)
+\item URB/REC - Camp Areas (MI)
+\item URB/REC - Camp Areas (OH)
+\item URB/REC - Golf Fairways (OH)
+\item URB/REC - Off-Road Motorcycle Trails
+\item URB/REC - Off-Road Motorcycle Trails (OH)
+\item URB/REC - Paths and Trails
+\item URB/REC - Paths and Trails (GA)
+\item URB/REC - Paths and Trails (MI)
+\item URB/REC - Paths and Trails (OH)
+\item URB/REC - Picnic Areas
+\item URB/REC - Picnic Areas (GA)
+\item URB/REC - Picnic Areas (MI)
+\item URB/REC - Picnic Areas (OH)
+\item URB/REC - Playgrounds
+\item URB/REC - Playgrounds (GA)
+\item URB/REC - Playgrounds (MI)
+\item URB/REC - Playgrounds (OH)
+\item Vinifera Wine Grape Site Desirability (Long to Medium)
+\item Vinifera Wine Grape Site Desirability (Long)
+\item Vinifera Wine Grape Site Desirability (Short to Medium)
+\item Vinifera Wine Grape Site Desirability (Short)
+\item WAQ - Soil Pesticide Absorbed Runoff Potential (TX)
+\item WAQ - Soil Pesticide Leaching Potential (TX)
+\item WAQ - Soil Pesticide Solution Runoff Potential (TX)
+\item WLF-Soil Suitability - Karner Blue Butterfly (WI)
+\item WLF - Burrowing Mammals & Reptiles (TX)
+\item WLF - Chufa for Turkey Forage (LA)
+\item WLF - Crawfish Aquaculture (TX)
+\item WLF - Desert Tortoise (CA)
+\item WLF - Desertic Herbaceous Plants (TX)
+\item WLF - Domestic Grasses & Legumes for Food and Cover (TX)
+\item WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
+\item WLF - Freshwater Wetland Plants (TX)
+\item WLF - Gopher Tortoise Burrowing Suitability
+\item WLF - Grain & Seed Crops for Food and Cover (TX)
+\item WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
+\item WLF - Irrigated Freshwater Wetland Plants (TX)
+\item WLF - Irrigated Grain & Seed Crops for Food & Cover (TX)
+\item WLF - Irrigated Saline Water Wetland Plants (TX)
+\item WLF - Riparian Herbaceous Plants (TX)
+\item WLF - Riparian Shrubs, Vines, & Trees (TX)
+\item WLF - Saline Water Wetland Plants (TX)
+\item WLF - Upland Coniferous Trees (TX)
+\item WLF - Upland Deciduous Trees (TX)
+\item WLF - Upland Desertic Shrubs & Trees (TX)
+\item WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
+\item WLF - Upland Native Herbaceous Plants (TX)
+\item WLF - Upland Shrubs & Vines (TX)
+\item WMS-Subsurface Water Management, Installation (ND)
+\item WMS-Subsurface Water Management, Outflow Quality (ND)
+\item WMS-Subsurface Water Management, Performance (ND)
+\item WMS - Constructing Grassed Waterways (OH)
+\item WMS - Constructing Grassed Waterways (TX)
+\item WMS - Constructing Terraces & Diversions (TX)
+\item WMS - Constructing Terraces and Diversions (OH)
+\item WMS - Drainage - (MI)
+\item WMS - Drainage (IL)
+\item WMS - Drainage (OH)
+\item WMS - Embankments, Dikes, and Levees
+\item WMS - Embankments, Dikes, and Levees (OH)
+\item WMS - Embankments, Dikes, and Levees (VT)
+\item WMS - Excavated Ponds (Aquifer-fed)
+\item WMS - Excavated Ponds (Aquifer-fed) (OH)
+\item WMS - Excavated Ponds (Aquifer-fed) (VT)
+\item WMS - Grape Production with Drip Irrigation (TX)
+\item WMS - Grassed Waterways - (MI)
+\item WMS - Irrigation, General
+\item WMS - Irrigation, Micro (above ground)
+\item WMS - Irrigation, Micro (above ground) (VT)
+\item WMS - Irrigation, Micro (subsurface drip)
+\item WMS - Irrigation, Micro (subsurface drip) (VT)
+\item WMS - Irrigation, Sprinkler (close spaced outlet drops)
+\item WMS - Irrigation, Sprinkler (general)
+\item WMS - Irrigation, Sprinkler (general) (VT)
+\item WMS - Irrigation, Surface (graded)
+\item WMS - Irrigation, Surface (level)
+\item WMS - Pond Reservoir Area
+\item WMS - Pond Reservoir Area (GA)
+\item WMS - Pond Reservoir Area (MI)
+\item WMS - Pond Reservoir Area (OH)
+\item WMS - Sprinkler Irrigation (MT)
+\item WMS - Sprinkler Irrigation RDC (IL)
+\item WMS - Subsurface Drains - Installation (VT)
+\item WMS - Subsurface Drains - Performance (VT)
+\item WMS - Subsurface Drains < 3 Feet Deep (TX)
+\item WMS - Subsurface Drains > 3 Feet Deep (TX)
+\item WMS - Subsurface Water Management, Outflow Quality
+\item WMS - Subsurface Water Management, System Installation
+\item WMS - Subsurface Water Management, System Performance
+\item WMS - Surface Drains (TX)
+\item WMS - Surface Irrigation Intake Family (TX)
+\item WMS - Surface Water Management, System
+}
+}
 }
 \author{
 Jason Nemecek, Chad Ferguson, Andrew Brown

--- a/man/get_SDA_property.Rd
+++ b/man/get_SDA_property.Rd
@@ -6,7 +6,8 @@
 \usage{
 get_SDA_property(
   property,
-  method,
+  method = c("Dominant Component (Category)", "Weighted Average", "Min/Max",
+    "Dominant Component (Numeric)", "Dominant Condition", "None"),
   areasymbols = NULL,
   mukeys = NULL,
   top_depth = NULL,
@@ -17,7 +18,7 @@ get_SDA_property(
 \arguments{
 \item{property}{a label or column name from property dictionary}
 
-\item{method}{one of: "Dominant Component (Category)", "Weighted Average", "Min/Max", "Dominant Component (Numeric)", "Dominant Condition"#'}
+\item{method}{one of: "Dominant Component (Category)", "Weighted Average", "Min/Max", "Dominant Component (Numeric)", "Dominant Condition", or "None". If "None" is selected, the number of rows returned will depend on whether a component or horizon level property was selected, otherwise the result will be 1:1 with the number of map units.}
 
 \item{areasymbols}{vector of soil survey area symbols}
 
@@ -34,6 +35,93 @@ a data.frame with result
 }
 \description{
 Get map unit properties from Soil Data Access
+}
+\details{
+The \code{property} argument refers to one of the property names or columns specified in the tables below.
+\subsection{Selected Component-level Properties}{\tabular{ll}{
+   \strong{Property (Component)} \tab \strong{Column} \cr
+   Range Production - Favorable Year \tab rsprod_h \cr
+   Range Production - Normal Year \tab rsprod_r \cr
+   Range Production - Unfavorable Year \tab rsprod_l \cr
+   Corrosion of Steel \tab corsteel \cr
+   Corrosion of Concrete \tab corcon \cr
+   Drainage Class \tab drainagecl \cr
+   Hydrologic Group \tab hydgrp \cr
+   Taxonomic Class Name \tab taxclname \cr
+   Taxonomic Order \tab taxorder \cr
+   Taxonomic Suborder \tab taxsuborder \cr
+   Taxonomic Temperature Regime \tab taxtempregime \cr
+   Wind Erodibility Group \tab weg \cr
+   Wind Erodibility Index \tab wei \cr
+   t Factor \tab tfact \cr
+}
+
+}
+
+\subsection{Selected Horizon-level Properties}{\tabular{ll}{
+   \strong{Property (Horizon)} \tab \strong{Column} \cr
+   0.1 bar H2O - Rep Value \tab wtenthbar_r \cr
+   0.33 bar H2O - Rep Value \tab wthirdbar_r \cr
+   15 bar H2O - Rep Value \tab wfifteenbar_r \cr
+   Available Water Capacity - Rep Value \tab awc_r \cr
+   Bray 1 Phosphate - Rep Value \tab pbray1_r \cr
+   Bulk Density 0.1 bar H2O - Rep Value \tab dbtenthbar_r \cr
+   Bulk Density 0.33 bar H2O - Rep Value \tab dbthirdbar_r \cr
+   Bulk Density 15 bar H2O - Rep Value \tab dbfifteenbar_r \cr
+   Bulk Density oven dry - Rep Value \tab dbovendry_r \cr
+   CaCO3 Clay - Rep Value \tab claysizedcarb_r \cr
+   Calcium Carbonate - Rep Value \tab caco3_r \cr
+   Cation Exchange Capcity - Rep Value \tab cec7_r \cr
+   Coarse Sand - Rep Value \tab sandco_r \cr
+   Coarse Silt - Rep Value \tab siltco_r \cr
+   Effective Cation Exchange Capcity - Rep Value \tab ecec_r \cr
+   Electrial Conductivity 1:5 by volume - Rep Value \tab ec15_r \cr
+   Electrical Conductivity - Rep Value \tab ec_r \cr
+   Exchangeable Sodium Percentage - Rep Value \tab esp_r \cr
+   Extract Aluminum - Rep Value \tab extral_r \cr
+   Extractable Acidity - Rep Value \tab extracid_r \cr
+   Fine Sand - Rep Value \tab sandfine_r \cr
+   Fine Silt - Rep Value \tab siltfine_r \cr
+   Free Iron - Rep Value \tab freeiron_r \cr
+   Gypsum - Rep Value \tab gypsum_r \cr
+   Kf \tab kffact \cr
+   Ki \tab kifact \cr
+   Kr \tab krfact \cr
+   Kw \tab kwfact \cr
+   LEP - Rep Value \tab lep_r \cr
+   Liquid Limit - Rep Value \tab ll_r \cr
+   Medium Sand - Rep Value \tab sandmed_r \cr
+   Organic Matter - Rep Value \tab om_r \cr
+   Oxalate Aluminum - Rep Value \tab aloxalate_r \cr
+   Oxalate Iron - Rep Value \tab feoxalate_r \cr
+   Oxalate Phosphate - Rep Value \tab poxalate_r \cr
+   Plasticity Index - Rep Value \tab pi_r \cr
+   Rock Fragments 3 - 10 cm - Rep Value \tab frag3to10_r \cr
+   Rock Fragments > 10 cm - Rep Value \tab fraggt10_r \cr
+   Rubbed Fiber \% - Rep Value \tab fiberrubbedpct_r \cr
+   Satiated H2O - Rep Value \tab wsatiated_r \cr
+   Saturated Hydraulic Conductivity - Rep Value \tab ksat_r \cr
+   Sodium Adsorption Ratio - Rep Value \tab sar_r \cr
+   Sum of Bases - Rep Value \tab sumbases_r \cr
+   Total Clay - Rep Value \tab claytotal_r \cr
+   Total Phosphate - Rep Value \tab ptotal_r \cr
+   Total Rock Fragment Volume - Rep Value \tab fragvoltot \cr
+   Total Sand - Rep Value \tab sandtotal_r \cr
+   Total Silt - Rep Value \tab silttotal_r \cr
+   Unrubbed Fiber \% - Rep Value \tab fiberunrubbedpct_r \cr
+   Very Coarse Sand - Rep Value \tab sandvc_r \cr
+   Very Fine Sand - Rep Value \tab sandvf_r \cr
+   Water Soluble Phosphate - Rep Value \tab ph2osoluble_r \cr
+   no. 10 sieve - Rep Value \tab sieveno10_r \cr
+   no. 200 sieve - Rep Value \tab sieveno200_r \cr
+   no. 4 sieve - Rep Value \tab sieveno4_r \cr
+   no. 40 sieve - Rep Value \tab sieveno40_r \cr
+   pH .01M CaCl2 - Rep Value \tab ph01mcacl2_r \cr
+   pH 1:1 water - Rep Value \tab ph1to1h2o_r \cr
+   pH Oxidized - Rep Value \tab phoxidized_r \cr
+}
+
+}
 }
 \author{
 Jason Nemecek, Chad Ferguson, Andrew Brown

--- a/misc/NASIS-ssurgo-export-tools/ssurgo-export.R
+++ b/misc/NASIS-ssurgo-export-tools/ssurgo-export.R
@@ -1,0 +1,125 @@
+library(soilDB)
+
+### SETUP
+## In NASIS, go to Exports Explorer menu and Add New Export...
+## 
+## Tab #1: Criteria
+## - Select Export Target: SSURGO
+## - Choose desired map units, data map units, and components
+## 
+## Tabs #2 and #3: Interpretations and Notes
+## - Select Interpretations to include in export
+## - Select Text Notes to include in export
+## 
+## Tab #4: Run Export 
+##  - Enter file name for ZIP
+##  - Export run on server and result emailed to user
+## 
+
+#' Get Interpretation Rating "Reasons" from MS Access SSURGO Export
+#'
+#' @param dsn Path to access database template, pointed at NASIS export files.
+#' @param mrulename Rule name of interpretation 
+#' @param n Number of reasons to return
+#'
+#' @return A `data.frame` containing columns: "lmapunitiid", "coiid", "mrulename", "cokeyref", "Reasons", "liid", "muiid", "corriid", "dmuiid", "areasymbol", "musym", "compname", "comppct_r", "interphr", "interphrc","mukey"  
+#' @examples 
+#' 
+#' library(data.table)
+#' 
+#' # dsn: path to MS Access template with a local SSURGO export (containing cointerp table for new mapunits)
+#' dsn <- "E:/workspace/Cochran_InterpCompare/SWRtemplate/SWRtemplate.mdb"
+#' 
+#' # mrulename: select a rule name (must exist in export referenced by dsn)
+#' mrulename <-  "WMS - Pond Reservoir Area" #"FOR - Mechanical Site Preparation (Surface)"
+#' 
+#' result <- data.table(.get_SSURGO_export_interp_reasons_by_mrulename(dsn, mrulename))
+#' 
+#' result_ssurgo <- get_SDA_interpretation(mrulename, 
+#'                                         method = "NONE", 
+#'                                         areasymbols = c("CA630","CA649"))
+#' 
+#' # result_dominant <- result[result[, .I[comppct_r == max(comppct_r)],by="mukey"]$V1,]
+#' result_dominant <- result
+#' 
+#' x1 <- data.table(mukey = result_dominant$mukey, 
+#'                  compname = result_dominant$compname,
+#'                  rating_new = result_dominant$interphr,
+#'                  rating_class = result_dominant$interphrc,
+#'                  rating_new_reason = result_dominant$Reason)
+#'                  
+#' x2 <- data.table(mukey = result_ssurgo$MUKEY, 
+#'                  compname = result_ssurgo$compname,
+#'                  rating_old = result_ssurgo$rating,
+#'                  rating_class = result_ssurgo$class)
+#'                  
+#' combined_result <- x2[x1, on = c("mukey","compname")]
+#' 
+#' combined_result$CHECK <- round(combined_result$rating_new, 2) == round(combined_result$rating_old, 2)
+#' 
+#' View(combined_result)       
+#'          
+.get_SSURGO_export_interp_reasons_by_mrulename <- function(dsn, mrulename, n = 2) {
+  # based on VBA Function in Report Functions module of above .mdb
+  # GetInterpReasons(strCokey As String, 
+  #                  strMRuleName As String, 
+  #                  intReasonCount As Integer) As Variant
+  channel <- DBI::dbConnect(odbc::odbc(),
+      .connection_string = paste0("Driver={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=", dsn))
+  
+  q <- sprintf("SELECT * FROM cointerp
+                WHERE [mrulename] = '%s' AND [ruledepth] = 0
+                ORDER BY [interphr] DESC", mrulename)
+  cointerpbase <- data.table::as.data.table(DBI::dbGetQuery(channel, q))
+  
+  # TODO: allow extend reasons to rules with ruledepth > 1?
+  q <- sprintf("SELECT cokey, interphrc FROM cointerp
+                WHERE [mrulename] = '%s' AND [ruledepth] = 1 
+                ORDER BY [interphr] DESC", mrulename)
+  res <- data.table::as.data.table(DBI::dbGetQuery(channel, q))
+  
+  # identify the key components of the cointerp table to relate to NASIS
+  cointerpkey <- data.frame(do.call('rbind', strsplit(cointerpbase$cointerpkey, ":")))
+  colnames(cointerpkey) <- c("lmapunitiid","coiid","mrulekey","seqnum")
+  
+  # unique "cokey" is a composition of mukey (SSURGO) plus coiid (NASIS)
+  cointerpbase$lmapunitiid <- as.integer(gsub("(\\d+):.*", "\\1", cointerpbase$cokey))
+  res$lmapunitiid <- as.integer(gsub("(\\d+):.*", "\\1", res$cokey))
+  cointerpbase$coiid <- as.integer(gsub(".*:(\\d+)", "\\1", cointerpbase$cokey))
+  res$coiid <- as.integer(gsub(".*:(\\d+)", "\\1", res$cokey))
+  
+  # internal function to get the full set of ids from NASIS to alias to export
+  .get_SSURGO_export_iid_table <- function(coiids) {  
+    dbQueryNASIS(NASIS(), sprintf("
+      SELECT liid, lmapunitiid, muiid, corriid, dmuiid, coiid, 
+             areasymbol, musym, muname, compname, comppct_r 
+        FROM area
+        INNER JOIN legend ON legend.areaiidref = area.areaiid
+        INNER JOIN lmapunit ON lmapunit.liidref = legend.liid
+        INNER JOIN mapunit ON mapunit.muiid = lmapunit.muiidref
+        INNER JOIN correlation ON correlation.muiidref = mapunit.muiid
+        INNER JOIN datamapunit ON datamapunit.dmuiid = correlation.dmuiidref
+        INNER JOIN component ON component.dmuiidref = datamapunit.dmuiid 
+      WHERE component.coiid IN %s", format_SQL_in_statement(coiids)))
+  }
+  
+  # get lookup table
+  res2 <- .get_SSURGO_export_iid_table(cointerpkey$coiid)
+  
+  # extract the "high represenative" rating and class for 0th level rule
+  high_rep_rating_class <- cointerpbase[,c("lmapunitiid","coiid","interphr","interphrc")]
+  colnames(high_rep_rating_class) <- c("lmapunitiid","coiid","interphr","interphrc")
+  
+  # flatten the reasons so they are 1:1 with component, join to lookup tables 
+  result <- as.data.frame(res[, list(mrulename = unique(mrulename),
+                           cokeyref = unique(cokey), 
+                           Reasons = paste0(.SD[["interphrc"]][1:pmin(.N, n)], collapse = "; ")),
+                    by = c("lmapunitiid", "coiid")][res2, 
+                                              on = c("lmapunitiid", "coiid")][high_rep_rating_class, 
+                                                                        on = c("lmapunitiid","coiid")])
+  
+  # add mukey:lmapunitiid alias for convenience
+  result$mukey <- result$lmapunitiid
+  
+  return(result)
+}

--- a/misc/NASIS-ssurgo-export-tools/ssurgo-export.R
+++ b/misc/NASIS-ssurgo-export-tools/ssurgo-export.R
@@ -39,26 +39,23 @@ library(soilDB)
 #'                                         method = "NONE", 
 #'                                         areasymbols = c("CA630","CA649"))
 #' 
-#' # result_dominant <- result[result[, .I[comppct_r == max(comppct_r)],by="mukey"]$V1,]
-#' result_dominant <- result
 #' 
-#' x1 <- data.table(mukey = result_dominant$mukey, 
-#'                  compname = result_dominant$compname,
-#'                  rating_new = result_dominant$interphr,
-#'                  rating_class = result_dominant$interphrc,
-#'                  rating_new_reason = result_dominant$Reason)
-#'                  
-#' x2 <- data.table(mukey = result_ssurgo$MUKEY, 
+#' x1 <- data.table(mukey = result$mukey,
+#'                  compname = result$compname,
+#'                  rating_new = result$interphr,
+#'                  rating_class = result$interphrc,
+#'                  rating_new_reason = result$Reason)
+#' 
+#' x2 <- data.table(mukey = result_ssurgo$MUKEY,
 #'                  compname = result_ssurgo$compname,
 #'                  rating_old = result_ssurgo$rating,
 #'                  rating_class = result_ssurgo$class)
-#'                  
+#' 
 #' combined_result <- x2[x1, on = c("mukey","compname")]
 #' 
 #' combined_result$CHECK <- round(combined_result$rating_new, 2) == round(combined_result$rating_old, 2)
 #' 
-#' View(combined_result)       
-#'          
+#' View(combined_result)
 .get_SSURGO_export_interp_reasons_by_mrulename <- function(dsn, mrulename, n = 2) {
   # based on VBA Function in Report Functions module of above .mdb
   # GetInterpReasons(strCokey As String, 
@@ -93,7 +90,7 @@ library(soilDB)
     dbQueryNASIS(NASIS(), sprintf("
       SELECT liid, lmapunitiid, muiid, corriid, dmuiid, coiid, 
              areasymbol, musym, muname, compname, comppct_r 
-        FROM area
+      FROM area
         INNER JOIN legend ON legend.areaiidref = area.areaiid
         INNER JOIN lmapunit ON lmapunit.liidref = legend.liid
         INNER JOIN mapunit ON mapunit.muiid = lmapunit.muiidref
@@ -106,7 +103,7 @@ library(soilDB)
   # get lookup table
   res2 <- .get_SSURGO_export_iid_table(cointerpkey$coiid)
   
-  # extract the "high represenative" rating and class for 0th level rule
+  # extract the "high representative" rating and class for 0th level rule
   high_rep_rating_class <- cointerpbase[,c("lmapunitiid","coiid","interphr","interphrc")]
   colnames(high_rep_rating_class) <- c("lmapunitiid","coiid","interphr","interphrc")
   

--- a/tests/testthat/test-SDA_interpretations.R
+++ b/tests/testthat/test-SDA_interpretations.R
@@ -1,5 +1,6 @@
 target_areas <-  c("CA649", "CA630")
 target_area_rows <- 231
+target_area_rows_all <- 1085
 
 target_mukeys <- c(463263, 463264)
 
@@ -45,4 +46,17 @@ test_that("SDA interpretations (weighted average) works", {
   res <- get_SDA_interpretation("FOR - Potential Seedling Mortality",
                                 method = "Weighted Average", mukeys = target_mukeys)
   expect_equal(sort(res$MUKEY), sort(target_mukeys))
+})
+
+test_that("SDA interpretations (no aggregation) works", {
+  skip_if_offline()
+  
+  skip_on_cran()
+  
+  res <- get_SDA_interpretation("FOR - Potential Seedling Mortality",
+                                method = "NONE", 
+                                areasymbols = target_areas)
+  expect_equal(nrow(res), target_area_rows_all)
+  
+  
 })

--- a/tests/testthat/test-SDA_properties.R
+++ b/tests/testthat/test-SDA_properties.R
@@ -1,5 +1,7 @@
 target_areas <-  c("CA649", "CA630")
-target_area_rows <- 231
+target_area_rows <- 231 # 1:1 with mukey
+target_area_rows_all <- 1085 # 1:1 with component
+target_area_rows_all_chorizon <- 3033 # 1:1 with chorizon
 
 target_mukeys <- c(463263, 463264)
 
@@ -96,4 +98,21 @@ test_that("SDA properties (min/max) works", {
     mukeys = target_mukeys,
     FUN = "MIN"
   )$mukey, target_mukeys)
+})
+
+test_that("SDA properties (no aggregation) works", {
+  skip_if_offline()
+  
+  skip_on_cran()
+  
+  # return results 1:1 with component for component properties
+  expect_equal(nrow(get_SDA_property(property = "Taxonomic Suborder",
+                                     method = "NONE",
+                                     areasymbols = target_areas)), target_area_rows_all)
+  
+  
+  # return results 1:1 with chorizon for horizon properties (includes cokey)
+  expect_equal(nrow(get_SDA_property("Total Sand - Rep Value", 
+                    method = "NONE", 
+                    areasymbols = target_areas)), target_area_rows_all_chorizon)
 })


### PR DESCRIPTION
Working on some new tools for interp validations in southwest region and intend to be using the new ssurgoOnDemand `get_SDA*` functions for handling some of the comparisons to "live" SSURGO. Here is my first cut at extending these things beyond the standard "mukey" and "areasymbol" and mapunit-level aggregation methods.

I am considering ways to further improve and manipulate the output for higher-level purposes (i.e. some sort of `fetch*` function) and I expect new aggregation methods and options will be added to the ones that have already been implemented to improve parity with WSS and more.

Perhaps the most generic case of "aggregation" is to return _un-aggregated_ component (or horizon) data back to the user. This is especially helpful when trying to interpret "Dominant Condition" where the result may be a product of several different components in a map unit that share a common rating.

Now, you can pass `method="NONE"` to `get_SDA_interpretation`/`get_SDA_property` to forgo any of the dominant/min/max/averaging that normally takes place when making "MUKEY thematic" output

The `get_SDA_property` method is smart enough to check to see if you are requesting a horizon-level property, and if so the result will return rows 1:1 with `chorizon` (and will have the chkey). Otherwise, a result that is 1:1 with the components in the selected map units or soil survey areas will be returned.

Example usage:

``` r
library(soilDB)

# interpretation by component, no aggregation
get_SDA_interpretation("WMS - Pond Reservoir Area", method = "NONE", mukeys = 2403721)
#> single result set, returning a data.frame
#>   areasymbol musym                                                   muname
#> 1      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 2      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 3      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 4      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 5      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#>     MUKEY    cokey           compname comppct_r rating            class
#> 1 2403721 19586079             Flanly        18  1.000     Very limited
#> 2 2403721 19586080  Typic Fluvaquents         2  1.000     Very limited
#> 3 2403721 19586081 Ultic Haploxeralfs         5  0.047 Somewhat limited
#> 4 2403721 19586082             Sierra        25  1.000     Very limited
#> 5 2403721 19586083         Urban land        50     NA        Not rated
#>                             reason
#> 1 Slope; Seepage; Depth to bedrock
#> 2                          Seepage
#> 3        Seepage; Depth to bedrock
#> 4                   Slope; Seepage
#> 5                             <NA>

# property by component, no aggregation; using label from lookup table
get_SDA_property('Corrosion of Steel', method = 'NONE', mukeys = 2403721)
#> single result set, returning a data.frame
#>   areasymbol musym                                                   muname
#> 1      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 2      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 3      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 4      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 5      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#>     mukey           compname comppct_r    cokey corsteel
#> 1 2403721         Urban land        50 19586083     <NA>
#> 2 2403721             Sierra        25 19586082 Moderate
#> 3 2403721             Flanly        18 19586079      Low
#> 4 2403721 Ultic Haploxeralfs         5 19586081 Moderate
#> 5 2403721  Typic Fluvaquents         2 19586080     High

# property by horizon, no aggregation; using physical column name
get_SDA_property('sandtotal_r', method = 'NONE', mukeys = 2403721, )
#> single result set, returning a data.frame
#>    areasymbol musym                                                   muname
#> 1       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 2       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 3       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 4       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 5       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 6       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 7       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 8       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 9       CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 10      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 11      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 12      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 13      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 14      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 15      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 16      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 17      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#> 18      CA630  9011 Urban land-Sierra-Flanly complex, 3 to 25 percent slopes
#>      mukey    cokey    chkey           compname comppct_r sandtotal_r
#> 1  2403721 19586082 57324675             Sierra        25          65
#> 2  2403721 19586082 57324676             Sierra        25          45
#> 3  2403721 19586082 57324677             Sierra        25          40
#> 4  2403721 19586082 57324678             Sierra        25          40
#> 5  2403721 19586082 57324679             Sierra        25          40
#> 6  2403721 19586079 57324662             Flanly        18          40
#> 7  2403721 19586079 57324663             Flanly        18          40
#> 8  2403721 19586079 57324664             Flanly        18          40
#> 9  2403721 19586079 57324665             Flanly        18          40
#> 10 2403721 19586079 57324666             Flanly        18          45
#> 11 2403721 19586079 57324667             Flanly        18          NA
#> 12 2403721 19586081 57324671 Ultic Haploxeralfs         5          NA
#> 13 2403721 19586081 57324672 Ultic Haploxeralfs         5          69
#> 14 2403721 19586081 57324673 Ultic Haploxeralfs         5          79
#> 15 2403721 19586081 57324674 Ultic Haploxeralfs         5          80
#> 16 2403721 19586080 57324668  Typic Fluvaquents         2          94
#> 17 2403721 19586080 57324669  Typic Fluvaquents         2          93
#> 18 2403721 19586080 57324670  Typic Fluvaquents         2          92
```
