### PR TITLE
get_SDA_property: MIN/MAX aggregation fixes

### DIFF
--- a/R/SDA_properties.R
+++ b/R/SDA_properties.R
@@ -9,10 +9,10 @@
 #' @param method one of: "Dominant Component (Category)", "Dominant Component (Numeric)", "Weighted Average", "MIN", "MAX", "Dominant Condition", or "None". If "None" is selected, the number of rows returned will depend on whether a component or horizon level property was selected, otherwise the result will be 1:1 with the number of map units.
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
-#' @param top_depth Default: `0` (centimeters); a numeric value for upper boundary (top depth) used only for method="weighted average" and "dominant component (numeric)"
-#' @param bottom_depth Default: `200` (centimeters); a numeric value for lower boundary (bottom depth) used only for method="weighted average" and "dominant component (numeric)"
+#' @param top_depth Default: `0` (centimeters); a numeric value for upper boundary (top depth) used only for method="Weighted Average", "Dominant Component (Numeric)", and "MIN/MAX"
+#' @param bottom_depth Default: `200` (centimeters); a numeric value for lower boundary (bottom depth) used only for method="Weighted Average", "Dominant Component (Numeric)", and "MIN/MAX"
 #' @param FUN Optional: character representing SQL aggregation function either "MIN" or "MAX" used only for method="min/max"; this argument is calculated internally if you specify `method="MIN"` or `method="MAX"`
-#' @param include_minors Include minor components in "Weighted Average" results?
+#' @param include_minors Include minor components in "Weighted Average" or "MIN/MAX" results?
 #' @param miscellaneous_areas Include miscellaneous areas  (non-soil components) in "Weighted Average", "MIN" or "MAX" results?
 #' @param query_string Default: `FALSE`; if `TRUE` return a character string containing query that would be sent to SDA via `SDA_query`
 #'
@@ -265,7 +265,7 @@ get_SDA_property <-
 .constructPropQuery <- function(method, property,
                                 areasymbols = NULL, mukeys = NULL,
                                 top_depth = 0, bottom_depth = 200, FUN = NULL,
-                                include_minors = FALSE, 
+                                include_minors = FALSE,
                                 miscellaneous_areas = FALSE) {
   # SQL by Jason Nemecek
 
@@ -353,18 +353,16 @@ get_SDA_property <-
     sprintf("(SELECT TOP 1 %s FROM mapunit
           INNER JOIN component ON component.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey %s
           GROUP BY %s, comppct_r ORDER BY SUM(comppct_r) over(partition by %s) DESC) AS %s",
-          property, 
-          ifelse(miscellaneous_areas, ""," AND component.compkind != 'Miscellaneous area'"), 
+          property,
+          ifelse(miscellaneous_areas, ""," AND component.compkind != 'Miscellaneous area'"),
           property, property, property)
   }
 
