### PR TITLE
 SDA_spatialQuery: add support for sapolygon/areasymbol results

### DIFF
--- a/R/SDA-spatial.R
+++ b/R/SDA-spatial.R
@@ -371,6 +371,7 @@ SDA_spatialQuery <- function(geom,
  
   # backwards compatibility with old value of what argument 
   if (what == 'geom') {
+    message("converting what='geom' to what='mupolygon'")
     what <- "mupolygon"
   }
   
@@ -404,13 +405,13 @@ SDA_spatialQuery <- function(geom,
   }
   
   # geom must have a valid CRS
-  if(is.na(proj4string(geom))) {
+  if (is.na(suppressWarnings(proj4string(geom)))) {
     stop('`geom` must have a valid CRS', call. = FALSE)
   }
   
   # CRS conversion if needed
   target.prj <- "+proj=longlat +datum=WGS84"
-  if(proj4string(geom) != target.prj) {
+  if (suppressWarnings(proj4string(geom)) != target.prj) {
     geom <- spTransform(geom, CRS(target.prj))
   }
   

--- a/man/SDA_spatialQuery.Rd
+++ b/man/SDA_spatialQuery.Rd
@@ -10,16 +10,18 @@ SDA_spatialQuery(
   geom,
   what = "mukey",
   geomIntersection = FALSE,
-  db = c("SSURGO", "STATSGO")
+  db = c("SSURGO", "STATSGO", "SAPOLYGON")
 )
 }
 \arguments{
 \item{geom}{a Spatial* object, with valid CRS. May contain multiple
 features.}
 
-\item{what}{a character vector specifying what to return. 'mukey':
-\code{data.frame} with intersecting map unit keys and names, \code{geom}
-overlapping or intersecting map unit polygons}
+\item{what}{a character vector specifying what to return. \code{'mukey'}:
+\code{data.frame} with intersecting map unit keys and names, \code{'mupolygon'}
+overlapping or intersecting map unit polygons from selected database, \code{'areasymbol'}:
+\code{data.frame} with intersecting soil survey areas, \code{'sapolygon'}:
+overlapping or intersecting soil survey area polygons (SSURGO only)}
 
 \item{geomIntersection}{logical; \code{FALSE}: overlapping map unit polygons
 returned, \code{TRUE}: intersection of \code{geom} + map unit polygons is
@@ -27,7 +29,7 @@ returned.}
 
 \item{db}{a character vector identifying the Soil Geographic Databases
 ('SSURGO' or 'STATSGO') to query. Option \var{STATSGO} currently works only
-in combination with \code{what = "geom"}.}
+in combination with \code{what = "mupolygon"}.}
 }
 \value{
 A \code{data.frame} if \code{what = 'mukey'}, otherwise
@@ -44,9 +46,7 @@ returned. See details.
 Queries for map unit keys are always more efficient vs. queries for
 overlapping or intersecting (i.e. least efficient) features. \code{geom} is
 converted to GCS / WGS84 as needed. Map unit keys are always returned when
-using \code{what = "geom"}.
-
-There is a 100,000 record limit and 32Mb JSON serializer limit, per query.
+using \code{what = "mupolygon"}.
 
 SSURGO (detailed soil survey, typically 1:24,000 scale) and STATSGO
 (generalized soil survey, 1:250,000 scale) data are stored together within

--- a/tests/testthat/test-SDA_query.R
+++ b/tests/testthat/test-SDA_query.R
@@ -77,7 +77,13 @@ test_that("SDA_spatialQuery() simple spatial query, tabular results", {
   expect_true(inherits(res, 'data.frame'))
   expect_equal(nrow(res), 1)
   expect_match(res$muname, 'Diablo')
-
+  
+  # test with what = "sapolygon" 
+  res <- suppressWarnings(SDA_spatialQuery(p, what = "areasymbol"))
+  expect_true(inherits(res, 'data.frame'))
+  expect_equal(nrow(res), 1)
+  expect_match(res$areasymbol, 'CA641')
+  
 })
 
 
@@ -98,6 +104,13 @@ test_that("SDA_spatialQuery() simple spatial query, spatial results", {
   # test with db = "STATSGO"
   res <- suppressWarnings(SDA_spatialQuery(p, what = 'geom', db = "STATSGO"))
 
+  # testing known values
+  expect_true(inherits(res, 'SpatialPolygonsDataFrame'))
+  expect_equal(nrow(res), 1)
+  
+  # test with what = "sapolygon" 
+  res <- suppressWarnings(SDA_spatialQuery(p, what = "sapolygon"))
+  
   # testing known values
   expect_true(inherits(res, 'SpatialPolygonsDataFrame'))
   expect_equal(nrow(res), 1)


### PR DESCRIPTION
This PR adds support in `SDA_spatialQuery()` to get results from the `sapolygon` table. Works with both "intersection" and "overlap" methods.

For example -- get all survey areas in MLRA 22A, using the MLRA boundary as `geom` "query feature"

``` r
library(sp)
library(soilDB)

mlra <- rgdal::readOGR("F:/Geodata/soils/MLRA_Boundaries_CA/mlra_a_ca.shp")
#> OGR data source with driver: ESRI Shapefile 
#> Source: "F:\Geodata\soils\MLRA_Boundaries_CA\mlra_a_ca.shp", layer: "mlra_a_ca"
#> with 59 features
#> It has 12 fields
#> Integer64 fields read as strings:  OBJECTID_1 OBJECTID
mlra <- spTransform(mlra, "EPSG:4326")

# get SSAs in 22A
mlra22a <- subset(mlra, MLRARSYM == "22A")

# get tabular result (just areasymbols)
res1 <- SDA_spatialQuery(mlra22a, what = "areasymbol")

# get geometry result (full sapolygon)
res2 <- SDA_spatialQuery(mlra22a, what = "sapolygon")

# get geometry result (clipped)
res3 <- SDA_spatialQuery(mlra22a, what = "sapolygon", geomIntersection = TRUE)

# compare
par(mar=c(0,0,0,0), mfrow=c(1,2))
plot(res2)
plot(mlra22a, add=TRUE, lwd=3, border="RED")
plot(res3)
plot(mlra22a, add=TRUE, lwd=3, border="RED")
```

![](https://i.imgur.com/bhVkVbR.png)

Minor other changes:

 - `what='geom'` has been superseded by `what='mupolygon'` (works with SSURGO or STATSGO); this helps distinguish from `sapolygon` geometric results and the input argument which is also called `geom`. `what='geom'` is converted to `'mupolygon'` with a message
 - suppress warnings from `proj4string()`