### PR TITLE
`get_SDA_pmgroupname()` and `get_SDA_hydric()` updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.6.5
+Version: 2.6.6
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov"),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 
@@ -19,5 +19,5 @@ Suggests: rgdal, jsonlite, httr, sf, rgeos, rvest, odbc, RSQLite,
 Repository: CRAN
 URL: http://ncss-tech.github.io/AQP/
 BugReports: https://github.com/ncss-tech/soilDB/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# soilDB 2.6.6 (2021-09-24)
+ * `get_SDA_pmgroupname()` and `get_SDA_hydric()` now support alternate aggregation methods. 
+   * Default for `get_SDA_pmgroupname()` is `"dominant component"`, now also supports `"dominant condition"` and `"none"`. 
+   * Default for `get_SDA_hydric()` is a map unit level aggregation of components and assigns new classes ; now supports `"dominant component"`, `"dominant condition"` and `"none"`
+
 # soilDB 2.6.5 (2021-08-19)
  * API calls that return geometry in projected coordinates (AEA/NAD83) now use ESPG:5070 instead of EPSG:6350
 

--- a/R/SDA_hydric.R
+++ b/R/SDA_hydric.R
@@ -3,59 +3,78 @@
 # last update: 2021/04/03
 
 #' Get map unit hydric soils information from Soil Data Access
+#' 
+#' Assess the hydric soils composition of a map unit. 
+#' 
+#' The default classes for `method="MAPUNIT"` are as follows:
+#'  - `'Nonhydric'` - no hydric components
+#'  - `'Hydric'` - all hydric components
+#'  - `'Predominantly Hydric'` - 50% or more of component proportion is hydric
+#'  - `'Partially Hydric'` - some proportion of the MAJOR components are hydric
+#'  - `'Predominantly Nonhydric'` - less than 50% of component proportion is hydric
+#'  
+#' The default result will also include the following summaries of component percentages: `total_comppct`, `hydric_majors` and `hydric_inclusions`.
+#' 
+#' @details Default `method` `"Mapunit"` produces aggregate summaries of all components in the mapunit. Use `"Dominant Component"`, `"Dominant Condition"` to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components). Use `"None"` for no aggregation (one record per component).
+#' 
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
+#' @param method One of: `"Mapunit"`, `"Dominant Component"`, `"Dominant Condition"`, `"None"`
+#' @param query_string Default: `FALSE`; if `TRUE` return a character string containing query that would be sent to SDA via `SDA_query`
 #' @author Jason Nemecek, Chad Ferguson, Andrew Brown
 #' @return a data.frame
 #' @export
 #' @importFrom soilDB format_SQL_in_statement SDA_query
