### PR TITLE
createStaticNASIS / .dump_NASIS_table: column order 

### DIFF
--- a/R/createStaticNASIS.R
+++ b/R/createStaticNASIS.R
@@ -35,7 +35,10 @@
 
   # construct query and return result
   q <- sprintf("SELECT %s FROM %s", paste(allcols, collapse = ", "), table_name)
-  return(dbQueryNASIS(con, q))
+  res <- dbQueryNASIS(con, q)
+  
+  # put back into original order from NASIS
+  return(res[, match(colnames(res), columns$name)])
 }
 
 #' Create a memory or file-based instance of NASIS database


### PR DESCRIPTION
Column order should match NASIS, even if datatypes require reorder for ODBC driver / query. Thanks to @jskovlin who saw something and said something. This was a one-liner fix.

For background some versions of Microsoft ODBC driver require re-ordering of "long data" columns such that they occur last in the SELECT statement. With the default column orders in NASIS  `SELECT * FROM table` cannot be used for any table that contains a text field when the driver is {odbc} https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/getting-long-data?view=sql-server-ver15

For instance:

Microsoft ODBC Driver (_**SQL Server Native Client 11.0**_):
```r
soilDB::dbQueryNASIS(soilDB::NASIS(), "SELECT * FROM sitetext")
#> Loading required namespace: odbc
#> Error in result_fetch(res@ptr, n): nanodbc/nanodbc.cpp:3011: 07009: [Microsoft][SQL Server Native Client 11.0]Invalid Descriptor Index
```

Note that there is no error when using _**ODBC Driver 13 for SQL Server**_ but I am not sure that everyone has moved over to this driver. 

The `.dump_NASIS_table()` method used in `createStaticNASIS()` handles this error for cases where the entire table is being queried by moving varchar columns to the end of the query. Now the result is re-ordered to match the original table from NASIS.

