### PR TITLE
get_phlabresults_data_from_NASIS_db(): Fix the weighted average of multiple records per horizon

### DIFF
--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -30,7 +30,21 @@
   if (nrow(hz_data) == 0) {
     stop('No site/pedons objects in local NASIS DB or selected set.', call. = FALSE)
   }
-
+  
+  ## https://github.com/ncss-tech/soilDB/issues/44
+  # optionally load phlabresults table
+  if (lab) {
+    phlabresults <- .get_phlabresults_data_from_NASIS_db(SS = SS, dsn = dsn)
+    
+    # TODO: perform phlabresults aggregation method(s) here
+    
+    hz_data <- merge(hz_data,
+                     phlabresults,
+                     by = c("peiid", "phiid"),
+                     all = TRUE,
+                     sort = FALSE)
+  }
+  
   # data that cannot be effectively flattened in SQL
 
   extended_data <- get_extended_data_from_NASIS_db(SS = SS,
@@ -259,13 +273,6 @@
   if (exists('top.bottom.equal', envir = soilDB.env))
     if (length(get('top.bottom.equal', envir = soilDB.env)) > 0)
       message("-> QC: equal hz top and bottom depths: use `get('top.bottom.equal', envir=soilDB.env)` for related pedon IDs")
-
-  ## https://github.com/ncss-tech/soilDB/issues/44
-  # optionally load phlabresults table
-  if (lab) {
-    phlabresults <- .get_phlabresults_data_from_NASIS_db(SS = SS)
-    horizons(hz_data) <- phlabresults
-  }
 
   # done
   return(hz_data)


### PR DESCRIPTION
Thanks to @hammerly who pointed out that weighted averaging of phlabresults wasn't working as expected and for highlighting some more possible improvements.

For examples, load upedonid: 1964IA113001, 1975IA045012.
Before:
``` r
f <- soilDB::fetchNASIS(rmHzErrors = TRUE, lab = TRUE)
#> Loading required namespace: odbc
#> mixing moist colors ... [14 of 42 horizons]
#> Warning: some records are missing rock fragment volume, these have been removed
#> Warning: all records are missing rock fragment volume (NULL). buffering result
#> with NA. will be converted to zero if nullFragsAreZero = TRUE.
#> Warning: some records are missing artifact volume, these have been removed
#> Warning: all records are missing artifact volume (NULL). buffering result with
#> NA. will be converted to zero if nullFragsAreZero = TRUE.
#> original data (24 rows) new data (28 rows)
#> Error: invalid horizons left join condition, data not changed
aqp::checkHzDepthLogic(f)
#> Error in stopifnot(inherits(x, "SoilProfileCollection") | inherits(x, : object 'f' not found
```

The join error reported is
```
original data (24 rows) new data (28 rows)
Error: invalid horizons left join condition, data not changed
```

After this PR:
``` r
f <- soilDB::fetchNASIS(rmHzErrors = TRUE, lab = TRUE)
#> Loading required namespace: odbc
#> mixing moist colors ... [14 of 42 horizons]
#> NOTICE: multiple phiid values exist in the `phlabresults` table, computing weighted averages and dominant values based on horizon thickness
#> Warning: some records are missing rock fragment volume, these have been removed
#> Warning: all records are missing rock fragment volume (NULL). buffering result
#> with NA. will be converted to zero if nullFragsAreZero = TRUE.
#> Warning: some records are missing artifact volume, these have been removed
#> Warning: all records are missing artifact volume (NULL). buffering result with
#> NA. will be converted to zero if nullFragsAreZero = TRUE.

aqp::checkHzDepthLogic(f)
#>     peiid valid depthLogic sameDepth missingDepth overlapOrGap
#> 1 1418603  TRUE      FALSE     FALSE        FALSE        FALSE
#> 2 1418605  TRUE      FALSE     FALSE        FALSE        FALSE
```
Note the notice:
```
NOTICE: multiple phiid values exist in the `phlabresults` table, computing weighted averages and dominant values based on horizon thickness
```

---

## Explanation

As it it stands `aqp::horizons()<-` does not allow the user to "duplicate" horizons by joining. This issue with `lab=TRUE` was probably introduced when we moved over to using aqp for most of the joins to the pre-built SoilProfileCollection and the internal logic/order of joins in `fetchNASIS()` was changed.

One can create a new SPC with horizon data that has errors in it, but you shouldn't* be able to create errors by joining where there weren't already errors. 

It appears that a the basics of weighted averaging logic were already present in `.get_phlabresults_data_from_NASIS_db()` but did not ever get called because of horizon ID column name for checking duplication hard coded as "phiidref" as opposed to "phiid". This PR provisionally fixes that unreachable code and adjusts several other things to create a reduced set of records that is 1:1 with phiid. There are more improvements that @hammerly suggested in #192 that can be incorporated now that this is fixed.
