### PR TITLE
first cut at a solution to #190 and more generally, a formal connection to datatypes as used in SDA

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,7 +8,7 @@ importFrom("stats", "aggregate", "complete.cases", "na.omit", "as.formula", "spl
 
 importFrom("utils", "URLencode", "download.file", "object.size",
              "read.csv", "read.table", "setTxtProgressBar",
-             "txtProgressBar", "write.table", "type.convert")
+             "txtProgressBar", "write.table")
 
 importFrom("methods", "slot<-", "as")
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # soilDB 2.6.3 (2021-06-16)
+ * `SDA_query()` and all functions that call `SDA_query()` get proper column class handling (related to #190), however:
+   - be careful with the use of CAST(): unknown datatypes may not be correctly interpreted
+   - 
  * Added new columns to soil classification ("SC") table result of `get_soilseries_from_NASIS()`; now including taxonomic mineralogy class which may contain multiple parts for series with strongly contrasting control sections
  * Updates to `get_SDA_*()` methods 
    - Extends `get_SDA_property(property = ...)` and `get_SDA_interpretation(rulename = ...)` vectorization over property/rulename to work with any aggregation method. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # soilDB 2.6.3 (2021-06-16)
  * `SDA_query()` and all functions that call `SDA_query()` get proper column class handling (related to #190), however:
    - be careful with the use of CAST(): unknown datatypes may not be correctly interpreted
-   - 
+   - previous column classes that were incorrectly guessed by `type.convert()` may have changed (e.g. `component.wei`)
  * Added new columns to soil classification ("SC") table result of `get_soilseries_from_NASIS()`; now including taxonomic mineralogy class which may contain multiple parts for series with strongly contrasting control sections
  * Updates to `get_SDA_*()` methods 
    - Extends `get_SDA_property(property = ...)` and `get_SDA_interpretation(rulename = ...)` vectorization over property/rulename to work with any aggregation method. 

--- a/R/SDA_query.R
+++ b/R/SDA_query.R
@@ -262,6 +262,8 @@ SDA_query <- function(q) {
   cc <- sapply(m, function(j) {
     # extract the data type
     dt <- strsplit(j, split = ',', fixed = TRUE)[[1]][8]
+    # known data types in SDA and appropriate classes in R
+    # fall-back to "character" for unknown data types
     switch(dt,
            'DataTypeName=char' = 'character',
            'DataTypeName=varchar' = 'character',
@@ -275,7 +277,8 @@ SDA_query <- function(q) {
            'DataTypeName=numeric' = 'numeric',
            'DataTypeName=real' = 'numeric',
            'DataTypeName=float' = 'numeric',
-           'DataTypeName=decimal' = 'numeric'
+           'DataTypeName=decimal' = 'numeric',
+           'character'
            )
   })
   

--- a/R/SDA_query.R
+++ b/R/SDA_query.R
@@ -266,9 +266,13 @@ SDA_query <- function(q) {
            'DataTypeName=char' = 'character',
            'DataTypeName=varchar' = 'character',
            'DataTypeName=nvarchar' = 'character',
+           'DataTypeName=text' = 'character',
+           'DataTypeName=ntext' = 'character',
            'DataTypeName=datetime' = 'character',
+           'DataTypeName=bit' = 'integer',
            'DataTypeName=int' = 'integer',
            'DataTypeName=smallint' = 'integer',
+           'DataTypeName=numeric' = 'numeric',
            'DataTypeName=real' = 'numeric',
            'DataTypeName=float' = 'numeric',
            'DataTypeName=decimal' = 'numeric'

--- a/R/SDA_query.R
+++ b/R/SDA_query.R
@@ -241,6 +241,8 @@ SDA_query <- function(q) {
 }
 
 
+## See https://github.com/ncss-tech/soilDB/pull/191 for a list of possibly data types
+
 # note: empty strings and 'NA' are converted into <NA>
 # convert the raw results from SDA into a proper data.frame
 # no conversion of strings -> factors
@@ -266,14 +268,19 @@ SDA_query <- function(q) {
     # fall-back to "character" for unknown data types
     switch(dt,
            'DataTypeName=char' = 'character',
+           'DataTypeName=nchar' = 'character',
            'DataTypeName=varchar' = 'character',
            'DataTypeName=nvarchar' = 'character',
            'DataTypeName=text' = 'character',
            'DataTypeName=ntext' = 'character',
            'DataTypeName=datetime' = 'character',
+           'DataTypeName=datetime2' = 'character',
+           'DataTypeName=timestamp' = 'character',
            'DataTypeName=bit' = 'integer',
            'DataTypeName=int' = 'integer',
+           'DataTypeName=bigint' = 'integer',
            'DataTypeName=smallint' = 'integer',
+           'DataTypeName=tinyint' = 'integer',
            'DataTypeName=numeric' = 'numeric',
            'DataTypeName=real' = 'numeric',
            'DataTypeName=float' = 'numeric',

--- a/R/fetchSDA_spatial.R
+++ b/R/fetchSDA_spatial.R
@@ -1,20 +1,20 @@
 #' @title Query Soil Data Access and Return Spatial Data
 #'
-#' @description This is a high-level "fetch" method to facilitate spatial queries to Soil Data Access (SDA) based on mapunit key (\code{mukey}) and national mapunit symbol (\code{nationalmusym}) for \code{mupolygon} (SSURGO) or \code{gsmmupolygon} (STATSGO) geometry OR legend key (\code{lkey}) and area symbols (\code{areasymbol}) for \code{sapolygon} (Soil Survey Area; SSA) geometry).
+#' @description This is a high-level "fetch" method to facilitate spatial queries to Soil Data Access (SDA) based on map unit key (\code{mukey}) and national map unit symbol (\code{nationalmusym}) for \code{mupolygon} (SSURGO) or \code{gsmmupolygon} (STATSGO) geometry OR legend key (\code{lkey}) and area symbols (\code{areasymbol}) for \code{sapolygon} (Soil Survey Area; SSA) geometry).
 #'
-#' A Soil Data Access spatial query is made returning geometry and key identifying information about the mapunit or area of interest. Additional columns from the mapunit or legend table can be included using \code{add.fields} argument.
+#' A Soil Data Access spatial query is made returning geometry and key identifying information about the map unit or area of interest. Additional columns from the map unit or legend table can be included using \code{add.fields} argument.
 #'
-#' This function automatically "chunks" the input vector (using \code{soilDB::makeChunks}) of mapunit identifiers to minimize the likelihood of exceeding the SDA data request size. The number of chunks varies with the \code{chunk.size} setting and the length of your input vector. If you are working with many mapunits and/or large extents, you may need to decrease this number in order to have more chunks.
+#' This function automatically "chunks" the input vector (using \code{soilDB::makeChunks}) of map unit identifiers to minimize the likelihood of exceeding the SDA data request size. The number of chunks varies with the \code{chunk.size} setting and the length of your input vector. If you are working with many map units and/or large extents, you may need to decrease this number in order to have more chunks.
 #'
 #' Querying regions with complex mapping may require smaller \code{chunk.size}. Numerically adjacent IDs in the input vector may share common qualities (say, all from same soil survey area or region) which could cause specific chunks to perform "poorly" (slow or error) no matter what the chunk size is. Shuffling the order of the inputs using \code{sample} may help to eliminate problems related to this, depending on how you obtained your set of MUKEY/nationalmusym to query. One could feasibly use \code{muacres} as a heuristic to adjust for total acreage within chunks.
 #'
-#' @param x A vector of MUKEYs / national mapunit symbols (for mupolygon geometry); OR legend keys (LKEY) / area symbols (for sapolygon geometry)
+#' @param x A vector of MUKEYs / national map unit symbols (for `mupolygon` geometry); OR legend keys (LKEY) / area symbols (for `sapolygon` geometry)
 #'
-#' @param by.col Column name containing mapunit identifier \code{"mukey"}, \code{"nmusym"}, or \code{"areasymbol"} for \code{geom.src} \code{sapolygon}; default is inferred from \code{is.numeric(x) == TRUE} for \code{mukey} or \code{lkey} and (\code{nationalmusym} or \code{areasymbol} otherwise.
+#' @param by.col Column name containing map unit identifier \code{"mukey"}, \code{"nmusym"}, or \code{"areasymbol"} for \code{geom.src} \code{sapolygon}; default is inferred from \code{is.numeric(x) == TRUE} for \code{mukey} or \code{lkey} and (\code{nationalmusym} or \code{areasymbol} otherwise.
 #'
-#' @param method geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon, and \code{"point"} returns a single point within each polygon.
+#' @param method geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon (via `STEnvelope()`), and \code{"point"} returns a single point (via `STPointOnSurface()`) within each polygon.
 #'
-#' @param geom.src Either \code{mupolygon} or \code{sapolygon}
+@param geom.src Either `mupolygon` (map unit polygons) or `sapolygon` (soil survey area boundary polygons)
 #'
 #' @param db Default: SSURGO. When \code{geom.src} is \code{mupolygon}, use STATSGO polygon geometry instead of SSURGO by setting \code{db = "STATSGO"}
 #'
@@ -24,7 +24,7 @@
 #'
 #' @param verbose Print messages?
 #'
-#' @return A Spatial*DataFrame corresponding to SDA spatial data for all symbols requested. Default result contains geometry with attribute table containing unique feature ID, symbol and area symbol plus additional fields in result specified with `add.fields`.
+#' @return A `Spatial*DataFrame` corresponding to SDA spatial data for all symbols requested. Default result contains geometry with attribute table containing unique feature ID, symbol and area symbol plus additional fields in result specified with `add.fields`.
 #'
 #' @details Note that STATSGO data are fetched using \code{CLIPAREASYMBOL = 'US'} to avoid duplicating state and national subsets of the geometry.
 #'

--- a/R/fetchSDA_spatial.R
+++ b/R/fetchSDA_spatial.R
@@ -14,7 +14,7 @@
 #'
 #' @param method geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon (via `STEnvelope()`), and \code{"point"} returns a single point (via `STPointOnSurface()`) within each polygon.
 #'
-@param geom.src Either `mupolygon` (map unit polygons) or `sapolygon` (soil survey area boundary polygons)
+#' @param geom.src Either `mupolygon` (map unit polygons) or `sapolygon` (soil survey area boundary polygons)
 #'
 #' @param db Default: SSURGO. When \code{geom.src} is \code{mupolygon}, use STATSGO polygon geometry instead of SSURGO by setting \code{db = "STATSGO"}
 #'

--- a/man/fetchSDA_spatial.Rd
+++ b/man/fetchSDA_spatial.Rd
@@ -16,13 +16,13 @@ fetchSDA_spatial(
 )
 }
 \arguments{
-\item{x}{A vector of MUKEYs / national mapunit symbols (for mupolygon geometry); OR legend keys (LKEY) / area symbols (for sapolygon geometry)}
+\item{x}{A vector of MUKEYs / national map unit symbols (for \code{mupolygon} geometry); OR legend keys (LKEY) / area symbols (for \code{sapolygon} geometry)}
 
-\item{by.col}{Column name containing mapunit identifier \code{"mukey"}, \code{"nmusym"}, or \code{"areasymbol"} for \code{geom.src} \code{sapolygon}; default is inferred from \code{is.numeric(x) == TRUE} for \code{mukey} or \code{lkey} and (\code{nationalmusym} or \code{areasymbol} otherwise.}
+\item{by.col}{Column name containing map unit identifier \code{"mukey"}, \code{"nmusym"}, or \code{"areasymbol"} for \code{geom.src} \code{sapolygon}; default is inferred from \code{is.numeric(x) == TRUE} for \code{mukey} or \code{lkey} and (\code{nationalmusym} or \code{areasymbol} otherwise.}
 
-\item{method}{geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon, and \code{"point"} returns a single point within each polygon.}
+\item{method}{geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon (via \code{STEnvelope()}), and \code{"point"} returns a single point (via \code{STPointOnSurface()}) within each polygon.}
 
-\item{geom.src}{Either \code{mupolygon} or \code{sapolygon}}
+\item{geom.src}{Either \code{mupolygon} (map unit polygons) or \code{sapolygon} (soil survey area boundary polygons)}
 
 \item{db}{Default: SSURGO. When \code{geom.src} is \code{mupolygon}, use STATSGO polygon geometry instead of SSURGO by setting \code{db = "STATSGO"}}
 
@@ -33,14 +33,14 @@ fetchSDA_spatial(
 \item{verbose}{Print messages?}
 }
 \value{
-A Spatial*DataFrame corresponding to SDA spatial data for all symbols requested. Default result contains geometry with attribute table containing unique feature ID, symbol and area symbol plus additional fields in result specified with \code{add.fields}.
+A \code{Spatial*DataFrame} corresponding to SDA spatial data for all symbols requested. Default result contains geometry with attribute table containing unique feature ID, symbol and area symbol plus additional fields in result specified with \code{add.fields}.
 }
 \description{
-This is a high-level "fetch" method to facilitate spatial queries to Soil Data Access (SDA) based on mapunit key (\code{mukey}) and national mapunit symbol (\code{nationalmusym}) for \code{mupolygon} (SSURGO) or \code{gsmmupolygon} (STATSGO) geometry OR legend key (\code{lkey}) and area symbols (\code{areasymbol}) for \code{sapolygon} (Soil Survey Area; SSA) geometry).
+This is a high-level "fetch" method to facilitate spatial queries to Soil Data Access (SDA) based on map unit key (\code{mukey}) and national map unit symbol (\code{nationalmusym}) for \code{mupolygon} (SSURGO) or \code{gsmmupolygon} (STATSGO) geometry OR legend key (\code{lkey}) and area symbols (\code{areasymbol}) for \code{sapolygon} (Soil Survey Area; SSA) geometry).
 
-A Soil Data Access spatial query is made returning geometry and key identifying information about the mapunit or area of interest. Additional columns from the mapunit or legend table can be included using \code{add.fields} argument.
+A Soil Data Access spatial query is made returning geometry and key identifying information about the map unit or area of interest. Additional columns from the map unit or legend table can be included using \code{add.fields} argument.
 
-This function automatically "chunks" the input vector (using \code{soilDB::makeChunks}) of mapunit identifiers to minimize the likelihood of exceeding the SDA data request size. The number of chunks varies with the \code{chunk.size} setting and the length of your input vector. If you are working with many mapunits and/or large extents, you may need to decrease this number in order to have more chunks.
+This function automatically "chunks" the input vector (using \code{soilDB::makeChunks}) of map unit identifiers to minimize the likelihood of exceeding the SDA data request size. The number of chunks varies with the \code{chunk.size} setting and the length of your input vector. If you are working with many map units and/or large extents, you may need to decrease this number in order to have more chunks.
 
 Querying regions with complex mapping may require smaller \code{chunk.size}. Numerically adjacent IDs in the input vector may share common qualities (say, all from same soil survey area or region) which could cause specific chunks to perform "poorly" (slow or error) no matter what the chunk size is. Shuffling the order of the inputs using \code{sample} may help to eliminate problems related to this, depending on how you obtained your set of MUKEY/nationalmusym to query. One could feasibly use \code{muacres} as a heuristic to adjust for total acreage within chunks.
 }

--- a/misc/SOD-wt-mean-check.R
+++ b/misc/SOD-wt-mean-check.R
@@ -1,0 +1,38 @@
+
+## further investigation of wt. mean
+## https://github.com/ncss-tech/soilDB/issues/193
+
+library(soilDB)
+
+# an example map unit + components
+SDA_query("SELECT mukey, component.cokey, compname, compkind, comppct_r, hzdept_r, hzdepb_r, sandtotal_r FROM component INNER JOIN chorizon ON component.cokey = chorizon.cokey WHERE mukey = '545857' ORDER BY comppct_r DESC, hzdept_r ASC;")
+
+# matches WSS: NA / NULL returned because the largest component has no data
+get_SDA_property(property = c("sandtotal_r","silttotal_r","claytotal_r"),
+                 method = "Dominant Component (Numeric)", 
+                 mukeys = 545857,
+                 top_depth = 0,
+                 bottom_depth = 25)
+
+# does not match WSS
+# (sand should be 67.4%, silt should be 19.6%, clay should be 13%)
+get_SDA_property(property = c("sandtotal_r","silttotal_r","claytotal_r"),
+                 method = "Weighted Average", 
+                 mukeys = 545857,
+                 top_depth = 0,
+                 bottom_depth = 25)
+
+# check source data
+get_SDA_property(property = c("sandtotal_r","silttotal_r","claytotal_r"),
+                 method = "None", 
+                 mukeys = 545857,
+                 top_depth = 0,
+                 bottom_depth = 25)
+
+
+# incorrect values are re-created when manually performing the wt. avg
+# that includes all of the weights
+sum(c(60, 30) * c(NA, 67.4), na.rm = TRUE) / sum(c(60, 30))
+sum(c(60, 30) * c(NA, 19.6), na.rm = TRUE) / sum(c(60, 30))
+sum(c(60, 30) * c(NA, 13), na.rm = TRUE) / sum(c(60, 30))
+

--- a/tests/testthat/test-SDA_query.R
+++ b/tests/testthat/test-SDA_query.R
@@ -132,10 +132,10 @@ test_that("SDA_query() interprets data type correctly", {
   expect_true(inherits(x.3$compkind, 'character'))
   expect_true(inherits(x.3$comppct_r, 'integer'))
   expect_true(inherits(x.3$majcompflag, 'character'))
-  expect_true(inherits(x.3$elev_r, 'integer'))
-  expect_true(inherits(x.3$slope_r, 'integer'))
-  expect_true(inherits(x.3$wei, 'integer'))
-  expect_true(inherits(x.3$weg, 'integer'))
+  expect_true(inherits(x.3$elev_r, 'numeric'))
+  expect_true(inherits(x.3$slope_r, 'numeric'))
+  expect_true(inherits(x.3$wei, 'character'))
+  expect_true(inherits(x.3$weg, 'character'))
 
 })
 

--- a/tests/testthat/test-fetchSDA_component.R
+++ b/tests/testthat/test-fetchSDA_component.R
@@ -36,7 +36,7 @@ test_that("fetchSDA() returns expected results", {
 
   skip_on_cran()
 
-  # there should be 2 components nad 10 horizons
+  # there should be 2 components and 10 horizons
   expect_equal(length(x), 2)
   expect_equal(nrow(x), 10)
 
@@ -45,5 +45,5 @@ test_that("fetchSDA() returns expected results", {
   expect_equal(site(x)$nationalmusym, c('kzc4', 'kzc4'))
 
   # test that both components have no NRCS forest/range site assigned
-  expect_equal(site(x)$ecoclassid, c(NA,NA))
+  expect_equal(site(x)$ecoclassid, c(NA_character_, NA_character_))
 })

--- a/tests/testthat/test-fetchSDA_spatial.R
+++ b/tests/testthat/test-fetchSDA_spatial.R
@@ -6,7 +6,7 @@ test_that("fetchSDA_spatial basic mupolygon functionality", {
 
   skip_on_cran()
 
-  # expect 3, relatively nonextensive join delineations
+  # expect 3, relatively non-extensive join delineations
   single.mukey <- fetchSDA_spatial(x = "2924882", by.col = 'mukey')
   expect_equal(nrow(single.mukey), 3)
 


### PR DESCRIPTION
All tests and R CMD check passing on my local machine. I'm a little concerned that I may have missed an important SQL Server datatype in the conversion code. This style of conversion is not robust to arbitrary use of CAST(xxx AS `SOMEOTHERDATATYPE`) that hasn't been included in the following `swtich()`:
```r
  # parse metadata to create colClasses argument
  cc <- sapply(m, function(j) {
    # extract the data type
    dt <- strsplit(j, split = ',', fixed = TRUE)[[1]][8]
    switch(dt,
           'DataTypeName=char' = 'character',
           'DataTypeName=varchar' = 'character',
           'DataTypeName=nvarchar' = 'character',
           'DataTypeName=datetime' = 'character',
           'DataTypeName=int' = 'integer',
           'DataTypeName=smallint' = 'integer',
           'DataTypeName=real' = 'numeric',
           'DataTypeName=float' = 'numeric',
           'DataTypeName=decimal' = 'numeric'
           )
  })
  
  # convert each column that isn't character
  idx <- which(cc != 'character')
  for(f in idx) {
    df[, f] <- as(df[, f], cc[f])
  }
  ```

Waiting to hear back from Phil on additional datatypes to expect.

@brownag maybe you have a more clever approach.