### PR TITLE
CRAN Release 2.6.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: soilDB
 Type: Package
 Title: Soil Database Interface
 Version: 2.6.2
-Date: 2021-04-22
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov"),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-# soilDB 2.6.2 (2021-05-07)
+# soilDB 2.6.2 (2021-05-14)
  *  Added `formativeElement` argument to `taxaExtent()` (SoilWeb taxon extent function)
     - "Formative elements" are derived from the dictionary provided by the {SoilTaxonomy} package (https://cran.r-project.org/package=SoilTaxonomy)
     - For example: `taxaExtent("abruptic", level = 'subgroup', formativeElement = TRUE)` will get an 800m grid (for SSURGO data in CONUS) showing extent of taxa that have "abruptic" in subgroup-level taxon name
  * `fetchNASIS(from="pedons")` result now contains the `"taxclname"` (full family-level taxon name) field from the NASIS `pedon` table; this value is calculated based on contents of `petaxhistory` child table
  * `get_SDA_interpretation` and `get_SDA_property` now support aggregation `method="NONE"` allowing for returning properties, classes and ratings for individual components or horizons (https://github.com/ncss-tech/soilDB/pull/181)
+ * `ISSR800.wcs` and `mukey.wcs` now return a result that inherits from `try-error` (and a message) if the Web Coverage Service query fails
 
 # soilDB 2.6.1 (2021-04-07)
  * Connections to local NASIS and various MS Access databases now use `DBI` and `odbc`, replacing `RODBC`

--- a/R/ISSR800.R
+++ b/R/ISSR800.R
@@ -28,7 +28,7 @@
 #' 
 #' @note There are still some issues to be resolved related to the encoding of NA Variables with a natural zero (e.g. SAR) have 0 set to NA.
 #' 
-#' @return \code{raster} object containing indexed map unit keys and associated raster attribute table
+#' @return \code{raster} object containing indexed map unit keys and associated raster attribute table or a try-error if request fails
 #' 
 #' @export
 ISSR800.wcs <- function(aoi, var, res = 800, quiet = FALSE) {
@@ -117,7 +117,8 @@ ISSR800.wcs <- function(aoi, var, res = 800, quiet = FALSE) {
   )
   
   if(inherits(dl.try, 'try-error')) {
-    stop('bad WCS request', call. = FALSE) 
+    message('bad WCS request')
+    return(dl.try)
   }
   
   # load pointer to file and return

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -27,7 +27,7 @@
 #' 
 #' Databases available from this WCS can be queried using \code{WCS_details(wcs = 'mukey')}.
 #' 
-#' @return \code{raster} object containing indexed map unit keys and associated raster attribute table
+#' @return \code{raster} object containing indexed map unit keys and associated raster attribute table or a try-error if request fails
 #'
 #' @export
 #'
@@ -115,7 +115,8 @@ mukey.wcs <- function(aoi, db = c('gnatsgo', 'gssurgo'), res = 30, quiet = FALSE
   )
 
   if(inherits(dl.try, 'try-error')) {
-   stop('bad WCS request', call. = FALSE)
+   message('bad WCS request')
+   return(dl.try)
   }
   
   ## TODO: suppressWarnings() used to quiet proj4string noise until we have a better solution

--- a/R/parseWebReport.R
+++ b/R/parseWebReport.R
@@ -92,5 +92,5 @@ parseWebReport <- function(url, args, index=1) {
   # note: col names aren't legal data.frame names
   
   # done
-  return(d)
+  return(as.data.frame(d))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,10 +50,10 @@ Dylan Beaudette, Jay Skovlin, Stephen Roecker and Andrew Brown (2021). soilDB: S
 
  * AKSite, Montana RangeDB, and PedonPC 6.x get and fetch methods now use {DBI}+{odbc}
  
-#### Other APIs
-
- * **NEW** functions [`ROSETTA`](http://ncss-tech.github.io/soilDB/docs/reference/ROSETTA.html), [`taxaExtent`](http://ncss-tech.github.io/soilDB/docs/reference/taxaExtent.html), [`mukey.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/mukey.wcs.html), [`ISSR800.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/ISSR800.wcs.html)
-  
+#### SoilWeb API
+ 
+ * `ISSR800.wcs` and `mukey.wcs` now return a result that inherits from `try-error` (and a message) if the Web Coverage Service fails
+ 
 ## Functions by Data Source 
     
   * SDA
@@ -66,7 +66,7 @@ Dylan Beaudette, Jay Skovlin, Stephen Roecker and Andrew Brown (2021). soilDB: S
     + [`fetchGDB`](http://ncss-tech.github.io/soilDB/docs/reference/fetchGDB.html)
 
   * ROSETTA
-    + <span style="color:red">**NEW:**</span> [`ROSETTA`](http://ncss-tech.github.io/soilDB/docs/reference/ROSETTA.html)
+    + [`ROSETTA`](http://ncss-tech.github.io/soilDB/docs/reference/ROSETTA.html)
   
   * SSURGO/KSSL via SoilWeb
     + [`fetchKSSL`](http://ncss-tech.github.io/soilDB/docs/reference/fetchKSSL.html)
@@ -74,9 +74,9 @@ Dylan Beaudette, Jay Skovlin, Stephen Roecker and Andrew Brown (2021). soilDB: S
     + [`siblings`](http://ncss-tech.github.io/soilDB/docs/reference/siblings.html)
     + [`OSDquery`](http://ncss-tech.github.io/soilDB/docs/reference/OSDquery.html) 
     + [`seriesExtent`](http://ncss-tech.github.io/soilDB/docs/reference/seriesExtent.html)
-    + <span style="color:red">**NEW:**</span> [`taxaExtent`](http://ncss-tech.github.io/soilDB/docs/reference/taxaExtent.html)
-    + <span style="color:red">**NEW:**</span> [`mukey.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/mukey.wcs.html)
-    + <span style="color:red">**NEW:**</span> [`ISSR800.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/ISSR800.wcs.html)
+    + [`taxaExtent`](http://ncss-tech.github.io/soilDB/docs/reference/taxaExtent.html)
+    + [`mukey.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/mukey.wcs.html)
+    + [`ISSR800.wcs`](http://ncss-tech.github.io/soilDB/docs/reference/ISSR800.wcs.html)
   
   * NASIS WWW interface
     + [`parseWebReport`](http://ncss-tech.github.io/soilDB/docs/reference/parseWebReport.html)

--- a/man/ISSR800.wcs.Rd
+++ b/man/ISSR800.wcs.Rd
@@ -27,7 +27,7 @@ The WCS query is parameterized using \code{raster::extent} derived from the abov
 Variables available from this WCS can be queried using \code{WCS_details(wcs = 'ISSR800')}.}
 }
 \value{
-\code{raster} object containing indexed map unit keys and associated raster attribute table
+\code{raster} object containing indexed map unit keys and associated raster attribute table or a try-error if request fails
 }
 \description{
 Intermediate-scale gridded (800m) soil property and interpretation maps from aggregated SSURGO and STATSGO data. These maps were developed by USDA-NRCS-SPSD staff in collaboration with UCD-LAWR. Originally for educational use and \href{https://casoilresource.lawr.ucdavis.edu/soil-properties/}{interactive thematic maps}, these data are a suitable alternative to gridded STATSGO-derived thematic soil maps. The full size grids can be \href{https://casoilresource.lawr.ucdavis.edu/soil-properties/download.php}{downloaded here}.

--- a/man/mukey.wcs.Rd
+++ b/man/mukey.wcs.Rd
@@ -16,7 +16,7 @@ mukey.wcs(aoi, db = c("gnatsgo", "gssurgo"), res = 30, quiet = FALSE)
 \item{quiet}{logical, passed to \code{download.file} to enable / suppress URL and progress bar for download.}
 }
 \value{
-\code{raster} object containing indexed map unit keys and associated raster attribute table
+\code{raster} object containing indexed map unit keys and associated raster attribute table or a try-error if request fails
 }
 \description{
 Download chunks of the gNATSGO or gSSURGO map unit key grid via bounding-box from the SoilWeb WCS.

--- a/tests/testthat/test-ISSR800.R
+++ b/tests/testthat/test-ISSR800.R
@@ -1,16 +1,20 @@
 test_that("ISSR800.wcs works", {
   
+  skip_if_offline()
+  
+  skip_on_cran()
+  
   x <- NULL
   
   expect_true(inherits(WCS_details("ISSR800"), 'data.frame'))
   
-  expect_silent(suppressWarnings({
+  suppressWarnings({
     
     x <- ISSR800.wcs(aoi = list(aoi = c(-114.16, 47.6, -114.15, 47.7),
                                 crs = '+init=epsg:4326'),
                      var = 'paws', quiet = TRUE)
     
-  }))
+  })
   
-  expect_true(inherits(x, 'RasterLayer'))
+  expect_true(inherits(x, 'RasterLayer') || inherits(x, 'try-error'))
 })

--- a/tests/testthat/test-mukey-WCS.R
+++ b/tests/testthat/test-mukey-WCS.R
@@ -1,17 +1,21 @@
 test_that("mukey.wcs works", {
-
+  
+  skip_if_offline()
+  
+  skip_on_cran()
+  
   x <- NULL
   
   expect_true(inherits(WCS_details("mukey"), 'data.frame'))
 
-  expect_silent(suppressWarnings({
+  suppressWarnings({
 
     x <- mukey.wcs(aoi = list(aoi = c(-114.16, 47.655, -114.155, 47.66),
                               crs = '+init=epsg:4326'),
                    db = 'gnatsgo', quiet = TRUE)
 
-  }))
-
-  expect_true(inherits(x, 'RasterLayer'))
+  })
+  
+  expect_true(inherits(x, 'RasterLayer') || inherits(x, 'try-error'))
 })
 


### PR DESCRIPTION
It appears that a couple tests of the WCS functionality are erroring out on new M1 Mac platform. Need to fail gracefully. 

https://www.stats.ox.ac.uk/pub/bdr/M1mac/soilDB.out
 - I have replaced a hard `stop()` on "bad WCS request" in `ISSR800.wcs` and `mukey.wcs` with a message and a try-error result.  

- The documentation has been updated to reflect that a `try-error` will be returned when WCS fails. 
- Tests are skipped if offline and on CRAN
- Test expectations have been updated to handle possible outputs under a failed WCS request (if for some reason tests fail to be skipped)

I will be making a submission to CRAN by end of today to correct it. 