### PR TITLE
fetchNASIS: Implement `fill` argument for NASIS pedons

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.6.3
+Version: 2.6.4
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov"),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# soilDB 2.6.4 (2021-07-23)
+ * `fetchNASIS(from="pedons")` now supports `fill=TRUE` argument just like `from="components"` to include pedons that have no horizon records
+ 
 # soilDB 2.6.3 (2021-07-16)
  * `SDA_query()` and all functions that call `SDA_query()` get proper column class handling (related to #190), however:
    - be careful with the use of CAST(): unknown datatypes may not be correctly interpreted

--- a/R/fetchNASIS.R
+++ b/R/fetchNASIS.R
@@ -63,8 +63,7 @@
 #' convenience field `soil_color`? (`'moist'` or `'dry'`)
 #' @param lab should the `phlabresults` child table be fetched with
 #' site/pedon/horizon data (default: `FALSE`)
-#' @param fill (`fetchNASIS(from='components')` only: include component records
-#' without horizon data in result? (default: `FALSE`)
+#' @param fill include pedon or component records without horizon data in result? (default: `FALSE`)
 #' @param stringsAsFactors logical: should character vectors be converted to
 #' factors? This argument is passed to the `uncode()` function. It does not
 #' convert those vectors that have been set outside of `uncode()` (i.e. hard
@@ -74,7 +73,7 @@
 #' @return A SoilProfileCollection object
 #' @author D. E. Beaudette, J. M. Skovlin, S.M. Roecker, A.G. Brown
 #' @export fetchNASIS
-fetchNASIS <- function(from='pedons',
+fetchNASIS <- function(from = 'pedons',
                        url = NULL,
                        SS = TRUE,
                        rmHzErrors = TRUE,
@@ -103,6 +102,7 @@ fetchNASIS <- function(from='pedons',
   if (from == 'pedons') {
     # pass arguments through
     res <- .fetchNASIS_pedons(SS = SS,
+                              fill = fill, 
                               rmHzErrors = rmHzErrors,
                               nullFragsAreZero = nullFragsAreZero,
                               soilColorState = soilColorState,

--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -83,6 +83,7 @@
   }
 
   #  aqp uses data.table for efficient logic checking
+  filled.ids <- character(0)
   if (rmHzErrors) {
 
     # get overall validity (combination of 4 logic tests applied to each peiid)
@@ -90,7 +91,6 @@
     
     # fill=TRUE adds horizons with NA phiid will have NA depths -- will not pass logic check
     filled.idx <- which(is.na(hz_data$phiid))
-    filled.ids <- character(0)
     if(length(filled.idx) > 0) {
       filled.ids <- as.character(hz_data$peiid[filled.idx])
       #print(dput(filled.ids))

--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -2,6 +2,7 @@
 
 # get NASIS site/pedon/horizon/diagnostic feature data
 .fetchNASIS_pedons <- function(SS = TRUE,
+                               fill = FALSE,
                                rmHzErrors = TRUE,
                                nullFragsAreZero = TRUE,
                                soilColorState = 'moist',
@@ -22,7 +23,8 @@
   # these fail gracefully when no data in local DB | selected set
   site_data  <- get_site_data_from_NASIS_db(SS = SS, stringsAsFactors = stringsAsFactors,
                                             dsn = dsn)
-  hz_data    <- get_hz_data_from_NASIS_db(SS = SS, stringsAsFactors = stringsAsFactors,
+  hz_data    <- get_hz_data_from_NASIS_db(SS = SS, fill = fill, 
+                                          stringsAsFactors = stringsAsFactors,
                                           dsn = dsn)
   color_data <- get_colors_from_NASIS_db(SS = SS, dsn = dsn)
 
@@ -85,19 +87,33 @@
 
     # get overall validity (combination of 4 logic tests applied to each peiid)
     h.test <- aqp::checkHzDepthLogic(hz_data, c("hzdept","hzdepb"), "peiid", fast = TRUE)
-
+    
+    # fill=TRUE adds horizons with NA phiid will have NA depths -- will not pass logic check
+    filled.idx <- which(is.na(hz_data$phiid))
+    filled.ids <- character(0)
+    if(length(filled.idx) > 0) {
+      filled.ids <- as.character(hz_data$peiid[filled.idx])
+      #print(dput(filled.ids))
+    }
+    
     # which are the good (valid) ones?
     good.ids <- as.character(h.test$peiid[which(h.test$valid)])
     bad.ids <- as.character(h.test$peiid[which(!h.test$valid)])
-    bad.horizons <- hz_data[which(!h.test$valid), c("peiid", "phiid",
-                                                    "pedon_id", "hzname",
-                                                    "hzdept", "hzdepb")]
+    bad.horizons <- hz_data[hz_data$peiid %in% h.test$peiid[which(!h.test$valid)], 
+                            c("peiid", "phiid", "pedon_id", "hzname", "hzdept", "hzdepb")]
     bad.pedon.ids <- site_data$pedon_id[which(site_data$peiid %in% bad.ids)]
-
+    
+    # handle fill=TRUE
+    if(length(filled.ids) > 0) {
+      good.ids <- unique(c(good.ids, filled.ids))
+      bad.ids <- unique(bad.ids[!bad.ids %in% filled.ids])
+    }
+    
     # optionally filter pedons WITH NO horizonation inconsistencies
-    if (rmHzErrors)
+    if (rmHzErrors) {
       hz_data <- hz_data[which(hz_data$peiid %in% good.ids), ]
-
+    }
+    
     # keep track of those pedons with horizonation errors
     assign('bad.pedon.ids', value = bad.pedon.ids, envir = soilDB.env)
     assign("bad.horizons", value = data.frame(bad.horizons), envir = soilDB.env)
@@ -245,18 +261,20 @@
     if (length(get('dup.pedon.ids', envir = soilDB.env)) > 0)
       message("-> QC: duplicate pedons: see `get('dup.pedon.ids', envir=soilDB.env)`")
 
-  # set NASIS-specific horizon identifier
-  tryCatch(hzidname(hz_data) <- 'phiid', error = function(e) {
-    if (grepl(e$message, pattern = "not unique$")) {
-       if (!rmHzErrors) {
-        # if rmHzErrors = FALSE, keep unique integer assigned ID to all records automatically
-        message("-> QC: duplicated horizons found! defaulting to `hzID` as unique horizon ID.")
-       } else {
-         stop(e)
-       }
+  # set NASIS component specific horizon identifier
+  if(!fill & length(filled.ids) == 0) {
+    res <- try(hzidname(hz_data) <- 'phiid')
+    if(inherits(res, 'try-error')) {
+      if(!rmHzErrors) {
+        warning("cannot set `phiid` as unique pedon horizon key -- duplicate horizons present with rmHzErrors=FALSE")
+      } else {
+        warning("cannot set `phiid` as unique pedon horizon key -- defaulting to `hzID`")
+      }
     }
-  })
-
+  } else {
+    warning("cannot set `phiid` as unique pedon horizon key - `NA` introduced by fill=TRUE", call.=F)
+  }
+  
   # set hz designation and texture fields -- NB: chose to use calculated texture -- more versatile
   # functions designed to use hztexclname() should handle presence of in-lieu, modifiers, etc.
   hzdesgnname(hz_data) <- "hzname"

--- a/R/get_hz_data_from_NASIS_db.R
+++ b/R/get_hz_data_from_NASIS_db.R
@@ -7,7 +7,9 @@
 #' Get horizon-level data from a local NASIS database.
 #'
 #' @param SS fetch data from Selected Set in NASIS or from the entire local database (default: `TRUE`)
-#'
+#' 
+#' @param fill include pedons without horizon data in result? default: `FALSE`
+#' 
 #' @param stringsAsFactors logical: should character vectors be converted to
 #' factors? This argument is passed to the `uncode()` function. It does not
 #' convert those vectors that have been set outside of `uncode()` (i.e. hard
@@ -26,10 +28,11 @@
 #' @keywords manip
 #' @export get_hz_data_from_NASIS_db
 get_hz_data_from_NASIS_db <- function(SS = TRUE,
+                                      fill = FALSE,
                                       stringsAsFactors = default.stringsAsFactors(),
                                       dsn = NULL) {
 
-  q <- "SELECT peiid, phiid, upedonid as pedon_id,
+  q <- sprintf("SELECT peiid, phiid, upedonid as pedon_id,
   hzname, dspcomplayerid as genhz, hzdept, hzdepb,
   bounddistinct, boundtopo,
   claytotest AS clay, CASE WHEN silttotest IS NULL THEN 100 - (claytotest + sandtotest) ELSE silttotest END AS silt,
@@ -38,7 +41,7 @@ get_hz_data_from_NASIS_db <- function(SS = TRUE,
   FROM
 
   pedon_View_1 p
-  INNER JOIN phorizon_View_1 ph ON ph.peiidref = p.peiid
+  %s JOIN phorizon_View_1 ph ON ph.peiidref = p.peiid
   LEFT OUTER JOIN phsample_View_1 phs ON phs.phiidref = ph.phiid
   LEFT OUTER JOIN
   (
@@ -47,7 +50,7 @@ get_hz_data_from_NASIS_db <- function(SS = TRUE,
   GROUP BY phiidref
   ) AS pht ON pht.phiidref = ph.phiid
 
-  ORDER BY p.upedonid, ph.hzdept ASC;"
+  ORDER BY p.upedonid, ph.hzdept ASC;", ifelse(fill, "LEFT", "INNER"))
 
   channel <- dbConnectNASIS(dsn)
 

--- a/man/fetchNASIS.Rd
+++ b/man/fetchNASIS.Rd
@@ -55,8 +55,7 @@ convenience field \code{soil_color}? (\code{'moist'} or \code{'dry'})}
 \item{lab}{should the \code{phlabresults} child table be fetched with
 site/pedon/horizon data (default: \code{FALSE})}
 
-\item{fill}{(\code{fetchNASIS(from='components')} only: include component records
-without horizon data in result? (default: \code{FALSE})}
+\item{fill}{include pedon or component records without horizon data in result? (default: \code{FALSE})}
 
 \item{stringsAsFactors}{logical: should character vectors be converted to
 factors? This argument is passed to the \code{uncode()} function. It does not

--- a/man/get_hz_data_from_NASIS_db.Rd
+++ b/man/get_hz_data_from_NASIS_db.Rd
@@ -6,12 +6,15 @@
 \usage{
 get_hz_data_from_NASIS_db(
   SS = TRUE,
+  fill = FALSE,
   stringsAsFactors = default.stringsAsFactors(),
   dsn = NULL
 )
 }
 \arguments{
 \item{SS}{fetch data from Selected Set in NASIS or from the entire local database (default: \code{TRUE})}
+
+\item{fill}{include pedons without horizon data in result? default: \code{FALSE}}
 
 \item{stringsAsFactors}{logical: should character vectors be converted to
 factors? This argument is passed to the \code{uncode()} function. It does not

--- a/tests/testthat/test-fetchNASIS.R
+++ b/tests/testthat/test-fetchNASIS.R
@@ -72,7 +72,13 @@ test_that("fetchNASIS(from='pedons') returns reasonable data", {
   expect_equal(any(is.na(x$total_frags_pct)), FALSE)
   expect_equal(any(is.na(x$total_frags_pct_nopf)), FALSE)
   expect_equal(any(is.na(x$fragvoltot)), FALSE)
-
+  
+  # make sure fill and rmHzErrors work without error
+  y <- suppressWarnings(fetchNASIS(from = 'pedons', fill = TRUE))
+  expect_true(inherits(y, 'SoilProfileCollection'))
+  
+  z <- suppressWarnings(fetchNASIS(from = 'pedons', fill = TRUE, rmHzErrors = FALSE))
+  expect_true(inherits(z, 'SoilProfileCollection'))
 })
 
 test_that("fetchNASIS(from='pedons') nullFragsAreZero works as expected", {


### PR DESCRIPTION
Closes #131; thanks to request from Julie Baker in 2-SON office

Having any depths be `NA` is an aqp/SoilProfileCollection depth logic error. Currently `fetchNASIS()` component filling checks for NA  `chiid` to identify permissible logic errors when `fill=TRUE` and `rmHzErrors=TRUE`. In the case of a "filled" SPC, it is not possible to set the unique horizon ID name because NA values are not allowed. Uses the default `hzID` integer calculated by aqp using ID-topdepth order.

Users of SoilProfileCollections must be aware of the need to check logic of the profiles in the collection before running relevant analyses. They can do this same way as is done in `fetchNASIS()` with `aqp::checkHzDepthLogic()`. Basic SPC operations, including `horizons<-` left join should work correctly in a filled SPC.

https://github.com/ncss-tech/soilDB/commit/d5f39b714f0b2d5d40eb9ad3859bdaf5cb863e70 implements `fill` argument that works for pedon data