-  .property_min_max <- function(property, FUN) {
+  .property_min_max <- function(property, top_depth, bottom_depth, FUN) {
     sprintf("(SELECT TOP 1 %s(chm1.%s) FROM component AS cm1
-           INNER JOIN chorizon AS chm1 ON 
-            cm1.cokey = chm1.cokey 
-            AND cm1.cokey = c.cokey) AS %s",
-           FUN, property,
-           property)
+             INNER JOIN chorizon AS chm1 ON cm1.cokey = chm1.cokey AND cm1.cokey = c.cokey
+             WHERE chm1.hzdept_r BETWEEN %s AND %s OR chm1.hzdepb_r BETWEEN %s AND %s) AS %s",
+            FUN, property, top_depth, bottom_depth, top_depth, bottom_depth, property)
   }
 
   .property_weighted_average <- function(property, top_depth, bottom_depth, where_clause, dominant = FALSE, include_minors = FALSE, miscellaneous_areas = FALSE) {
@@ -375,7 +373,7 @@ get_SDA_property <-
             INTO #kitchensink
             FROM legend  AS lks
             INNER JOIN  mapunit AS muks ON muks.lkey = lks.lkey AND %s
-            SELECT mu1.mukey, cokey, comppct_r,  
+            SELECT mu1.mukey, cokey, comppct_r,
             SUM (comppct_r) OVER (PARTITION BY mu1.mukey) AS SUM_COMP_PCT
             INTO #comp_temp
             FROM legend AS l1
@@ -395,15 +393,15 @@ get_SDA_property <-
             INTO #main
             FROM legend AS l
             INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
-            INNER JOIN component AS c ON c.mukey = mu.mukey 
+            INNER JOIN component AS c ON c.mukey = mu.mukey
             INNER JOIN chorizon AS ch ON ch.cokey = c.cokey AND hzdepb_r >= %s AND hzdept_r <= %s
-            INNER JOIN chtexturegrp AS cht ON ch.chkey = cht.chkey 
+            INNER JOIN chtexturegrp AS cht ON ch.chkey = cht.chkey
             WHERE cht.rvindicator = 'yes' AND ch.hzdept_r IS NOT NULL
             ORDER BY areasymbol, musym, muname, mu.mukey, comppct_r DESC, cokey, hzdept_r, hzdepb_r
             %s",
             gsub("^(l|mu)\\.","\\1ks.", where_clause),
             gsub("^(l|mu)\\.","\\11.", where_clause),
-            ifelse(include_minors, "", "AND majcompflag = 'Yes'"), 
+            ifelse(include_minors, "", "AND majcompflag = 'Yes'"),
             ifelse(miscellaneous_areas, ""," AND c1.compkind != 'Miscellaneous area'"),
             ifelse(dominant, "            AND c1.cokey = (SELECT TOP 1 c2.cokey FROM component AS c2
                             INNER JOIN mapunit AS mm1 ON
@@ -456,7 +454,7 @@ paste0(sprintf("#last_step2.%s", property), collapse = ", ")))
     # dominant component numeric is a more specific case of weighted average
     .property_weighted_average(property, top_depth, bottom_depth, where_clause, dominant = TRUE, include_minors = FALSE, miscellaneous_areas = FALSE)
   }
-  
+
   # create query based on method
   switch(toupper(agg_method$method),
     # dominant component (category)
@@ -476,17 +474,17 @@ paste0(sprintf("#last_step2.%s", property), collapse = ", ")))
 
     "MIN/MAX" =
       sprintf("SELECT areasymbol, musym, muname, mu.mukey AS mukey, %s
-               FROM legend AS l
-               INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
-               LEFT JOIN component AS c ON c.mukey = mu.mukey AND 
-                                             c.cokey = (SELECT TOP 1 c1.cokey FROM component AS c1
-                                                        INNER JOIN mapunit ON c.mukey = mapunit.mukey AND
-                                                                              c1.mukey = mu.mukey
-                                                        %s
-                                                        ORDER BY c1.comppct_r DESC, c1.cokey)",
-              paste0(sapply(agg_property, function(x) .property_min_max(x, FUN = FUN)), collapse = ", "),
+               INTO #funagg
+                    FROM legend AS l
+                    INNER JOIN mapunit AS mu ON mu.lkey = l.lkey AND %s
+                    LEFT JOIN component AS c ON c.mukey = mu.mukey %s %s
+               SELECT areasymbol, musym, muname, mukey, %s FROM #funagg
+               GROUP BY areasymbol, musym, muname, mukey",
+              paste0(sapply(agg_property, function(x) .property_min_max(x, top_depth, bottom_depth, FUN = FUN)), collapse = ", "),
               where_clause,
-              ifelse(miscellaneous_areas, ""," AND c1.compkind != 'Miscellaneous area'")),
+              ifelse(include_minors, ""," AND c.majcompflag = 'Yes'"),
+              ifelse(miscellaneous_areas, ""," AND c.compkind != 'Miscellaneous area'"),
+              paste0(paste0(FUN, "(", agg_property, ") AS ", agg_property), collapse=",")),
 
     # dominant component (numeric) (.dominant_component_numeric handles vector agg_property)
     "DOMINANT COMPONENT (NUMERIC)" = .property_dominant_component_numeric(agg_property, top_depth, bottom_depth, where_clause),