-get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL) {
+get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL, method = "MAPUNIT", query_string = FALSE) {
+        
+        stopifnot(!is.null(areasymbols) | !is.null(mukeys))
+        
+        if (!is.null(areasymbols)) {
+                areasymbols <- soilDB::format_SQL_in_statement(areasymbols)
+        }
 
-stopifnot(!is.null(areasymbols) | !is.null(mukeys))
-
-if (!is.null(areasymbols))
-        areasymbols <- soilDB::format_SQL_in_statement(areasymbols)
-
-if (!is.null(mukeys))
-        mukeys <- soilDB::format_SQL_in_statement(mukeys)
-
-
-where_clause <- switch(as.character(is.null(areasymbols)),
-                       "TRUE" = sprintf("mu.mukey IN %s", mukeys),
-                       "FALSE" = sprintf("l.areasymbol IN %s", areasymbols))
-
-q <- sprintf("SELECT areasymbol,
+        if (!is.null(mukeys)) {
+                mukeys <- soilDB::format_SQL_in_statement(mukeys)
+        }
+        
+        method <- match.arg(toupper(method), c("MAPUNIT", "DOMINANT COMPONENT", "DOMINANT CONDITION", "NONE"))
+        
+        where_clause <- switch(as.character(is.null(areasymbols)),
+                               "TRUE" = sprintf("mu.mukey IN %s", mukeys),
+                               "FALSE" = sprintf("l.areasymbol IN %s", areasymbols))
+        
+        q <- sprintf("SELECT areasymbol,
         musym,
         muname,
         mu.mukey/1 AS mukey,
-        (SELECT TOP 1 COUNT_BIG(*)
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
-        INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey) AS comp_count,
-        (SELECT TOP 1 COUNT_BIG(*)
+        INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey) AS total_comppct,
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag = 'Yes') AS count_maj_comp,
-        (SELECT TOP 1 COUNT_BIG(*)
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating = 'Yes' ) AS all_hydric,
-        (SELECT TOP 1 COUNT_BIG(*)
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
-        AND majcompflag = 'Yes' AND hydricrating = 'Yes') AS maj_hydric,
-        (SELECT TOP 1 COUNT_BIG(*)
+        AND majcompflag = 'Yes' AND hydricrating = 'Yes') AS hydric_majors,
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag = 'Yes' AND hydricrating != 'Yes') AS maj_not_hydric,
-         (SELECT TOP 1 COUNT_BIG(*)
+         (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey=mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag != 'Yes' AND hydricrating  = 'Yes' ) AS hydric_inclusions,
-        (SELECT TOP 1 COUNT_BIG(*)
+        (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating  != 'Yes') AS all_not_hydric,
-         (SELECT TOP 1 COUNT_BIG(*)
+         (SELECT TOP 1 SUM(comppct_r)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating  IS NULL ) AS hydric_null
@@ -63,15 +82,52 @@ q <- sprintf("SELECT areasymbol,
         FROM legend AS l
         INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
 
-
         SELECT areasymbol, mukey, musym, muname,
-        CASE WHEN comp_count = all_not_hydric + hydric_null THEN  'Nonhydric'
-        WHEN comp_count = all_hydric  THEN 'Hydric'
-        WHEN comp_count != all_hydric AND count_maj_comp = maj_hydric THEN 'Predominantly Hydric'
-        WHEN hydric_inclusions >= 0.5 AND  maj_hydric < 0.5 THEN  'Predominantly Nonhydric'
-        WHEN maj_not_hydric >= 0.5  AND  maj_hydric >= 0.5 THEN 'Partially Hydric' ELSE 'Error' END AS HYDRIC_RATING
+               ISNULL(total_comppct, 0) AS total_comppct, 
+               ISNULL(hydric_majors, 0) AS hydric_majors, 
+               ISNULL(hydric_inclusions, 0) AS hydric_inclusions,
+        CASE WHEN total_comppct = all_not_hydric + hydric_null THEN 'Nonhydric'
+        WHEN total_comppct = all_hydric THEN 'Hydric'
+        WHEN ISNULL(hydric_majors, 0) + ISNULL(hydric_inclusions, 0) >= total_comppct / 2 THEN 'Predominantly Hydric'
+        WHEN  ISNULL(hydric_majors, 0) > 0 THEN 'Partially Hydric'
+        WHEN ISNULL(hydric_majors, 0) < total_comppct / 2 THEN 'Predominantly Nonhydric' 
+        ELSE 'Error' END AS HYDRIC_RATING
         FROM #main_query", where_clause)
-
+   
+        comp_selection <- ""
+        hyd_selection <- ""
+        if (method != "MAPUNIT") {
+           if (method %in% c("DOMINANT COMPONENT", "DOMINANT CONDITION")) {
+                   comp_selection <- "AND c.cokey =
+                (SELECT TOP 1 c1.cokey FROM component AS c1
+                 INNER JOIN mapunit AS mu1 ON c1.mukey = mu1.mukey AND c1.mukey = mu.mukey 
+                 ORDER BY c1.comppct_r DESC, c1.cokey)"
+           }
+           
+           if (method == "DOMINANT CONDITION") {
+                   hyd_selection <-
+                           "AND hydricrating = (SELECT TOP 1 hydricrating FROM mapunit
+                INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
+                GROUP BY hydricrating, comppct_r
+                ORDER BY SUM(comppct_r) over(partition by hydricrating) DESC)"
+           }
+           
+           q <- sprintf(paste0("SELECT areasymbol,
+                   musym,
+                   muname,
+                   mu.mukey, ",
+                   ifelse(method == "DOMINANT CONDITION", "", "cokey, compname, comppct_r, majcompflag, "),
+                   "hydricrating
+                 FROM legend l 
+           INNER JOIN mapunit mu ON mu.lkey = l.lkey 
+           INNER JOIN component c ON c.mukey = mu.mukey %s %s
+           WHERE %s"), comp_selection, hyd_selection, where_clause)
+   }
+        
+   if (query_string) {
+           return(q)
+   }
+        
    # execute query
    res <- soilDB::SDA_query(q)
 

--- a/R/SDA_hydric.R
+++ b/R/SDA_hydric.R
@@ -3,20 +3,20 @@
 # last update: 2021/04/03
 
 #' Get map unit hydric soils information from Soil Data Access
-#' 
-#' Assess the hydric soils composition of a map unit. 
-#' 
+#'
+#' Assess the hydric soils composition of a map unit.
+#'
 #' The default classes for `method="MAPUNIT"` are as follows:
-#'  - `'Nonhydric'` - no hydric components
-#'  - `'Hydric'` - all hydric components
-#'  - `'Predominantly Hydric'` - 50% or more of component proportion is hydric
-#'  - `'Partially Hydric'` - some proportion of the MAJOR components are hydric
-#'  - `'Predominantly Nonhydric'` - less than 50% of component proportion is hydric
-#'  
+#' - `'Nonhydric'` - no hydric components
+#' - `'Hydric'` - all hydric components
+#' - `'Predominantly Hydric'` - hydric component percentage is 50% or more
+#' - `'Partially Hydric'` - one or more of the major components is hydric
+#' - `'Predominantly Nonhydric'` - hydric component percentage is less than 50%
+#'
 #' The default result will also include the following summaries of component percentages: `total_comppct`, `hydric_majors` and `hydric_inclusions`.
-#' 
-#' @details Default `method` `"Mapunit"` produces aggregate summaries of all components in the mapunit. Use `"Dominant Component"`, `"Dominant Condition"` to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components). Use `"None"` for no aggregation (one record per component).
-#' 
+#'
+#' @details Default `method` `"Mapunit"` produces aggregate summaries of all components in the mapunit. Use `"Dominant Component"` and `"Dominant Condition"` to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components), respectively. Use `"None"` for no aggregation (one record per component).
+#'
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
 #' @param method One of: `"Mapunit"`, `"Dominant Component"`, `"Dominant Condition"`, `"None"`
@@ -26,9 +26,9 @@
 #' @export
 #' @importFrom soilDB format_SQL_in_statement SDA_query
 get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL, method = "MAPUNIT", query_string = FALSE) {
-        
+
         stopifnot(!is.null(areasymbols) | !is.null(mukeys))
-        
+
         if (!is.null(areasymbols)) {
                 areasymbols <- soilDB::format_SQL_in_statement(areasymbols)
         }
@@ -36,45 +36,45 @@ get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL, method = "MAPUNIT"
         if (!is.null(mukeys)) {
                 mukeys <- soilDB::format_SQL_in_statement(mukeys)
         }
-        
+
         method <- match.arg(toupper(method), c("MAPUNIT", "DOMINANT COMPONENT", "DOMINANT CONDITION", "NONE"))
-        
+
         where_clause <- switch(as.character(is.null(areasymbols)),
                                "TRUE" = sprintf("mu.mukey IN %s", mukeys),
                                "FALSE" = sprintf("l.areasymbol IN %s", areasymbols))
-        
+
         q <- sprintf("SELECT areasymbol,
         musym,
         muname,
         mu.mukey/1 AS mukey,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey) AS total_comppct,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag = 'Yes') AS count_maj_comp,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating = 'Yes' ) AS all_hydric,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag = 'Yes' AND hydricrating = 'Yes') AS hydric_majors,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag = 'Yes' AND hydricrating != 'Yes') AS maj_not_hydric,
-         (SELECT TOP 1 SUM(comppct_r)
+         (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey=mapunit.mukey AND mapunit.mukey = mu.mukey
         AND majcompflag != 'Yes' AND hydricrating  = 'Yes' ) AS hydric_inclusions,
-        (SELECT TOP 1 SUM(comppct_r)
+        (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating  != 'Yes') AS all_not_hydric,
-         (SELECT TOP 1 SUM(comppct_r)
+         (SELECT TOP 1 ISNULL(SUM(comppct_r), 0)
         FROM mapunit
         INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
         AND hydricrating  IS NULL ) AS hydric_null
@@ -83,27 +83,27 @@ get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL, method = "MAPUNIT"
         INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
 
         SELECT areasymbol, mukey, musym, muname,
-               ISNULL(total_comppct, 0) AS total_comppct, 
-               ISNULL(hydric_majors, 0) AS hydric_majors, 
-               ISNULL(hydric_inclusions, 0) AS hydric_inclusions,
+               total_comppct AS total_comppct,
+               hydric_majors AS hydric_majors,
+               hydric_inclusions AS hydric_inclusions,
         CASE WHEN total_comppct = all_not_hydric + hydric_null THEN 'Nonhydric'
         WHEN total_comppct = all_hydric THEN 'Hydric'
-        WHEN ISNULL(hydric_majors, 0) + ISNULL(hydric_inclusions, 0) >= total_comppct / 2 THEN 'Predominantly Hydric'
-        WHEN  ISNULL(hydric_majors, 0) > 0 THEN 'Partially Hydric'
-        WHEN ISNULL(hydric_majors, 0) < total_comppct / 2 THEN 'Predominantly Nonhydric' 
+        WHEN hydric_majors + hydric_inclusions >= total_comppct / 2 THEN 'Predominantly Hydric'
+        WHEN hydric_majors > 0 THEN 'Partially Hydric'
+        WHEN hydric_majors + hydric_inclusions < total_comppct / 2 THEN 'Predominantly Nonhydric'
         ELSE 'Error' END AS HYDRIC_RATING
         FROM #main_query", where_clause)
-   
+
         comp_selection <- ""
         hyd_selection <- ""
         if (method != "MAPUNIT") {
            if (method %in% c("DOMINANT COMPONENT", "DOMINANT CONDITION")) {
                    comp_selection <- "AND c.cokey =
                 (SELECT TOP 1 c1.cokey FROM component AS c1
-                 INNER JOIN mapunit AS mu1 ON c1.mukey = mu1.mukey AND c1.mukey = mu.mukey 
+                 INNER JOIN mapunit AS mu1 ON c1.mukey = mu1.mukey AND c1.mukey = mu.mukey
                  ORDER BY c1.comppct_r DESC, c1.cokey)"
            }
-           
+
            if (method == "DOMINANT CONDITION") {
                    hyd_selection <-
                            "AND hydricrating = (SELECT TOP 1 hydricrating FROM mapunit
@@ -111,23 +111,23 @@ get_SDA_hydric <- function(areasymbols = NULL, mukeys = NULL, method = "MAPUNIT"
                 GROUP BY hydricrating, comppct_r
                 ORDER BY SUM(comppct_r) over(partition by hydricrating) DESC)"
            }
-           
+
            q <- sprintf(paste0("SELECT areasymbol,
                    musym,
                    muname,
                    mu.mukey, ",
                    ifelse(method == "DOMINANT CONDITION", "", "cokey, compname, comppct_r, majcompflag, "),
                    "hydricrating
-                 FROM legend l 
-           INNER JOIN mapunit mu ON mu.lkey = l.lkey 
+                 FROM legend l
+           INNER JOIN mapunit mu ON mu.lkey = l.lkey
            INNER JOIN component c ON c.mukey = mu.mukey %s %s
            WHERE %s"), comp_selection, hyd_selection, where_clause)
    }
-        
+
    if (query_string) {
            return(q)
    }
-        
+
    # execute query
    res <- soilDB::SDA_query(q)
 

--- a/man/get_SDA_hydric.Rd
+++ b/man/get_SDA_hydric.Rd
@@ -31,14 +31,14 @@ The default classes for \code{method="MAPUNIT"} are as follows:
 \itemize{
 \item \code{'Nonhydric'} - no hydric components
 \item \code{'Hydric'} - all hydric components
-\item \code{'Predominantly Hydric'} - 50\% or more of component proportion is hydric
-\item \code{'Partially Hydric'} - some proportion of the MAJOR components are hydric
-\item \code{'Predominantly Nonhydric'} - less than 50\% of component proportion is hydric
+\item \code{'Predominantly Hydric'} - hydric component percentage is 50\% or more
+\item \code{'Partially Hydric'} - one or more of the major components is hydric
+\item \code{'Predominantly Nonhydric'} - hydric component percentage is less than 50\%
 }
 
 The default result will also include the following summaries of component percentages: \code{total_comppct}, \code{hydric_majors} and \code{hydric_inclusions}.
 
-Default \code{method} \code{"Mapunit"} produces aggregate summaries of all components in the mapunit. Use \code{"Dominant Component"}, \code{"Dominant Condition"} to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components). Use \code{"None"} for no aggregation (one record per component).
+Default \code{method} \code{"Mapunit"} produces aggregate summaries of all components in the mapunit. Use \code{"Dominant Component"} and \code{"Dominant Condition"} to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components), respectively. Use \code{"None"} for no aggregation (one record per component).
 }
 \author{
 Jason Nemecek, Chad Ferguson, Andrew Brown

--- a/man/get_SDA_hydric.Rd
+++ b/man/get_SDA_hydric.Rd
@@ -4,18 +4,41 @@
 \alias{get_SDA_hydric}
 \title{Get map unit hydric soils information from Soil Data Access}
 \usage{
-get_SDA_hydric(areasymbols = NULL, mukeys = NULL)
+get_SDA_hydric(
+  areasymbols = NULL,
+  mukeys = NULL,
+  method = "MAPUNIT",
+  query_string = FALSE
+)
 }
 \arguments{
 \item{areasymbols}{vector of soil survey area symbols}
 
 \item{mukeys}{vector of map unit keys}
+
+\item{method}{One of: \code{"Mapunit"}, \code{"Dominant Component"}, \code{"Dominant Condition"}, \code{"None"}}
+
+\item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 }
 \value{
 a data.frame
 }
 \description{
-Get map unit hydric soils information from Soil Data Access
+Assess the hydric soils composition of a map unit.
+}
+\details{
+The default classes for \code{method="MAPUNIT"} are as follows:
+\itemize{
+\item \code{'Nonhydric'} - no hydric components
+\item \code{'Hydric'} - all hydric components
+\item \code{'Predominantly Hydric'} - 50\% or more of component proportion is hydric
+\item \code{'Partially Hydric'} - some proportion of the MAJOR components are hydric
+\item \code{'Predominantly Nonhydric'} - less than 50\% of component proportion is hydric
+}
+
+The default result will also include the following summaries of component percentages: \code{total_comppct}, \code{hydric_majors} and \code{hydric_inclusions}.
+
+Default \code{method} \code{"Mapunit"} produces aggregate summaries of all components in the mapunit. Use \code{"Dominant Component"}, \code{"Dominant Condition"} to get the dominant component (highest percentage) or dominant hydric condition (similar conditions aggregated across components). Use \code{"None"} for no aggregation (one record per component).
 }
 \author{
 Jason Nemecek, Chad Ferguson, Andrew Brown

--- a/man/get_SDA_pmgroupname.Rd
+++ b/man/get_SDA_pmgroupname.Rd
@@ -4,20 +4,33 @@
 \alias{get_SDA_pmgroupname}
 \title{Get map unit parent material group information from Soil Data Access}
 \usage{
-get_SDA_pmgroupname(areasymbols = NULL, mukeys = NULL, simplify = TRUE)
+get_SDA_pmgroupname(
+  areasymbols = NULL,
+  mukeys = NULL,
+  method = "DOMINANT COMPONENT",
+  simplify = TRUE,
+  query_string = FALSE
+)
 }
 \arguments{
 \item{areasymbols}{vector of soil survey area symbols}
 
 \item{mukeys}{vector of map unit keys}
 
+\item{method}{One of: \code{"Dominant Component"}, \code{"Dominant Condition"}, \code{"None"}}
+
 \item{simplify}{logical; group into generalized parent material groups? Default \code{TRUE}}
+
+\item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 }
 \value{
 a data.frame
 }
 \description{
-Uses "Dominant Component" aggregation method.
+Get map unit parent material group information from Soil Data Access
+}
+\details{
+Default \code{method} is \code{"Dominant Component"} to get the dominant component (highest percentage). Use \code{"Dominant Condition"} or dominant parent material condition (similar conditions aggregated across components). Use \code{"None"} for no aggregation (one record per component).
 }
 \author{
 Jason Nemecek, Chad Ferguson, Andrew Brown

--- a/tests/testthat/test-SDA_hydric.R
+++ b/tests/testthat/test-SDA_hydric.R
@@ -9,4 +9,8 @@ test_that("get_SDA_hydric works", {
 
   # by mukey
   expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995))), 2)
+  
+  expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "none")), 11)
+  expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant component")), 2)
+  expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant condition")), 2)
 })

