### PR TITLE
get_OSD: Handle "NA" and type conversion  

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,7 +8,7 @@ importFrom("stats", "aggregate", "complete.cases", "na.omit", "as.formula", "spl
 
 importFrom("utils", "URLencode", "download.file", "object.size",
              "read.csv", "read.table", "setTxtProgressBar",
-             "txtProgressBar", "write.table")
+             "txtProgressBar", "write.table", "type.convert")
 
 importFrom("methods", "slot<-", "as")
 

--- a/R/get_OSD.R
+++ b/R/get_OSD.R
@@ -152,9 +152,10 @@ get_OSD_JSON <- function(series, base_url = NULL) {
     res$HORIZONS <- list(data.frame(data.table::rbindlist(lapply(jsp$HORIZONS[[1]], data.frame), fill = TRUE)))
 
     # replace NAs ( from toJSON(na='string') )
-    res[res == "NA"] <- NA_character_
-    res$SITE[[1]][res$SITE[[1]] == "NA"] <- NA_character_
-    res$HORIZONS[[1]][res$HORIZONS[[1]] == "NA"] <- NA_character_
+    # handle type conversion (mixed NA/numerics will be CHARACTER without conversion)
+    res <- type.convert(res, na.strings = "NA", as.is = TRUE)
+    res$SITE[[1]] <- type.convert(res$SITE[[1]], na.strings = "NA", as.is = TRUE)
+    res$HORIZONS[[1]] <- type.convert(res$HORIZONS[[1]], na.strings = "NA", as.is = TRUE)
 
     # handles weird cases
     if (inherits(res, 'try-error'))

--- a/R/get_OSD.R
+++ b/R/get_OSD.R
@@ -2,11 +2,11 @@
 #'
 #' @param series A character vector of Official Series names e.g. `"Chewacla"`
 #' @param result Select `"json"`, `"html"`, or `"txt"` output
-#' 
-#' @param base_url Optional: alternate JSON/HTML/TXT repository path. Default: `NULL` uses `"https://github.com/ncss-tech/SoilKnowledgeBase"` for `result="json"` 
-#' 
+#'
+#' @param base_url Optional: alternate JSON/HTML/TXT repository path. Default: `NULL` uses `"https://github.com/ncss-tech/SoilKnowledgeBase"` for `result="json"`
+#'
 #' @param verbose Print errors and warning messages related to HTTP requests? Default: `FALSE`
-#' 
+#'
 #' @details The default `base_url` for `result="json"` is to JSON files stored in a GitHub repository  that is regularly updated from the official source of Series Descriptions. Using format: `https://raw.githubusercontent.com/ncss-tech/SoilKnowledgeBase/main/inst/extdata/OSD/{LETTER}/{SERIES}.json` for JSON. And `"https://soilseriesdesc.sc.egov.usda.gov/OSD_Docs/{LETTER}/{SERIES}.html` is for `result="html"` (official source).
 #'
 #' @return For JSON result: A `data.frame` with 1 row per series, and 1 column per "section" in the OSD as defined in National Soil Survey Handbook. For TXT or HTML result a list of character vectors containing OSD text with 1 element per series and one value per line.
@@ -17,20 +17,20 @@
 #' \donttest{
 #' if(requireNamespace("curl") &
 #'    curl::has_internet()) {
-#'    
+#'
 #' series <- c("Musick", "Hector", "Chewacla")
 #' get_OSD(series)
 #' }
 #' }
 get_OSD <- function(series, base_url = NULL, result = c("json","html","txt"), verbose = FALSE) {
   result <- match.arg(tolower(result), c("json","html","txt"))
-  
+
   a_url <- NULL
   if (!is.null(base_url)) {
     a_url <- base_url
   }
-  
-  switch(result, 
+
+  switch(result,
          "json" = { .get_OSD_JSON(series, base_url = a_url, verbose = verbose) },
          "html" = { .get_OSD_HTML(series, base_url = a_url, verbose = verbose) },
          "txt" =  { .get_OSD_TXT(series, verbose = verbose)  })
@@ -43,47 +43,47 @@ get_OSD <- function(series, base_url = NULL, result = c("json","html","txt"), ve
 .get_OSD_HTML <- function(series, base_url = NULL, verbose = FALSE) {
   if(!requireNamespace('rvest', quietly=TRUE))
     stop('please install the `rvest` package', call.=FALSE)
-  
+
   if (missing(base_url) || is.null(base_url))
     base_url <- 'https://soilseriesdesc.sc.egov.usda.gov/OSD_Docs/'
-  
+
   # get HTML content and strip blank / NA lines
   res <- sapply(.seriesNameToURL(series, base_url = base_url), function(x) {
-    
+
     # if the URL is bad a warning with 404 will be generated
     u <- suppressWarnings(try(url(x, "rb"), silent = TRUE))
     if (inherits(u, 'try-error'))
       return(NULL)
-    
+
     # HTML results as xml_document
     html.raw <- rvest::read_html(u, silent = !verbose)
-    
+
     # close connection
     close(u)
-    
+
     ## not quite right, this removes the title but is otherwise a better candidate for future
     # # 2021-09-13: explicit conversion of &nbsp; -> simple white space
     # textResult <- rvest::html_text2(html.raw, preserve_nbsp = FALSE)
-    
+
     # NOTE: not enough line-breaks between Date and "<H1>XXX SERIES</H1>", lines are joined
     textResult <- rvest::html_text(html.raw)
-    
+
     # remove extra line-breaks and other cruft
     textResult <- .stripOSDContents(readLines(textConnection(textResult)))
-    
+
     # line 5 does not break after the date: "09/2021FRESNO SERIES"
     # repair it
     txt.part <- strsplit(textResult[5], "[0-9]+\\/[0-9]+")[[1]][2]
     date.part <- gsub(txt.part, '', textResult[5])
-    
+
     # correct contents of line 5
     textResult[5] <- date.part
-    
+
     # insert the correct contents of line 6, shift everything forwards
     c(textResult[1:5], txt.part, textResult[6:length(textResult)])
-    
+
   })
-  
+
   names(res) <- toupper(series)
   return(res)
 }
@@ -91,10 +91,10 @@ get_OSD <- function(series, base_url = NULL, result = c("json","html","txt"), ve
 .get_OSD_TXT <- function(series, base_url = "", verbose = FALSE) {
   sapply(series, function(x) {
     fp <- .seriesNameToURL(x, base_url = base_url, extension = "txt")
-    
+
     if (!file.exists(fp))
       return(NULL)
-    
+
     # remove empty lines and fix other markup
     try(.stripOSDContents(readLines(fp)), silent = !verbose)
   })
@@ -110,31 +110,31 @@ get_OSD_JSON <- function(series, base_url = NULL) {
   # http://github.com/ncss-tech/SoilKnowledgeBase is default JSON repository path
   if (missing(base_url) || is.null(base_url))
     base_url <- "https://raw.githubusercontent.com/ncss-tech/SoilKnowledgeBase/main/inst/extdata/OSD"
-  
+
   if (!requireNamespace("jsonlite"))
     stop("package `jsonlite` is required", call. = FALSE)
-  
+
   # convert series name to upper case and remove NA
   series <- toupper(na.omit(series))
-  
+
   # get first letter of each taxon (if any)
   if (length(series) > 0 && all(nchar(series) > 1)) {
     firstLetter <- substr(series, 0, 1)
   } else stop("argument `series` should be character vector of existing official series names", call. = FALSE)
-  
+
   # construct URL
   path <- file.path(base_url, firstLetter, paste0(series, ".json"))
-  
+
   # query, handle errors, return 'tidy' data.frame result
   data.frame(data.table::rbindlist(lapply(seq_along(path), function(i) {
-    
+
     p <- path[i]
     jsp <- try(jsonlite::read_json(p), silent = TRUE)
-    
+
     # warning will be generated for non-existent URL
     if (inherits(jsp, 'try-error'))
       return(NULL)
-    
+
     jspn <- names(jsp)[!names(jsp) %in% c('SITE','HORIZONS')]
     res <- try({
       data.table::as.data.table(lapply(jspn, function(m) {
@@ -146,18 +146,23 @@ get_OSD_JSON <- function(series, base_url = NULL) {
       }))
     }, silent = FALSE)
     colnames(res) <- jspn
-    
+
     jsp$SITE[[1]][[1]]$id <- i
     res$SITE <- list(data.frame(data.table::rbindlist(lapply(jsp$SITE[[1]], data.frame), fill = TRUE)))
     res$HORIZONS <- list(data.frame(data.table::rbindlist(lapply(jsp$HORIZONS[[1]], data.frame), fill = TRUE)))
-    
+
+    # replace NAs ( from toJSON(na='string') )
+    res[res == "NA"] <- NA_character_
+    res$SITE[[1]][res$SITE[[1]] == "NA"] <- NA_character_
+    res$HORIZONS[[1]][res$HORIZONS[[1]] == "NA"] <- NA_character_
+
     # handles weird cases
     if (inherits(res, 'try-error'))
       return(NULL)
-    
+
     return(res)
   })))
-  
+
 }
 
 ## Migrated / adapted from parseOSD repo
@@ -172,12 +177,12 @@ get_OSD_JSON <- function(series, base_url = NULL) {
 
 # prepare a file name and capitalized-first-letter folder based on a series name
 .seriesNameToFileName <- function(s, extension = 'txt') {
-  
+
   # convert space to _
   s <- gsub(pattern = ' ', replacement = '_', toupper(s))
-  
+
   # TODO: convert apostrophe
-  
+
   sprintf('%s/%s.%s', substr(s, 1, 1), s, extension)
 }
 
@@ -185,11 +190,11 @@ get_OSD_JSON <- function(series, base_url = NULL) {
 .stripOSDContents <- function(x) {
   x <- x[which(x != '')]
   x <- x[which(!is.na(x))]
-  
+
   gsub('"', ' inches', x)
-  
+
   # convert &nbsp; (\ua0) >- ' '
   res <- gsub('\ua0', ' ', x)
-  
+
   return(res)
 }


### PR DESCRIPTION
This PR adds support for the `na = 'string'` argument for `toJSON()` that will be new format (https://github.com/ncss-tech/SoilKnowledgeBase/pull/37) for missing data in SoilKnowledgeBase repo parsed OSD JSON. This addresses my concerns about type stability discussed in ncss-tech/SoilKnowledgeBase#35

Before:
``` r
x <- soilDB::get_OSD("AABAB", base_url = 'https://raw.githubusercontent.com/ncss-tech/SoilKnowledgeBase/1cdb0f08b1fd178a61e510837f024501d1bd94a1/inst/extdata/OSD')
#> Loading required namespace: jsonlite
str(x$HORIZONS)
#> List of 1
#>  $ :'data.frame':    7 obs. of  16 variables:
#>   ..$ name         : chr [1:7] "Oi" "A1" "A2" "Bw1" ...
#>   ..$ top          : int [1:7] 0 3 10 30 48 56 112
#>   ..$ bottom       : int [1:7] 3 10 30 48 56 112 155
#>   ..$ dry_hue      : chr [1:7] "NA" "10YR" "10YR" "10YR" ...
#>   ..$ dry_value    : chr [1:7] "NA" "5" "6" "6" ...
#>   ..$ dry_chroma   : chr [1:7] "NA" "4" "4" "4" ...
#>   ..$ moist_hue    : chr [1:7] "NA" "10YR" "10YR" "10YR" ...
#>   ..$ moist_value  : chr [1:7] "NA" "3" "4" "4" ...
#>   ..$ moist_chroma : chr [1:7] "NA" "4" "4" "4" ...
#>   ..$ texture_class: chr [1:7] "NA" "silt loam" "silt loam" "silty clay loam" ...
#>   ..$ cf_class     : chr [1:7] "NA" "NA" "NA" "NA" ...
#>   ..$ pH           : chr [1:7] "NA" "NA" "5.4" "5.4" ...
#>   ..$ pH_class     : chr [1:7] "NA" "moderately acid" "strongly acid" "strongly acid" ...
#>   ..$ distinctness : chr [1:7] "abrupt" "clear" "clear" "abrupt" ...
#>   ..$ topography   : chr [1:7] "smooth" "smooth" "wavy" "wavy" ...
#>   ..$ narrative    : chr [1:7] "Oi--0 to 1 inch; slightly decomposed deciduous leaves and twigs; abrupt smooth boundary." "A1--1 to 4 inches; dark yellowish brown (10YR 3/4) medial silt loam, yellowish brown (10YR 5/4) dry; moderate m"| __truncated__ "A2--4 to 12 inches; dark yellowish brown (10YR 4/4) medial silt loam, light yellowish brown (10YR 6/4) dry; mod"| __truncated__ "Bw1--12 to 19 inches; dark yellowish brown (10YR 4/4) silty clay loam, light yellowish brown (10YR 6/4) dry; fe"| __truncated__ ...
```

**Install this branch**
```r
remotes::install_github("ncss-tech/soilDB@get_OSD-nahandle", dependencies = FALSE)
```

After:
``` r
x <- soilDB::get_OSD("AABAB", base_url = 'https://raw.githubusercontent.com/ncss-tech/SoilKnowledgeBase/1cdb0f08b1fd178a61e510837f024501d1bd94a1/inst/extdata/OSD')
#> Loading required namespace: jsonlite
str(x$HORIZONS)
#> List of 1
#>  $ :'data.frame':    7 obs. of  16 variables:
#>   ..$ name         : chr [1:7] "Oi" "A1" "A2" "Bw1" ...
#>   ..$ top          : int [1:7] 0 3 10 30 48 56 112
#>   ..$ bottom       : int [1:7] 3 10 30 48 56 112 155
#>   ..$ dry_hue      : chr [1:7] NA "10YR" "10YR" "10YR" ...
#>   ..$ dry_value    : int [1:7] NA 5 6 6 7 7 7
#>   ..$ dry_chroma   : int [1:7] NA 4 4 4 2 3 2
#>   ..$ moist_hue    : chr [1:7] NA "10YR" "10YR" "10YR" ...
#>   ..$ moist_value  : int [1:7] NA 3 4 4 5 5 5
#>   ..$ moist_chroma : int [1:7] NA 4 4 4 3 4 1
#>   ..$ texture_class: chr [1:7] NA "silt loam" "silt loam" "silty clay loam" ...
#>   ..$ cf_class     : logi [1:7] NA NA NA NA NA NA ...
#>   ..$ pH           : num [1:7] NA NA 5.4 5.4 5.6 5.4 5.6
#>   ..$ pH_class     : chr [1:7] NA "moderately acid" "strongly acid" "strongly acid" ...
#>   ..$ distinctness : chr [1:7] "abrupt" "clear" "clear" "abrupt" ...
#>   ..$ topography   : chr [1:7] "smooth" "smooth" "wavy" "wavy" ...
#>   ..$ narrative    : chr [1:7] "Oi--0 to 1 inch; slightly decomposed deciduous leaves and twigs; abrupt smooth boundary." "A1--1 to 4 inches; dark yellowish brown (10YR 3/4) medial silt loam, yellowish brown (10YR 5/4) dry; moderate m"| __truncated__ "A2--4 to 12 inches; dark yellowish brown (10YR 4/4) medial silt loam, light yellowish brown (10YR 6/4) dry; mod"| __truncated__ "Bw1--12 to 19 inches; dark yellowish brown (10YR 4/4) silty clay loam, light yellowish brown (10YR 6/4) dry; fe"| __truncated__ ...
```
NB: cf_class has class logical when all NA, but type.convert() works for "NA" and other mixed columns (e.g. pH)

Try two OSDs, where only the second series has cf modifiers:

```r
x <- soilDB::get_OSD(c("AABAB", "ARPATUTU"), base_url = 'https://raw.githubusercontent.com/ncss-tech/SoilKnowledgeBase/1cdb0f08b1fd178a61e510837f024501d1bd94a1/inst/extdata/OSD')
str(x$HORIZONS)
#> List of 2
#>  $ :'data.frame':    7 obs. of  16 variables:
#>   ..$ name         : chr [1:7] "Oi" "A1" "A2" "Bw1" ...
#>   ..$ top          : int [1:7] 0 3 10 30 48 56 112
#>   ..$ bottom       : int [1:7] 3 10 30 48 56 112 155
#>   ..$ dry_hue      : chr [1:7] NA "10YR" "10YR" "10YR" ...
#>   ..$ dry_value    : int [1:7] NA 5 6 6 7 7 7
#>   ..$ dry_chroma   : int [1:7] NA 4 4 4 2 3 2
#>   ..$ moist_hue    : chr [1:7] NA "10YR" "10YR" "10YR" ...
#>   ..$ moist_value  : int [1:7] NA 3 4 4 5 5 5
#>   ..$ moist_chroma : int [1:7] NA 4 4 4 3 4 1
#>   ..$ texture_class: chr [1:7] NA "silt loam" "silt loam" "silty clay loam" ...
#>   ..$ cf_class     : logi [1:7] NA NA NA NA NA NA ...
#>   ..$ pH           : num [1:7] NA NA 5.4 5.4 5.6 5.4 5.6
#>   ..$ pH_class     : chr [1:7] NA "moderately acid" "strongly acid" "strongly acid" ...
#>   ..$ distinctness : chr [1:7] "abrupt" "clear" "clear" "abrupt" ...
#>   ..$ topography   : chr [1:7] "smooth" "smooth" "wavy" "wavy" ...
#>   ..$ narrative    : chr [1:7] "Oi--0 to 1 inch; slightly decomposed deciduous leaves and twigs; abrupt smooth boundary." "A1--1 to 4 inches; dark yellowish brown (10YR 3/4) medial silt loam, yellowish brown (10YR 5/4) dry; moderate m"| __truncated__ "A2--4 to 12 inches; dark yellowish brown (10YR 4/4) medial silt loam, light yellowish brown (10YR 6/4) dry; mod"| __truncated__ "Bw1--12 to 19 inches; dark yellowish brown (10YR 4/4) silty clay loam, light yellowish brown (10YR 6/4) dry; fe"| __truncated__ ...
#>  $ :'data.frame':    5 obs. of  16 variables:
#>   ..$ name         : chr [1:5] "A" "Bt1" "Bt2" "Bt3" ...
#>   ..$ top          : int [1:5] 0 5 18 40 71
#>   ..$ bottom       : int [1:5] 5 18 40 71 200
#>   ..$ dry_hue      : chr [1:5] "7.5YR" "7.5YR" "7.5YR" "7.5YR" ...
#>   ..$ dry_value    : int [1:5] 5 5 5 5 NA
#>   ..$ dry_chroma   : int [1:5] 3 3 4 4 NA
#>   ..$ moist_hue    : chr [1:5] "7.5YR" "7.5YR" "7.5YR" "7.5YR" ...
#>   ..$ moist_value  : int [1:5] 4 4 4 4 NA
#>   ..$ moist_chroma : int [1:5] 2 3 4 4 NA
#>   ..$ texture_class: chr [1:5] "loam" "loam" "loam" "clay loam" ...
#>   ..$ cf_class     : chr [1:5] NA NA "channery" "extremely flaggy" ...
#>   ..$ pH           : num [1:5] 5.6 5.4 5.4 5.4 NA
#>   ..$ pH_class     : chr [1:5] "moderately acid" "strongly acid" "strongly acid" "strongly acid" ...
#>   ..$ distinctness : chr [1:5] "abrupt" "clear" "abrupt" "very abrupt" ...
#>   ..$ topography   : chr [1:5] "smooth" "wavy" "wavy" "smooth" ...
#>   ..$ narrative    : chr [1:5] "A--0 to 5 cm; brown (7.5YR 5/3) loam, brown (7.5YR 4/2) moist; moderate fine granular structure; slightly hard,"| __truncated__ "Bt1--5 to 18 cm; brown (7.5YR 5/3) loam, brown (7.5YR 4/3) moist; moderate medium subangular blocky structure; "| __truncated__ "Bt2--18 to 40 cm; brown (7.5YR 5/4) channery loam, brown (7.5YR 4/4) moist; moderate medium subangular blocky s"| __truncated__ "Bt3--40 to 71 cm; brown (7.5YR 5/4) extremely flaggy clay loam, brown (7.5YR 4/4) moist; weak fine subangular b"| __truncated__ ...
```

After rbinding the $HORIZONS list of data.frame, the `cf_class` is _character_ (as it should be) not logical
```r
data.table::rbindlist(x$HORIZONS)
#>     name top bottom dry_hue dry_value dry_chroma moist_hue moist_value
#>  1:   Oi   0      3    <NA>        NA         NA      <NA>          NA
#>  2:   A1   3     10    10YR         5          4      10YR           3
#>  3:   A2  10     30    10YR         6          4      10YR           4
#>  4:  Bw1  30     48    10YR         6          4      10YR           4
#>  5:  Bw2  48     56    10YR         7          2      10YR           5
#>  6:  Bw3  56    112    10YR         7          3      10YR           5
#>  7:   Cg 112    155    2.5Y         7          2       5GY           5
#>  8:    A   0      5   7.5YR         5          3     7.5YR           4
#>  9:  Bt1   5     18   7.5YR         5          3     7.5YR           4
#> 10:  Bt2  18     40   7.5YR         5          4     7.5YR           4
#> 11:  Bt3  40     71   7.5YR         5          4     7.5YR           4
#> 12:    R  71    200    <NA>        NA         NA      <NA>          NA
#>     moist_chroma   texture_class         cf_class  pH        pH_class
#>  1:           NA            <NA>             <NA>  NA            <NA>
#>  2:            4       silt loam             <NA>  NA moderately acid
#>  3:            4       silt loam             <NA> 5.4   strongly acid
#>  4:            4 silty clay loam             <NA> 5.4   strongly acid
#>  5:            3       silt loam             <NA> 5.6 moderately acid
#>  6:            4 silty clay loam             <NA> 5.4   strongly acid
#>  7:            1 silty clay loam             <NA> 5.6 moderately acid
#>  8:            2            loam             <NA> 5.6 moderately acid
#>  9:            3            loam             <NA> 5.4   strongly acid
#> 10:            4            loam         channery 5.4   strongly acid
#> 11:            4       clay loam extremely flaggy 5.4   strongly acid
#> 12:           NA            <NA>             <NA>  NA            <NA>
#>     distinctness topography
#>  1:       abrupt     smooth
#>  2:        clear     smooth
#>  3:        clear       wavy
#>  4:       abrupt       wavy
#>  5:        clear       wavy
#>  6:        clear     smooth
#>  7:         <NA>       <NA>
#>  8:       abrupt     smooth
#>  9:        clear       wavy
#> 10:       abrupt       wavy
#> 11:  very abrupt     smooth
#> 12:         <NA>       <NA>
#>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               narrative
#>  1:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            Oi--0 to 1 inch; slightly decomposed deciduous leaves and twigs; abrupt smooth boundary.
#>  2:                                                                                                                                                                                                                                                                                                            A1--1 to 4 inches; dark yellowish brown (10YR 3/4) medial silt loam, yellowish brown (10YR 5/4) dry; moderate medium subangular blocky structure; hard, friable, slightly sticky and slightly plastic; common very fine and fine roots; many very fine tubular pores moderately acid (5.6); clear smooth boundary. (2 to 7 inches thick)
#>  3:                                                                                                                                                                                                                                                                              A2--4 to 12 inches; dark yellowish brown (10YR 4/4) medial silt loam, light yellowish brown (10YR 6/4) dry; moderate medium subangular blocky structure; hard, friable, slightly sticky and slightly plastic; common fine, medium, and coarse roots; many very fine and common fine tubular pores; strongly acid (pH 5.4); clear wavy boundary. (6 to 11 inches thick)
#>  4:                                                                                            Bw1--12 to 19 inches; dark yellowish brown (10YR 4/4) silty clay loam, light yellowish brown (10YR 6/4) dry; few fine and medium distinct grayish brown (10YR 5/2) redox depletions, light gray (10YR 7/2) dry, and common fine distinct yellowish red (5YR 4/6) redox concentrations, reddish yellow (5YR 6/8) dry; moderate coarse and very coarse prismatic structure; hard, firm, moderately sticky and slightly plastic; few fine roots; many very fine and fine tubular pores; strongly acid (pH 5.4); abrupt wavy boundary. (5 to 9 inches thick)
#>  5:                                                                                                                                                                                                                                       Bw2--19 to 22 inches; brown (10YR 5/3) silt loam, light gray (10YR 7/2) dry; common fine and medium distinct yellowish red (5YR 5/8) redox concentrations, reddish yellow (5YR 6/8) dry; moderate medium subangular blocky structure; hard, firm, moderately sticky and moderately plastic; few fine roots; few very fine tubular pores; moderately acid (pH 5.6); clear wavy boundary. (2 to 4 inches thick)
#>  6:                                                                         Bw3--22 to 44 inches; yellowish brown (10YR 5/4) silty clay loam, very pale brown (10YR 7/3) dry, many fine and medium distinct yellowish red (5YR 4/6) redox concentrations, yellowish red (5YR 5/8) dry; moderate very coarse prismatic structure parting to weak medium subangular blocky; hard, firm, moderately sticky and moderately plastic; few fine roots; many very fine and fine tubular pores; dark reddish brown (2.5YR 3/4) iron coatings on some peds, reddish brown (2.5YR 4/4) dry; strongly acid (pH 5.4); clear smooth boundary. (20 to 25 inches thick)
#>  7:                                                                                                                                                                                                                                                                                                                     Cg--44 to 61 inches; greenish gray (5GY 5/1) silty clay loam, light gray (2.5Y 7/2) dry; few fine distinct dark greenish gray (5BG 4/1) redox concentrations, not visible when dry; massive; very hard, very firm, moderately sticky and moderately plastic; common very fine and fine tubular pores; moderately acid (pH 5.6).
#>  8:                                                                                                                                                                                                                                                                                                       A--0 to 5 cm; brown (7.5YR 5/3) loam, brown (7.5YR 4/2) moist; moderate fine granular structure; slightly hard, friable, nonsticky, nonplastic; common very fine roots throughout; common very fine tubular pores; 3 percent subangular strongly cemented schist gravel; moderately acid (pH 5.6); abrupt smooth boundary. (2 to 20 cm thick)
#>  9:                                                                                                                                                                                Bt1--5 to 18 cm; brown (7.5YR 5/3) loam, brown (7.5YR 4/3) moist; moderate medium subangular blocky structure; slightly hard, friable, slightly sticky, nonplastic; many very fine and common fine roots throughout; common very fine tubular pores; 8 percent distinct clay films on all faces of peds; 10 percent subangular strongly cemented schist gravel; strongly acid (pH 5.4); clear wavy boundary. (Combined thickness of upper Bt horizons is 8 to 40 cm)
#> 10:                                                                                                          Bt2--18 to 40 cm; brown (7.5YR 5/4) channery loam, brown (7.5YR 4/4) moist; moderate medium subangular blocky structure; slightly hard, friable, moderately sticky, slightly plastic; common very fine, fine, and medium roots throughout, and common very coarse roots at top of horizon; common very fine tubular pores; 20 percent distinct clay films on all faces of peds; 25 percent angular strongly cemented schist channers, 5 percent angular strongly cemented schist flagstones; strongly acid (pH 5.4); abrupt wavy boundary.
#> 11: Bt3--40 to 71 cm; brown (7.5YR 5/4) extremely flaggy clay loam, brown (7.5YR 4/4) moist; weak fine subangular blocky structure; moderately hard, friable, moderately sticky, moderately plastic; common medium, coarse, and very coarse roots throughout; common very fine tubular pores; 25 percent prominent clay films on bottom surfaces of rock fragments and 40 percent distinct clay films on all faces of peds; 40 percent angular strongly cemented schist channers, 35 percent angular strongly cemented schist flagstones; strongly acid (pH 5.4); very abrupt smooth boundary. (Combined thickness of upper Bt horizons is 15 to 55 cm)
#> 12:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          R--71 to 200 cm; indurated schist bedrock.
```