--- a/man/get_SDA_property.Rd
+++ b/man/get_SDA_property.Rd
@@ -27,13 +27,13 @@ get_SDA_property(
 
 \item{mukeys}{vector of map unit keys}
 
-\item{top_depth}{Default: \code{0} (centimeters); a numeric value for upper boundary (top depth) used only for method="weighted average" and "dominant component (numeric)"}
+\item{top_depth}{Default: \code{0} (centimeters); a numeric value for upper boundary (top depth) used only for method="Weighted Average", "Dominant Component (Numeric)", and "MIN/MAX"}
 
-\item{bottom_depth}{Default: \code{200} (centimeters); a numeric value for lower boundary (bottom depth) used only for method="weighted average" and "dominant component (numeric)"}
+\item{bottom_depth}{Default: \code{200} (centimeters); a numeric value for lower boundary (bottom depth) used only for method="Weighted Average", "Dominant Component (Numeric)", and "MIN/MAX"}
 
 \item{FUN}{Optional: character representing SQL aggregation function either "MIN" or "MAX" used only for method="min/max"; this argument is calculated internally if you specify \code{method="MIN"} or \code{method="MAX"}}
 
-\item{include_minors}{Include minor components in "Weighted Average" results?}
+\item{include_minors}{Include minor components in "Weighted Average" or "MIN/MAX" results?}
 
 \item{miscellaneous_areas}{Include miscellaneous areas  (non-soil components) in "Weighted Average", "MIN" or "MAX" results?}
 


### PR DESCRIPTION
Closes #219

Resolves 3 issues brought up by @dylanbeaudette's example:

 - [x]  `top_depth` and `bottom_depth` arguments now supported for `method="MIN"` and `method="MAX"`
 - [x] `include_minors` argument now supported for `method="MIN"` and `method="MAX"`
 - [x] Refactored SQL; removed second subquery, replaced with a temporary table and a mapunit level aggregation of components (proper support for vectorization where values may be derived from multiple components)

---

```{r}
library(soilDB)

# test with same mu as in #219

mu <- '623426'

# use NONE aggregation to compare results
get_SDA_property(property = c('sandtotal_r','claytotal_r'), method = 'NONE', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 2      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 3      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 4      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 5      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey    cokey    chkey compname comppct_r hzdept_r hzdepb_r sandtotal_r
#> 1 623426 20848343 61342444   Braman        80        0       33        11.4
#> 2 623426 20848343 61342443   Braman        80       33      102         6.7
#> 3 623426 20848343 61342442   Braman        80      102      244         6.9
#> 4 623426 20848342 61342440    Osage        20        0       41         7.2
#> 5 623426 20848342 61342441    Osage        20       41      183         5.5
#>   claytotal_r
#> 1        20.5
#> 2        31.0
#> 3        31.0
#> 4        45.0
#> 5        47.5
                 
# include_minors is now respected by MIN/MAX (gives expected value of 47.5)
get_SDA_property(property = 'claytotal_r', method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey claytotal_r
#> 1 623426        47.5

# top and bottom depth are also respected by MIN/MAX (gives expected value of 45)
get_SDA_property(property = 'claytotal_r', top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey claytotal_r
#> 1 623426          45

# default include_minors=FALSE works as expected
get_SDA_property(property = 'claytotal_r', method = 'MAX', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey claytotal_r
#> 1 623426          31
get_SDA_property(property = 'claytotal_r', top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey claytotal_r
#> 1 623426        20.5

# works with multiple properties
get_SDA_property(property = c('sandtotal_r','claytotal_r'), method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        47.5
get_SDA_property(property = c('sandtotal_r','claytotal_r'), top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4          45
get_SDA_property(property = c('sandtotal_r','claytotal_r'), method = 'MAX', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4          31
get_SDA_property(property = c('sandtotal_r','claytotal_r'), top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu,)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        20.5
                 
# works with multiple mapunits
mu <- c(623426, 623452)
get_SDA_property(property = c('sandtotal_r','claytotal_r'), method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 2      OK113    57         Steedman-Lucien complex, 3 to 15 percent slopes
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        47.5
#> 2 623452        43.0        47.5
get_SDA_property(property = c('sandtotal_r','claytotal_r'), top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu, include_minors = TRUE)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 2      OK113    57         Steedman-Lucien complex, 3 to 15 percent slopes
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        45.0
#> 2 623452        43.0        47.5
get_SDA_property(property = c('sandtotal_r','claytotal_r'), method = 'MAX', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 2      OK113    57         Steedman-Lucien complex, 3 to 15 percent slopes
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        31.0
#> 2 623452        43.0        47.5
get_SDA_property(property = c('sandtotal_r','claytotal_r'), top_depth = 0, bottom_depth = 25, method = 'MAX', mukeys = mu)
#>   areasymbol musym                                                  muname
#> 1      OK113    31 Braman silt loam, 0 to 1 percent slopes, rarely flooded
#> 2      OK113    57         Steedman-Lucien complex, 3 to 15 percent slopes
#>    mukey sandtotal_r claytotal_r
#> 1 623426        11.4        20.5
#> 2 623452        43.0        47.5
```