### PR TITLE
Update `get_soilseries_from_NASIS`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# soilDB 2.6.3 (2021-06-11)
+# soilDB 2.6.3 (2021-06-16)
+ * Added new columns to soil classification ("SC") table result of `get_soilseries_from_NASIS()`; now including taxonomic mineralogy class which may contain multiple parts for series with strongly contrasting control sections
  * Updates to `get_SDA_*()` methods 
    - Extends `get_SDA_property(property = ...)` and `get_SDA_interpretation(rulename = ...)` vectorization over property/rulename to work with any aggregation method. 
      - Now supports: Dominant Condition, Min/Max, Dominant Component, Weighted Average

--- a/R/get_soilseries_from_NASIS.R
+++ b/R/get_soilseries_from_NASIS.R
@@ -12,7 +12,9 @@
 #'
 #' @param dsn Optional: path to local SQLite database containing NASIS
 #' table structure; default: `NULL`
-#'
+#' 
+#' @param delimiter _character_. Used to collapse `taxminalogy` records where multiple values are used to describe strongly contrasting control sections. Default `" over "` creates combination mineralogy classes as they would be used in the family name.
+#' 
 #' @return A \code{data.frame}
 #'
 #' @author Stephen Roecker
@@ -21,7 +23,7 @@
 #'
 #' @export get_soilseries_from_NASIS
 get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactors(),