--- a/tests/testthat/test-SDA_hydric.R
+++ b/tests/testthat/test-SDA_hydric.R
@@ -5,11 +5,16 @@ test_that("get_SDA_hydric works", {
   skip_on_cran()
 
   # by areasymbol
-  expect_equal(nrow(get_SDA_hydric(areasymbols = c("CA077", "CA630"))), 313)
+  x <- get_SDA_hydric(areasymbols = c("CA077", "CA630"))
+  expect_equal(nrow(x), 313)
+
+  # check classification of mapunits
+  x.nonhydric <- subset(x, x$HYDRIC_RATING == "Nonhydric")
+  expect_equal(nrow(x.nonhydric), 171)
+  expect_true(all(x.nonhydric$hydric_majors == 0 & x.nonhydric$hydric_inclusions == 0))
 
   # by mukey
   expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995))), 2)
-  
   expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "none")), 11)
   expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant component")), 2)
   expect_equal(nrow(get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant condition")), 2)

--- a/tests/testthat/test-SDA_pmgroupname.R
+++ b/tests/testthat/test-SDA_pmgroupname.R
@@ -5,4 +5,6 @@ test_that("get_SDA_pmgroupname works", {
 
   expect_equal(nrow(get_SDA_pmgroupname(areasymbols = c("CA077", "CA630"))), 292)
   expect_equal(nrow(get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE)), 2)
+  expect_equal(nrow(get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE, method = "none")), 7)
+  expect_equal(nrow(get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE, method = "dominant condition")), 2)
 })


### PR DESCRIPTION
`get_SDA_pmgroupname()`: added support for alternate aggregation methods (dominant condition, none)
 - also: fix bug with "mixed" -> "miscellaneous deposits" having too high of precedence

`get_SDA_hydric()`: overhauled logic to use component _percentage_ not _counts_, and added better explanation of derived mapunit-level classes. Also support alternate aggregation methods (dominant component, dominant condition, none)

The default classes for `method="MAPUNIT"` are as follows:
 - `'Nonhydric'` - no hydric components
 - `'Hydric'` - all hydric components
 - `'Predominantly Hydric'` - hydric component percentage is 50% or more
 - `'Partially Hydric'` - one or more of the major components is hydric
 - `'Predominantly Nonhydric'` - hydric component percentage is less than 50%

Added `query_string` argument to both methods.