-                                      dsn = NULL) {
+                                      dsn = NULL, delimiter = " over ") {
   q.soilseries <- "
   SELECT soilseriesname, soilseriesstatus, benchmarksoilflag, soiltaxclasslastupdated, mlraoffice, taxclname, taxorder, taxsuborder, taxgrtgroup, taxsubgrp, taxpartsize, taxpartsizemod, taxceactcl, taxreaction, taxtempcl, taxfamhahatmatcl, originyear, establishedyear, descriptiondateinitial, descriptiondateupdated, statsgoflag, soilseriesedithistory, soilseriesiid, areasymbol, areaname, areaacres, obterm, areatypename
   FROM soilseries ss
@@ -51,7 +53,7 @@ get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactor
   # aggregate mineralogy data (ordered by minorder, combined with "over")
   d.minagg <- aggregate(d.soilseriesmin$taxminalogy, 
                         list(soilseriesiid = d.soilseriesmin$soilseriesiidref), 
-                        paste0, collapse = " over ")
+                        paste0, collapse = delimiter)
   colnames(d.minagg) <- c("soilseriesiid", "taxminalogy")
   
   res <- merge(

--- a/R/get_soilseries_from_NASIS.R
+++ b/R/get_soilseries_from_NASIS.R
@@ -22,40 +22,55 @@
 #' @export get_soilseries_from_NASIS
 get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactors(),
                                       dsn = NULL) {
-
   q.soilseries <- "
-  SELECT soilseriesname, soilseriesstatus, benchmarksoilflag, statsgoflag, mlraoffice, areasymbol, areatypename, taxclname, taxorder, taxsuborder, taxgrtgroup, taxsubgrp, taxpartsize, taxpartsizemod, taxceactcl, taxreaction, taxtempcl, originyear, establishedyear, soiltaxclasslastupdated, soilseriesiid
-
-  FROM
-  soilseries ss
-
-  INNER JOIN
-      area       a  ON a.areaiid      = ss.typelocstareaiidref
-  INNER JOIN
-      areatype   at ON at.areatypeiid = ss.typelocstareatypeiidref
-
-  ORDER BY soilseriesname
-  ;"
-
-  # LEFT OUTER JOIN
-  #     soilseriestaxmineralogy sstm ON sstm.soilseriesiidref = ss.soilseriesiid
-
+  SELECT soilseriesname, soilseriesstatus, benchmarksoilflag, soiltaxclasslastupdated, mlraoffice, taxclname, taxorder, taxsuborder, taxgrtgroup, taxsubgrp, taxpartsize, taxpartsizemod, taxceactcl, taxreaction, taxtempcl, taxfamhahatmatcl, originyear, establishedyear, descriptiondateinitial, descriptiondateupdated, statsgoflag, soilseriesedithistory, soilseriesiid, areasymbol, areaname, areaacres, obterm, areatypename
+  FROM soilseries ss
+  INNER JOIN area a ON a.areaiid = ss.typelocstareaiidref
+  INNER JOIN areatype at ON at.areatypeiid = ss.typelocstareatypeiidref
+  ORDER BY soilseriesname;"
+  
+  q.min <- "SELECT soilseriesiidref, minorder, taxminalogy FROM soilseriestaxmineralogy 
+            ORDER BY soilseriesiidref, minorder;"
+  
   channel <- dbConnectNASIS(dsn)
 
   if (inherits(channel, 'try-error'))
     return(data.frame())
 
   # exec query
-  d.soilseries <- dbQueryNASIS(channel, q.soilseries)
-
+  d.soilseries <- dbQueryNASIS(channel, q.soilseries, close = FALSE)
+  d.soilseriesmin <- dbQueryNASIS(channel, q.min)
+  
   # recode metadata domains
   d.soilseries <- uncode(d.soilseries, stringsAsFactors = stringsAsFactors, dsn = dsn)
+  d.soilseriesmin <- uncode(d.soilseriesmin, stringsAsFactors = stringsAsFactors, dsn = dsn)
 
   # prep
   d.soilseries$soiltaxclasslastupdated <- format(d.soilseries$soiltaxclasslastupdated, "%Y")
-
-  # done
-  return(d.soilseries)
+  
+  # aggregate mineralogy data (ordered by minorder, combined with "over")
+  d.minagg <- aggregate(d.soilseriesmin$taxminalogy, 
+                        list(soilseriesiid = d.soilseriesmin$soilseriesiidref), 
+                        paste0, collapse = " over ")
+  colnames(d.minagg) <- c("soilseriesiid", "taxminalogy")
+  
+  res <- merge(
+      d.soilseries,
+      d.minagg,
+      by = "soilseriesiid",
+      all.x = TRUE,
+      incomparables = NA,
+      sort = FALSE
+    )
+  
+  # reorder column names
+  return(res[,c("soilseriesiid", "soilseriesname", "soilseriesstatus", "benchmarksoilflag", 
+                "soiltaxclasslastupdated", "mlraoffice", "taxclname", "taxorder", 
+                "taxsuborder", "taxgrtgroup", "taxsubgrp", "taxpartsize", "taxpartsizemod", 
+                "taxceactcl", "taxreaction", "taxtempcl", "taxminalogy", "taxfamhahatmatcl", 
+                "originyear", "establishedyear", "descriptiondateinitial", "descriptiondateupdated", 
+                "statsgoflag", "soilseriesedithistory", "areasymbol", "areaname", 
+                "areaacres", "obterm", "areatypename")])
 }
 
 get_soilseries_from_NASISWebReport <- function(soils, stringsAsFactors = default.stringsAsFactors()) {

--- a/R/get_soilseries_from_NASIS.R
+++ b/R/get_soilseries_from_NASIS.R
@@ -12,9 +12,9 @@
 #'
 #' @param dsn Optional: path to local SQLite database containing NASIS
 #' table structure; default: `NULL`
-#' 
+#'
 #' @param delimiter _character_. Used to collapse `taxminalogy` records where multiple values are used to describe strongly contrasting control sections. Default `" over "` creates combination mineralogy classes as they would be used in the family name.
-#' 
+#'
 #' @return A \code{data.frame}
 #'
 #' @author Stephen Roecker
@@ -30,10 +30,10 @@ get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactor
   INNER JOIN area a ON a.areaiid = ss.typelocstareaiidref
   INNER JOIN areatype at ON at.areatypeiid = ss.typelocstareatypeiidref
   ORDER BY soilseriesname;"
-  
-  q.min <- "SELECT soilseriesiidref, minorder, taxminalogy FROM soilseriestaxmineralogy 
+
+  q.min <- "SELECT soilseriesiidref, minorder, taxminalogy FROM soilseriestaxmineralogy
             ORDER BY soilseriesiidref, minorder;"
-  
+
   channel <- dbConnectNASIS(dsn)
 
   if (inherits(channel, 'try-error'))
@@ -42,20 +42,20 @@ get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactor
   # exec query
   d.soilseries <- dbQueryNASIS(channel, q.soilseries, close = FALSE)
   d.soilseriesmin <- dbQueryNASIS(channel, q.min)
-  
+
   # recode metadata domains
   d.soilseries <- uncode(d.soilseries, stringsAsFactors = stringsAsFactors, dsn = dsn)
   d.soilseriesmin <- uncode(d.soilseriesmin, stringsAsFactors = stringsAsFactors, dsn = dsn)
 
   # prep
-  d.soilseries$soiltaxclasslastupdated <- format(d.soilseries$soiltaxclasslastupdated, "%Y")
-  
+  d.soilseries$soiltaxclasslastupdated <- format(as.Date.POSIXct(d.soilseries$soiltaxclasslastupdated), "%Y")
+
   # aggregate mineralogy data (ordered by minorder, combined with "over")
-  d.minagg <- aggregate(d.soilseriesmin$taxminalogy, 
-                        list(soilseriesiid = d.soilseriesmin$soilseriesiidref), 
+  d.minagg <- aggregate(d.soilseriesmin$taxminalogy,
+                        list(soilseriesiid = d.soilseriesmin$soilseriesiidref),
                         paste0, collapse = delimiter)
   colnames(d.minagg) <- c("soilseriesiid", "taxminalogy")
-  
+
   res <- merge(
       d.soilseries,
       d.minagg,
@@ -64,13 +64,13 @@ get_soilseries_from_NASIS <- function(stringsAsFactors = default.stringsAsFactor
       incomparables = NA,
       sort = FALSE
     )
-  
+
   # reorder column names
-  return(res[,c("soilseriesiid", "soilseriesname", "soilseriesstatus", "benchmarksoilflag", 
-                "soiltaxclasslastupdated", "mlraoffice", "taxclname", "taxorder", 
-                "taxsuborder", "taxgrtgroup", "taxsubgrp", "taxpartsize", "taxpartsizemod", 
-                "taxceactcl", "taxreaction", "taxtempcl", "taxminalogy", "taxfamhahatmatcl", 
-                "originyear", "establishedyear", "descriptiondateinitial", "descriptiondateupdated", 
+  return(res[,c("soilseriesiid", "soilseriesname", "soilseriesstatus", "benchmarksoilflag",
+                "soiltaxclasslastupdated", "mlraoffice", "taxclname", "taxorder",
+                "taxsuborder", "taxgrtgroup", "taxsubgrp", "taxpartsize", "taxpartsizemod",
+                "taxceactcl", "taxreaction", "taxtempcl", "taxminalogy", "taxfamhahatmatcl",
+                "originyear", "establishedyear", "descriptiondateinitial", "descriptiondateupdated",
                 "statsgoflag", "soilseriesedithistory", "areasymbol", "areaname", 
                 "areaacres", "obterm", "areatypename")])
 }

--- a/man/get_soilseries_from_NASIS.Rd
+++ b/man/get_soilseries_from_NASIS.Rd
@@ -7,7 +7,8 @@
 \usage{
 get_soilseries_from_NASIS(
   stringsAsFactors = default.stringsAsFactors(),
-  dsn = NULL
+  dsn = NULL,
+  delimiter = " over "
 )
 }
 \arguments{
@@ -17,6 +18,8 @@ convert those vectors that have set outside of \code{uncode()} (i.e. hard coded)
 
 \item{dsn}{Optional: path to local SQLite database containing NASIS
 table structure; default: \code{NULL}}
+
+\item{delimiter}{\emph{character}. Used to collapse \code{taxminalogy} records where multiple values are used to describe strongly contrasting control sections. Default \code{" over "} creates combination mineralogy classes as they would be used in the family name.}
 }
 \value{
 A \code{data.frame}

--- a/tests/testthat/test-fetchNASIS.R
+++ b/tests/testthat/test-fetchNASIS.R
@@ -133,6 +133,13 @@ test_that("getHzErrorsNASIS works", {
   expect_silent({suppressMessages(getHzErrorsNASIS(dsn = dsn))})
 })
 
+test_that("get_soilseries_from_NASIS works", { 
+  if (!local_NASIS_defined(dsn = dsn)) {
+    skip("local NASIS database not available")
+  }
+  expect_silent({suppressMessages(get_soilseries_from_NASIS(dsn = dsn))})
+})
+
 
 
 

--- a/tests/testthat/test-fetchNASIS.R
+++ b/tests/testthat/test-fetchNASIS.R
@@ -60,7 +60,7 @@ test_that("fetchNASIS(from='pedons') returns reasonable data", {
   # get data
   # ignore warnings for now
   x <- suppressWarnings(fetchNASIS(from = 'pedons'))
-  
+
   # expected outcomes
   expect_true(inherits(x, 'SoilProfileCollection'))
   expect_equal(nrow(site(x)) > 0, TRUE)
@@ -109,7 +109,7 @@ test_that("fetchNASIS(from='components') returns reasonable data", {
   # get data
   # ignore warnings for now
   x <- suppressWarnings(fetchNASIS(from = 'components'))
- 
+
   # expected outcomes
   expect_true(inherits(x, 'SoilProfileCollection'))
   expect_equal(nrow(site(x)) > 0, TRUE)
@@ -126,18 +126,24 @@ test_that("get_text_notes_from_NASIS_db works", {
   expect_silent({get_text_notes_from_NASIS_db()})
 })
 
-test_that("getHzErrorsNASIS works", { 
+test_that("getHzErrorsNASIS works", {
   if (!local_NASIS_defined(dsn = dsn)) {
     skip("local NASIS database not available")
   }
   expect_silent({suppressMessages(getHzErrorsNASIS(dsn = dsn))})
 })
 
-test_that("get_soilseries_from_NASIS works", { 
+test_that("get_soilseries_from_NASIS works", {
   if (!local_NASIS_defined(dsn = dsn)) {
     skip("local NASIS database not available")
   }
-  expect_silent({suppressMessages(get_soilseries_from_NASIS(dsn = dsn))})
+  expect_silent({suppressMessages(res <- get_soilseries_from_NASIS(dsn = dsn))})
+
+  # all calculated combined taxminalogy classes exist in corresponding taxclname
+  over.idx <- grep(" over ", res$taxminalogy)
+  expect_true(all(sapply(seq_len(length(over.idx)), function(i)
+    grepl(res$taxminalogy[over.idx[i]], tolower(res$taxclname[over.idx[i]])))))
+
 })
 
 


### PR DESCRIPTION
 - Minor updates to add missing columns to the result of querying the "SC database" table `soilseries` in NASIS.

 - Also handles the possible many:one relationships in mineralogy classes stored in `soilseriestaxmineralogy` by concatenating using the word "over" and ordering based on the `minorder` field