### PR TITLE
SDA function cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-# soilDB 2.6.10 (2021-12-07)
- * `waterDayYear()` and `.formatDates()` allow optional `tz` argument; used for consistent POSIX time conversion in tests where date/time has granularity finer than one day
+# soilDB 2.6.10 (2021-12-13)
+ * `waterDayYear()` and `.formatDates()` allow optional `format` and `tz` argument; used for consistent POSIX time conversion in tests where date/time has granularity finer than one day
+ * `fetchSDA()` extensions for better handling of components with no horizon data
+ * `SDA_spatialQuery()` and `processSDA_WKT()` fully use {sf}, replacing {sp} in these contexts
+ * `SDA_spatialQuery()` gains argument `byFeature` to use multiple single-feature queries and combine the results with a unique feature ID specified by `idcol` argument. This allows for specific feature intersection results without secondary spatial overlay of the polygons (https://github.com/ncss-tech/soilDB/issues/222)
 
 # soilDB 2.6.9 (2021-12-02)
  * Replaced functionality using {plyr}/{reshape2} with {base}/{data.table}

--- a/R/SDA-spatial.R
+++ b/R/SDA-spatial.R
@@ -1,36 +1,41 @@
-#' Post-process WKT returned from SDA.
+#' Post-process Well-Known Text from Soil Data Access
 #' 
-#' This is a helper function, commonly used with \code{SDA_query} to extract
-#' WKT (well-known text) representation of geometry to an sp-class object.
+#' This is a helper function commonly used with \code{SDA_query} to extract
+#' WKT (well-known text) representation of geometry to an `sf` or `sp` object.
 #' 
 #' The SDA website can be found at \url{https://sdmdataaccess.nrcs.usda.gov}.
 #' See the [SDA Tutorial](http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html) for detailed examples.
 #' 
-#' @param d \code{data.frame} returned by \code{SDA_query}, containing WKT
-#' representation of geometry
-#' @param g name of column in \code{d} containing WKT geometry
-#' @param p4s PROJ4 CRS definition, typically GCS WGS84
-#' 
+#' @param d \code{data.frame} returned by \code{SDA_query}, containing WKT representation of geometry
+#' @param g name of column in `d` containing WKT geometry
+#' @param crs CRS definition (e.g. an EPSG code). Default `4326` for WGS84 Geographic Coordinate System
+#' @param p4s Deprecated: PROJ4 CRS definition
+#' @param as_sf Return an `sf` `data.frame`? If `FALSE` return a `Spatial*` object.
 #' @details The SDA website can be found at \url{https://sdmdataaccess.nrcs.usda.gov}. See the \href{http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html}{SDA Tutorial} for detailed examples.
 #' 
-#' @note This function requires the `httr`, `jsonlite`, `XML` ,  and `sf` packages.
+#' @note This function requires the `sf` package.
 #' 
-#' @author D.E. Beaudette
+#' @author D.E. Beaudette, A.G. Brown
 #'
-#' @return A \code{Spatial*} object.
-#' @note This function requires the \code{httr}, \code{jsonlite}, \code{XML},
-#' and \code{rgeos} packages.
+#' @return An `sf` object or if `as_sf` is `FALSE` a `Spatial*` object.
 #' @author D.E. Beaudette
 #' @export processSDA_WKT
-processSDA_WKT <- function(d, g='geom', p4s='+proj=longlat +datum=WGS84') {
+processSDA_WKT <- function(d, g='geom', crs = 4326, p4s = NULL, as_sf = TRUE) {
+  if (!is.null(p4s)) {
+    .Deprecated(msg = "Passing PROJ4 strings via `p4s` is deprecated. SDA interfaces in soilDB use the WGS84 Geographic Coordinate System (EPSG:4326) by default. Use the `crs` argument to customize.")
+  }
   
-  # SDA is always this CRS; proj4string approach obsolete
-  stopifnot(g == 'geom', p4s == '+proj=longlat +datum=WGS84')
+  if (!requireNamespace("sf")) {
+    stop("package `sf` is required", call. = FALSE)
+  }
   
-  # convert wkt to SPDF
+  # convert wkt to sf/SPDF
   d[[g]] <- sf::st_as_sfc(wk::as_wkt(d[,g]))
   sfobj <- sf::st_as_sf(d)
-  sfobj <- sf::st_set_crs(sfobj, sf::st_crs(4326))
+  sfobj <- sf::st_set_crs(sfobj, sf::st_crs(crs))
+  if (as_sf) {
+    return(sfobj)
+  }
   return(sf::as_Spatial(sfobj))
 }
 
@@ -128,204 +133,179 @@ FROM geom_data;
 
 #' Query Soil Data Access by spatial intersection with supplied geometry
 #' 
-#' Query SDA (SSURGO / STATSGO) records via spatial intersection with supplied
-#' geometries. Input can be SpatialPoints, SpatialLines, or SpatialPolygons
-#' objects with a valid CRS. Map unit keys, overlapping polygons, or the
-#' spatial intersection of \code{geom} + SSURGO / STATSGO polygons can be
-#' returned. See details.
+#' Query SDA (SSURGO / STATSGO) records via spatial intersection with supplied geometries. Input can be SpatialPoints, SpatialLines, or SpatialPolygons objects with a valid CRS. Map unit keys, overlapping polygons, or the spatial intersection of \code{geom} + SSURGO / STATSGO polygons can be returned. See details.
 #' 
-#' Queries for map unit keys are always more efficient vs. queries for
-#' overlapping or intersecting (i.e. least efficient) features. \code{geom} is
-#' converted to GCS / WGS84 as needed. Map unit keys are always returned when
-#' using \code{what = "mupolygon"}.
+#' Queries for map unit keys are always more efficient vs. queries for overlapping or intersecting (i.e. least efficient) features. \code{geom} is converted to GCS / WGS84 as needed. Map unit keys are always returned when using \code{what = "mupolygon"}.
 #' 
-#' SSURGO (detailed soil survey, typically 1:24,000 scale) and STATSGO
-#' (generalized soil survey, 1:250,000 scale) data are stored together within
-#' SDA. This means that queries that don't specify an area symbol may result in
-#' a mixture of SSURGO and STATSGO records. See the examples below and the
-#' [SDA Tutorial](http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html)
-#' for details.
+#' SSURGO (detailed soil survey, typically 1:24,000 scale) and STATSGO (generalized soil survey, 1:250,000 scale) data are stored together within SDA. This means that queries that don't specify an area symbol may result in a mixture of SSURGO and STATSGO records. See the examples below and the [SDA Tutorial](http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html) for details.
 #' 
-#' @aliases SDA_spatialQuery SDA_make_spatial_query SDA_query_features
-#' @param geom a Spatial* object, with valid CRS. May contain multiple
-#' features.
-#' @param what a character vector specifying what to return. `'mukey'`:
-#' \code{data.frame} with intersecting map unit keys and names, `'mupolygon'`
-#' overlapping or intersecting map unit polygons from selected database, `'areasymbol'`:
-#' \code{data.frame} with intersecting soil survey areas, `'sapolygon'`:
-#' overlapping or intersecting soil survey area polygons (SSURGO only) 
-#' @param geomIntersection logical; \code{FALSE}: overlapping map unit polygons
-#' returned, \code{TRUE}: intersection of \code{geom} + map unit polygons is
-#' returned.
-#' @param db a character vector identifying the Soil Geographic Databases
-#' ('SSURGO' or 'STATSGO') to query. Option \var{STATSGO} currently works only
-#' in combination with \code{what = "mupolygon"}. 
+#' @aliases SDA_spatialQuery
+#' @param geom an `sf` or `Spatial*` object, with valid CRS. May contain multiple features.
+#' @param what a character vector specifying what to return. `'mukey'`: `data.frame` with intersecting map unit keys and names, `'mupolygon'` overlapping or intersecting map unit polygons from selected database, `'areasymbol'`: `data.frame` with intersecting soil survey areas, `'sapolygon'`: overlapping or intersecting soil survey area polygons (SSURGO only) 
+#' @param geomIntersection logical; `FALSE`: overlapping map unit polygons returned, `TRUE`: intersection of `geom` + map unit polygons is returned.
+#' @param db a character vector identifying the Soil Geographic Databases (`'SSURGO'` or `'STATSGO'`) to query. Option \var{STATSGO} currently works only in combination with `what = "mupolygon"`. 
 #' @param query_string Default: `FALSE`; if `TRUE` return a character string containing query that would be sent to SDA via `SDA_query`
-#' @return A \code{data.frame} if \code{what = 'mukey'}, otherwise
-#' \code{SpatialPolygonsDataFrame} object.
-#' @note Row-order is not preserved across features in \code{geom} and returned
-#' object. Use \code{sp::over()} or similar functionality to extract from
-#' results. Polygon area in acres is computed server-side when \code{what =
-#' 'geom'} and \code{geomIntersection = TRUE}.
+#' @return A `data.frame` if `what = 'mukey'`, otherwise a `SpatialPolygonsDataFrame` or `sf` object.
+#' @note Row-order is not preserved across features in \code{geom} and returned object. Use `sf::st_intersects()` or similar functionality to extract from results. Polygon area in acres is computed server-side when `what = 'mupolygon'` and `geomIntersection = TRUE`.
 #' @author D.E. Beaudette, A.G. Brown, D.R. Schlaepfer
 #' @seealso \code{\link{SDA_query}}
 #' @keywords manip
 #' @examples
-#' 
 #' \donttest{
-#' if(requireNamespace("curl") &
-#'    curl::has_internet() & 
-#'    requireNamespace("sp") &
-#'    requireNamespace("scales") &
-#'    requireNamespace("raster") 
-#'    ) {
-#' 
-#' library(aqp)
-#' library(sp)
-#' library(raster)
-#' 
-#' ## query at a point
-#' 
-#' # example point
-#' p <- SpatialPoints(cbind(x = -119.72330, y = 36.92204), 
-#'                    proj4string = CRS('+proj=longlat +datum=WGS84'))
-#' 
-#' # query map unit records at this point
-#' res <- SDA_spatialQuery(p, what = 'mukey')
-#' 
-#' # convert results into an SQL "IN" statement
-#' # useful when there are multiple intersecting records
-#' mu.is <- format_SQL_in_statement(res$mukey)
-#' 
-#' # composite SQL WHERE clause
-#' sql <- sprintf("mukey IN %s", mu.is)
-#' 
-#' # get commonly used map unit / component / chorizon records
-#' # as a SoilProfileCollection object
-#' # confusing but essential: request that results contain `mukey`
-#' # with `duplicates = TRUE`
-#' x <- fetchSDA(sql, duplicates = TRUE)
-#' 
-#' # safely set texture class factor levels
-#' # by making a copy of this column
-#' # this will save in lieu of textures in the original
-#' # `texture` column
-#' horizons(x)$texture.class <- factor(x$texture, levels = SoilTextureLevels())
-#' 
-#' # graphical depiction of the result
-#' plotSPC(x, color='texture.class', label='compname', 
-#'         name='hzname', cex.names = 1, width=0.25, 
-#'         plot.depth.axis=FALSE, hz.depths=TRUE, 
-#'         name.style='center-center'
-#' )
-#' 
-#' 
-#' 
-#' ## query mukey + geometry that intersect with a bounding box
-#' 
-#' # define a bounding box: xmin, xmax, ymin, ymax
-#' #
-#' #         +-------------------(ymax, xmax)
-#' #         |                        |
-#' #         |                        |
-#' #     (ymin, xmin) ----------------+
-#' b <- c(-119.747629, -119.67935, 36.912019, 36.944987)
-#' 
-#' # convert bounding box to WKT
-#' bbox.sp <-as(extent(b), 'SpatialPolygons')
-#' proj4string(bbox.sp) <- '+proj=longlat +datum=WGS84'
-#' 
-#' # results contain associated map unit keys (mukey)
-#' # return SSURGO polygons, after intersection with provided BBOX
-#' ssurgo.geom <- SDA_spatialQuery(
-#'   bbox.sp, 
-#'   what = 'geom', 
-#'   db = 'SSURGO', 
-#'   geomIntersection = TRUE
-#' )
-#' 
-#' # return STATSGO polygons, after intersection with provided BBOX
-#' statsgo.geom <- SDA_spatialQuery(
-#'   bbox.sp, 
-#'   what = 'geom', 
-#'   db = 'STATSGO', 
-#'   geomIntersection = TRUE
-#' )
-#' 
-#' # inspect results
-#' par(mar = c(0,0,3,1))
-#' plot(ssurgo.geom, border = 'royalblue')
-#' plot(statsgo.geom, lwd = 2, border = 'firebrick', add = TRUE)
-#' plot(bbox.sp, lwd = 3, add = TRUE)
-#' legend(
-#'   x = 'topright', 
-#'   legend = c('BBOX', 'STATSGO', 'SSURGO'), 
-#'   lwd = c(3, 2, 1),
-#'   col = c('black', 'firebrick', 'royalblue'),
-#' )
-#' 
-#' 
-#' # quick reminder that STATSGO map units often contain many components
-#' # format an SQL IN statement using the first STATSGO mukey
-#' mu.is <- format_SQL_in_statement(statsgo.geom$mukey[1])
-#' 
-#' # composite SQL WHERE clause
-#' sql <- sprintf("mukey IN %s", mu.is)
-#' 
-#' # get commonly used map unit / component / chorizon records
-#' # as a SoilProfileCollection object
-#' x <- fetchSDA(sql)
-#' 
-#' # tighter figure margins
-#' par(mar = c(0,0,3,1))
-#' 
-#' 
-#' # organize component sketches by national map unit symbol
-#' # color horizons via awc
-#' # adjust legend title
-#' # add alternate label (vertical text) containing component percent
-#' # move horizon names into the profile sketches
-#' # make profiles wider
-#' groupedProfilePlot(
-#'   x, 
-#'   groups = 'nationalmusym', 
-#'   label = 'compname', 
-#'   color = 'awc_r', 
-#'   col.label = 'Available Water Holding Capacity (cm / cm)',
-#'   alt.label = 'comppct_r',
-#'   name.style = 'center-center',
-#'   width = 0.3
-#' )
-#' 
-#' 
-#' mtext(
-#'   'STATSGO (1:250,000) map units contain a lot of components!', 
-#'   side = 1, 
-#'   adj = 0, 
-#'   line = -1.5, 
-#'   at = 0.25, 
-#'   font = 4
-#' )
-#'  }
+#'   if (requireNamespace("aqp") && requireNamespace("sf")) {
+#'     
+#'     library(aqp)
+#'     library(sf)
+#'     
+#'     ## query at a point
+#'     
+#'     # example point
+#'     p <- sf::st_as_sf(data.frame(x = -119.72330, 
+#'                                  y = 36.92204),
+#'                       coords = c('x', 'y'),
+#'                       crs = 4326)
+#'     
+#'     # query map unit records at this point
+#'     res <- SDA_spatialQuery(p, what = 'mukey')
+#'     
+#'     # convert results into an SQL "IN" statement
+#'     # useful when there are multiple intersecting records
+#'     mu.is <- format_SQL_in_statement(res$mukey)
+#'     
+#'     # composite SQL WHERE clause
+#'     sql <- sprintf("mukey IN %s", mu.is)
+#'     
+#'     # get commonly used map unit / component / chorizon records
+#'     # as a SoilProfileCollection object
+#'     # request that results contain `mukey` with `duplicates = TRUE`
+#'     x <- fetchSDA(sql, duplicates = TRUE)
+#'     
+#'     # safely set texture class factor levels
+#'     # by making a copy of this column
+#'     # this will save in lieu of textures in the original
+#'     # `texture` column
+#'     horizons(x)$texture.class <- factor(x$texture, levels = SoilTextureLevels())
+#'     
+#'     # graphical depiction of the result
+#'     plotSPC(x,
+#'             color = 'texture.class',
+#'             label = 'compname',
+#'             name = 'hzname',
+#'             cex.names = 1,
+#'             width = 0.25,
+#'             plot.depth.axis = FALSE,
+#'             hz.depths = TRUE,
+#'             name.style = 'center-center')
+#'     
+#'     ## query mukey + geometry that intersect with a bounding box
+#'     
+#'     # define a bounding box: xmin, xmax, ymin, ymax
+#'     #
+#'     #         +-------------------(ymax, xmax)
+#'     #         |                        |
+#'     #         |                        |
+#'     #     (ymin, xmin) ----------------+
+#'     b <- c(-119.747629, -119.67935, 36.912019, 36.944987)
+#'     
+#'     # convert bounding box to WKT
+#'     bbox.sp <- sf::st_as_sf(wk::rct(
+#'       xmin = b[1], xmax = b[2], ymin = b[3], ymax = b[4],
+#'       crs = sf::st_crs(4326)
+#'     ))
+#'     
+#'     # results contain associated map unit keys (mukey)
+#'     # return SSURGO polygons, after intersection with provided BBOX
+#'     ssurgo.geom <- SDA_spatialQuery(
+#'       bbox.sp,
+#'       what = 'mupolygon',
+#'       db = 'SSURGO',
+#'       geomIntersection = TRUE
+#'     )
+#'     
+#'     # return STATSGO polygons, after intersection with provided BBOX
+#'     statsgo.geom <- SDA_spatialQuery(
+#'       bbox.sp,
+#'       what = 'mupolygon',
+#'       db = 'STATSGO',
+#'       geomIntersection = TRUE
+#'     )
+#'     
+#'     # inspect results
+#'     par(mar = c(0,0,3,1))
+#'     plot(sf::st_geometry(ssurgo.geom), border = 'royalblue')
+#'     plot(sf::st_geometry(statsgo.geom), lwd = 2, border = 'firebrick', add = TRUE)
+#'     plot(sf::st_geometry(bbox.sp), lwd = 3, add = TRUE)
+#'     legend(
+#'       x = 'topright',
+#'       legend = c('BBOX', 'STATSGO', 'SSURGO'),
+#'       lwd = c(3, 2, 1),
+#'       col = c('black', 'firebrick', 'royalblue'),
+#'     )
+#'     
+#'     # quick reminder that STATSGO map units often contain many components
+#'     # format an SQL IN statement using the first STATSGO mukey
+#'     mu.is <- format_SQL_in_statement(statsgo.geom$mukey[1])
+#'     
+#'     # composite SQL WHERE clause
+#'     sql <- sprintf("mukey IN %s", mu.is)
+#'     
+#'     # get commonly used map unit / component / chorizon records
+#'     # as a SoilProfileCollection object
+#'     x <- fetchSDA(sql)
+#'     
+#'     # tighter figure margins
+#'     par(mar = c(0,0,3,1))
+#'     
+#'     # organize component sketches by national map unit symbol
+#'     # color horizons via awc
+#'     # adjust legend title
+#'     # add alternate label (vertical text) containing component percent
+#'     # move horizon names into the profile sketches
+#'     # make profiles wider
+#'     aqp::groupedProfilePlot(x,
+#'                             groups = 'nationalmusym',
+#'                             label = 'compname',
+#'                             color = 'awc_r',
+#'                             col.label = 'Available Water Holding Capacity (cm / cm)',
+#'                             alt.label = 'comppct_r',
+#'                             name.style = 'center-center',
+#'                             width = 0.3
+#'     )
+#'     
+#'     mtext(
+#'       'STATSGO (1:250,000) map units contain a lot of components!',
+#'       side = 1,
+#'       adj = 0,
+#'       line = -1.5,
+#'       at = 0.25,
+#'       font = 4
+#'     )
+#'   }
 #' }
-#' 
-#' 
 #' @export SDA_spatialQuery
 SDA_spatialQuery <- function(geom,
                              what = 'mukey',
                              geomIntersection = FALSE,
                              db = c("SSURGO", "STATSGO", "SAPOLYGON"),
                              query_string = FALSE) {
+  # check for required packages
+  if (!requireNamespace('sf', quietly = TRUE))
+    stop('please install the `sf` package', call.=FALSE)
+  
+  if (!requireNamespace('wk', quietly = TRUE))
+    stop('please install the `wk` package', call.=FALSE)
+  
   what <- tolower(what)
   db <- toupper(db)
   
-  # sf support
+  # sp support
   return_sf <- FALSE
   if (inherits(geom, 'sf') || inherits(geom, 'sfc')) {
-    if (requireNamespace("sf")) {
-      geom <- sf::as_Spatial(geom)
-      return_sf <- TRUE
-    }
+    return_sf <- TRUE
+  } else if (inherits(geom, 'Spatial')) {
+    geom <- sf::st_as_sf(geom)
+  } else {
+    stop('`geom` must be an sf or Spatial* object', call. = FALSE)
   }
   
   # backwards compatibility with old value of what argument 
@@ -333,13 +313,6 @@ SDA_spatialQuery <- function(geom,
     message("converting what='geom' to what='mupolygon'")
     what <- "mupolygon"
   }
-  
-  # check for required packages
-  if (!requireNamespace('sf', quietly = TRUE))
-    stop('please install the `sf` package', call.=FALSE)
-  
-  if (!requireNamespace('wk', quietly = TRUE))
-    stop('please install the `wk` package', call.=FALSE)
   
   # sanity checks
   if (!what %in% c('mukey', 'mupolygon', 'areasymbol', 'sapolygon')) {
@@ -361,25 +334,20 @@ SDA_spatialQuery <- function(geom,
     stop("query type 'areasymbol' for 'STATSGO' is not supported", call. = FALSE)
   }
   
-  # geom must be an sp object
-  if(! inherits(geom, 'Spatial')) {
-    stop('`geom` must be a Spatial* object', call. = FALSE)
-  }
-  
   # geom must have a valid CRS
-  if (is.na(suppressWarnings(proj4string(geom)))) {
+  if (is.na(sf::st_crs(geom)$wkt)) {
     stop('`geom` must have a valid CRS', call. = FALSE)
   }
   
   # CRS conversion if needed
-  target.prj <- "+proj=longlat +datum=WGS84"
-  if (suppressWarnings(proj4string(geom)) != target.prj) {
-    geom <- spTransform(geom, CRS(target.prj))
+  target.prj <- sf::st_crs(4326)
+  if (suppressWarnings(sf::st_crs(geom)) != target.prj) {
+    geom <- sf::st_transform(geom, target.prj)
   }
   
   # WKT encoding
   # use a geometry collection
-  wkt <- wk::wk_collection(wk::as_wkt(sf::st_as_sf(geom)))
+  wkt <- wk::wk_collection(wk::as_wkt(geom))
   
   # returning geom + mukey or geom + areasymbol
   if (what %in% c('mupolygon', 'sapolygon')) {
@@ -406,7 +374,7 @@ SDA_spatialQuery <- function(geom,
     # single query for all of the features
     # note that row-order / number of rows in results may not match geom
     res <- suppressMessages(SDA_query(q))
-    res <- processSDA_WKT(res)
+    res <- processSDA_WKT(res, as_sf = return_sf)
   }
   
   # SSURGO only
@@ -441,10 +409,6 @@ SDA_spatialQuery <- function(geom,
     # single query for all of the features
     # note that row-order / number of rows in results may not match geom
     res <- suppressMessages(SDA_query(q))
-  }
-  
-  if (inherits(res, 'Spatial') && return_sf) {
-    res <- sf::st_as_sf(res)
   }
   
   return(res)

--- a/R/SDA_coecoclass.R
+++ b/R/SDA_coecoclass.R
@@ -33,7 +33,9 @@ get_SDA_coecoclass <- function(method = "None",
     ecoclassref <- soilDB::format_SQL_in_statement(ecoclassref)
   }
   
-  base_query <- "SELECT * FROM legend l
+  base_query <- "SELECT mu.mukey, c.cokey, coecoclasskey, 
+                  comppct_r, majcompflag, compname, compkind, 
+                  ecoclassid, ecoclassname FROM legend l
    LEFT JOIN mapunit mu ON l.lkey = mu.lkey
    LEFT JOIN component c ON mu.mukey = c.mukey %s
    LEFT JOIN coecoclass ce ON c.cokey = ce.cokey %s

--- a/R/SDA_query.R
+++ b/R/SDA_query.R
@@ -98,7 +98,7 @@ format_SQL_in_statement <- function(x) {
 #' @return a data.frame result (\code{NULL} if empty, try-error on error)
 #' @export
 #' @author D.E. Beaudette
-#' @seealso \code{\link{mapunit_geom_by_ll_bbox}}
+#' @seealso \code{\link{SDA_spatialQuery}}
 #' @keywords manip
 #' @examples
 #' \donttest{
@@ -152,7 +152,6 @@ format_SQL_in_statement <- function(x) {
 #'    str(x)
 #'  }
 #' }
-
 SDA_query <- function(q) {
 
   # check for required packages

--- a/R/SSURGO_spatial_query.R
+++ b/R/SSURGO_spatial_query.R
@@ -18,9 +18,7 @@
 #' @param source the data source, currently ignored
 #' @return The data returned from this function will depend on the query style.
 #' See examples below.
-#' @note This function should be considered experimental; arguments, results,
-#' and side-effects could change at any time. SDA now supports spatial queries,
-#' consider using \code{\link{SDA_query_features}} instead.
+#' @note SDA now supports spatial queries, consider using \code{\link{SDA_spatialQuery}} instead.
 #' @author D.E. Beaudette
 #' @keywords manip
 #' @examples

--- a/R/mapunit_geom_by_ll_bbox.R
+++ b/R/mapunit_geom_by_ll_bbox.R
@@ -1,5 +1,3 @@
-
-
 # 2011-06-22
 # It appears that SDA does not actually return the spatial intersection of map unit polygons and bounding box. Rather, just those polygons that overlap the bbox.
 #' Fetch Map Unit Geometry from SDA
@@ -14,47 +12,10 @@
 #' 
 #' @author Dylan E. Beaudette
 #' @export
-#'
-#' @examples
-#'## fetch map unit geometry from a bounding-box:
-#'# 
-#'#         +------------- (-120.41, 38.70)
-#'#         |                     |
-#'#         |                     |
-#'# (-120.54, 38.61) --------------+
-#'# 
-#' \donttest{
-#' if(requireNamespace("curl") &
-#' curl::has_internet() &
-#'   require(sp) & 
-#'   require(rgdal)) {
-#'     
-#'     # basic usage
-#'     b <- c(-120.54,38.61,-120.41,38.70)
-#'     x <- try(mapunit_geom_by_ll_bbox(b)) # about 20 seconds
-#'     
-#'     if(!inherits(x,'try-error')) {
-#'       # note that the returned geometry is everything overlapping the bbox
-#'       # and not an intersection... why?
-#'       plot(x)
-#'     rect(b[1], b[2], b[3], b[4], border='red', lwd=2)
-#'     
-#'     
-#'     # get map unit data for matching map unit keys
-#'     in.statement <- format_SQL_in_statement(unique(x$mukey))
-#'     
-#'     q <- paste("SELECT mukey, muname FROM mapunit WHERE mukey IN ", in.statement, sep="")
-#'     res <- SDA_query(q)
-#'     
-#'     #inspect
-#'     head(res)
-#'   } else {
-#'     message('could not download XML result from SDA')
-#'   }
-#'  }
-#'}
 mapunit_geom_by_ll_bbox <- function(bbox, source='sda') {
 	
+  .Deprecated("SDA_spatialQuery", msg = "See ?SDA_spatialQuery for example using a longitude/latitude bounding box")
+  
 	# must have rgdal installed
    if(!requireNamespace('rgdal', quietly=TRUE))
     stop('please install the `rgdal` package', call.=FALSE)

--- a/man/SDA_query.Rd
+++ b/man/SDA_query.Rd
@@ -77,7 +77,7 @@ if(requireNamespace("curl") & requireNamespace("wk") &
 }
 }
 \seealso{
-\code{\link{mapunit_geom_by_ll_bbox}}
+\code{\link{SDA_spatialQuery}}
 }
 \author{
 D.E. Beaudette

--- a/man/SDA_spatialQuery.Rd
+++ b/man/SDA_spatialQuery.Rd
@@ -9,6 +9,8 @@ SDA_spatialQuery(
   what = "mukey",
   geomIntersection = FALSE,
   db = c("SSURGO", "STATSGO", "SAPOLYGON"),
+  byFeature = FALSE,
+  idcol = "gid",
   query_string = FALSE
 )
 }
@@ -20,6 +22,10 @@ SDA_spatialQuery(
 \item{geomIntersection}{logical; \code{FALSE}: overlapping map unit polygons returned, \code{TRUE}: intersection of \code{geom} + map unit polygons is returned.}
 
 \item{db}{a character vector identifying the Soil Geographic Databases (\code{'SSURGO'} or \code{'STATSGO'}) to query. Option \var{STATSGO} currently works only in combination with \code{what = "mupolygon"}.}
+
+\item{byFeature}{Iterate over features, returning a combined data.frame where each feature is uniquely identified by value in \code{idcol}. Default \code{FALSE}.}
+
+\item{idcol}{Unique IDs used for individual features when \code{byFeature = TRUE}; Default \code{"gid"}}
 
 \item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 }

--- a/man/SDA_spatialQuery.Rd
+++ b/man/SDA_spatialQuery.Rd
@@ -2,8 +2,6 @@
 % Please edit documentation in R/SDA-spatial.R
 \name{SDA_spatialQuery}
 \alias{SDA_spatialQuery}
-\alias{SDA_make_spatial_query}
-\alias{SDA_query_features}
 \title{Query Soil Data Access by spatial intersection with supplied geometry}
 \usage{
 SDA_spatialQuery(
@@ -15,195 +13,162 @@ SDA_spatialQuery(
 )
 }
 \arguments{
-\item{geom}{a Spatial* object, with valid CRS. May contain multiple
-features.}
+\item{geom}{an \code{sf} or \verb{Spatial*} object, with valid CRS. May contain multiple features.}
 
-\item{what}{a character vector specifying what to return. \code{'mukey'}:
-\code{data.frame} with intersecting map unit keys and names, \code{'mupolygon'}
-overlapping or intersecting map unit polygons from selected database, \code{'areasymbol'}:
-\code{data.frame} with intersecting soil survey areas, \code{'sapolygon'}:
-overlapping or intersecting soil survey area polygons (SSURGO only)}
+\item{what}{a character vector specifying what to return. \code{'mukey'}: \code{data.frame} with intersecting map unit keys and names, \code{'mupolygon'} overlapping or intersecting map unit polygons from selected database, \code{'areasymbol'}: \code{data.frame} with intersecting soil survey areas, \code{'sapolygon'}: overlapping or intersecting soil survey area polygons (SSURGO only)}
 
-\item{geomIntersection}{logical; \code{FALSE}: overlapping map unit polygons
-returned, \code{TRUE}: intersection of \code{geom} + map unit polygons is
-returned.}
+\item{geomIntersection}{logical; \code{FALSE}: overlapping map unit polygons returned, \code{TRUE}: intersection of \code{geom} + map unit polygons is returned.}
 
-\item{db}{a character vector identifying the Soil Geographic Databases
-('SSURGO' or 'STATSGO') to query. Option \var{STATSGO} currently works only
-in combination with \code{what = "mupolygon"}.}
+\item{db}{a character vector identifying the Soil Geographic Databases (\code{'SSURGO'} or \code{'STATSGO'}) to query. Option \var{STATSGO} currently works only in combination with \code{what = "mupolygon"}.}
 
 \item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 }
 \value{
-A \code{data.frame} if \code{what = 'mukey'}, otherwise
-\code{SpatialPolygonsDataFrame} object.
+A \code{data.frame} if \code{what = 'mukey'}, otherwise a \code{SpatialPolygonsDataFrame} or \code{sf} object.
 }
 \description{
-Query SDA (SSURGO / STATSGO) records via spatial intersection with supplied
-geometries. Input can be SpatialPoints, SpatialLines, or SpatialPolygons
-objects with a valid CRS. Map unit keys, overlapping polygons, or the
-spatial intersection of \code{geom} + SSURGO / STATSGO polygons can be
-returned. See details.
+Query SDA (SSURGO / STATSGO) records via spatial intersection with supplied geometries. Input can be SpatialPoints, SpatialLines, or SpatialPolygons objects with a valid CRS. Map unit keys, overlapping polygons, or the spatial intersection of \code{geom} + SSURGO / STATSGO polygons can be returned. See details.
 }
 \details{
-Queries for map unit keys are always more efficient vs. queries for
-overlapping or intersecting (i.e. least efficient) features. \code{geom} is
-converted to GCS / WGS84 as needed. Map unit keys are always returned when
-using \code{what = "mupolygon"}.
+Queries for map unit keys are always more efficient vs. queries for overlapping or intersecting (i.e. least efficient) features. \code{geom} is converted to GCS / WGS84 as needed. Map unit keys are always returned when using \code{what = "mupolygon"}.
 
-SSURGO (detailed soil survey, typically 1:24,000 scale) and STATSGO
-(generalized soil survey, 1:250,000 scale) data are stored together within
-SDA. This means that queries that don't specify an area symbol may result in
-a mixture of SSURGO and STATSGO records. See the examples below and the
-\href{http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html}{SDA Tutorial}
-for details.
+SSURGO (detailed soil survey, typically 1:24,000 scale) and STATSGO (generalized soil survey, 1:250,000 scale) data are stored together within SDA. This means that queries that don't specify an area symbol may result in a mixture of SSURGO and STATSGO records. See the examples below and the \href{http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html}{SDA Tutorial} for details.
 }
 \note{
-Row-order is not preserved across features in \code{geom} and returned
-object. Use \code{sp::over()} or similar functionality to extract from
-results. Polygon area in acres is computed server-side when \code{what =
-'geom'} and \code{geomIntersection = TRUE}.
+Row-order is not preserved across features in \code{geom} and returned object. Use \code{sf::st_intersects()} or similar functionality to extract from results. Polygon area in acres is computed server-side when \code{what = 'mupolygon'} and \code{geomIntersection = TRUE}.
 }
 \examples{
-
 \donttest{
-if(requireNamespace("curl") &
-   curl::has_internet() & 
-   requireNamespace("sp") &
-   requireNamespace("scales") &
-   requireNamespace("raster") 
-   ) {
-
-library(aqp)
-library(sp)
-library(raster)
-
-## query at a point
-
-# example point
-p <- SpatialPoints(cbind(x = -119.72330, y = 36.92204), 
-                   proj4string = CRS('+proj=longlat +datum=WGS84'))
-
-# query map unit records at this point
-res <- SDA_spatialQuery(p, what = 'mukey')
-
-# convert results into an SQL "IN" statement
-# useful when there are multiple intersecting records
-mu.is <- format_SQL_in_statement(res$mukey)
-
-# composite SQL WHERE clause
-sql <- sprintf("mukey IN \%s", mu.is)
-
-# get commonly used map unit / component / chorizon records
-# as a SoilProfileCollection object
-# confusing but essential: request that results contain `mukey`
-# with `duplicates = TRUE`
-x <- fetchSDA(sql, duplicates = TRUE)
-
-# safely set texture class factor levels
-# by making a copy of this column
-# this will save in lieu of textures in the original
-# `texture` column
-horizons(x)$texture.class <- factor(x$texture, levels = SoilTextureLevels())
-
-# graphical depiction of the result
-plotSPC(x, color='texture.class', label='compname', 
-        name='hzname', cex.names = 1, width=0.25, 
-        plot.depth.axis=FALSE, hz.depths=TRUE, 
-        name.style='center-center'
-)
-
-
-
-## query mukey + geometry that intersect with a bounding box
-
-# define a bounding box: xmin, xmax, ymin, ymax
-#
-#         +-------------------(ymax, xmax)
-#         |                        |
-#         |                        |
-#     (ymin, xmin) ----------------+
-b <- c(-119.747629, -119.67935, 36.912019, 36.944987)
-
-# convert bounding box to WKT
-bbox.sp <-as(extent(b), 'SpatialPolygons')
-proj4string(bbox.sp) <- '+proj=longlat +datum=WGS84'
-
-# results contain associated map unit keys (mukey)
-# return SSURGO polygons, after intersection with provided BBOX
-ssurgo.geom <- SDA_spatialQuery(
-  bbox.sp, 
-  what = 'geom', 
-  db = 'SSURGO', 
-  geomIntersection = TRUE
-)
-
-# return STATSGO polygons, after intersection with provided BBOX
-statsgo.geom <- SDA_spatialQuery(
-  bbox.sp, 
-  what = 'geom', 
-  db = 'STATSGO', 
-  geomIntersection = TRUE
-)
-
-# inspect results
-par(mar = c(0,0,3,1))
-plot(ssurgo.geom, border = 'royalblue')
-plot(statsgo.geom, lwd = 2, border = 'firebrick', add = TRUE)
-plot(bbox.sp, lwd = 3, add = TRUE)
-legend(
-  x = 'topright', 
-  legend = c('BBOX', 'STATSGO', 'SSURGO'), 
-  lwd = c(3, 2, 1),
-  col = c('black', 'firebrick', 'royalblue'),
-)
-
-
-# quick reminder that STATSGO map units often contain many components
-# format an SQL IN statement using the first STATSGO mukey
-mu.is <- format_SQL_in_statement(statsgo.geom$mukey[1])
-
-# composite SQL WHERE clause
-sql <- sprintf("mukey IN \%s", mu.is)
-
-# get commonly used map unit / component / chorizon records
-# as a SoilProfileCollection object
-x <- fetchSDA(sql)
-
-# tighter figure margins
-par(mar = c(0,0,3,1))
-
-
-# organize component sketches by national map unit symbol
-# color horizons via awc
-# adjust legend title
-# add alternate label (vertical text) containing component percent
-# move horizon names into the profile sketches
-# make profiles wider
-groupedProfilePlot(
-  x, 
-  groups = 'nationalmusym', 
-  label = 'compname', 
-  color = 'awc_r', 
-  col.label = 'Available Water Holding Capacity (cm / cm)',
-  alt.label = 'comppct_r',
-  name.style = 'center-center',
-  width = 0.3
-)
-
-
-mtext(
-  'STATSGO (1:250,000) map units contain a lot of components!', 
-  side = 1, 
-  adj = 0, 
-  line = -1.5, 
-  at = 0.25, 
-  font = 4
-)
- }
+  if (requireNamespace("aqp") && requireNamespace("sf")) {
+    
+    library(aqp)
+    library(sf)
+    
+    ## query at a point
+    
+    # example point
+    p <- sf::st_as_sf(data.frame(x = -119.72330, 
+                                 y = 36.92204),
+                      coords = c('x', 'y'),
+                      crs = 4326)
+    
+    # query map unit records at this point
+    res <- SDA_spatialQuery(p, what = 'mukey')
+    
+    # convert results into an SQL "IN" statement
+    # useful when there are multiple intersecting records
+    mu.is <- format_SQL_in_statement(res$mukey)
+    
+    # composite SQL WHERE clause
+    sql <- sprintf("mukey IN \%s", mu.is)
+    
+    # get commonly used map unit / component / chorizon records
+    # as a SoilProfileCollection object
+    # request that results contain `mukey` with `duplicates = TRUE`
+    x <- fetchSDA(sql, duplicates = TRUE)
+    
+    # safely set texture class factor levels
+    # by making a copy of this column
+    # this will save in lieu of textures in the original
+    # `texture` column
+    horizons(x)$texture.class <- factor(x$texture, levels = SoilTextureLevels())
+    
+    # graphical depiction of the result
+    plotSPC(x,
+            color = 'texture.class',
+            label = 'compname',
+            name = 'hzname',
+            cex.names = 1,
+            width = 0.25,
+            plot.depth.axis = FALSE,
+            hz.depths = TRUE,
+            name.style = 'center-center')
+    
+    ## query mukey + geometry that intersect with a bounding box
+    
+    # define a bounding box: xmin, xmax, ymin, ymax
+    #
+    #         +-------------------(ymax, xmax)
+    #         |                        |
+    #         |                        |
+    #     (ymin, xmin) ----------------+
+    b <- c(-119.747629, -119.67935, 36.912019, 36.944987)
+    
+    # convert bounding box to WKT
+    bbox.sp <- sf::st_as_sf(wk::rct(
+      xmin = b[1], xmax = b[2], ymin = b[3], ymax = b[4],
+      crs = sf::st_crs(4326)
+    ))
+    
+    # results contain associated map unit keys (mukey)
+    # return SSURGO polygons, after intersection with provided BBOX
+    ssurgo.geom <- SDA_spatialQuery(
+      bbox.sp,
+      what = 'mupolygon',
+      db = 'SSURGO',
+      geomIntersection = TRUE
+    )
+    
+    # return STATSGO polygons, after intersection with provided BBOX
+    statsgo.geom <- SDA_spatialQuery(
+      bbox.sp,
+      what = 'mupolygon',
+      db = 'STATSGO',
+      geomIntersection = TRUE
+    )
+    
+    # inspect results
+    par(mar = c(0,0,3,1))
+    plot(sf::st_geometry(ssurgo.geom), border = 'royalblue')
+    plot(sf::st_geometry(statsgo.geom), lwd = 2, border = 'firebrick', add = TRUE)
+    plot(sf::st_geometry(bbox.sp), lwd = 3, add = TRUE)
+    legend(
+      x = 'topright',
+      legend = c('BBOX', 'STATSGO', 'SSURGO'),
+      lwd = c(3, 2, 1),
+      col = c('black', 'firebrick', 'royalblue'),
+    )
+    
+    # quick reminder that STATSGO map units often contain many components
+    # format an SQL IN statement using the first STATSGO mukey
+    mu.is <- format_SQL_in_statement(statsgo.geom$mukey[1])
+    
+    # composite SQL WHERE clause
+    sql <- sprintf("mukey IN \%s", mu.is)
+    
+    # get commonly used map unit / component / chorizon records
+    # as a SoilProfileCollection object
+    x <- fetchSDA(sql)
+    
+    # tighter figure margins
+    par(mar = c(0,0,3,1))
+    
+    # organize component sketches by national map unit symbol
+    # color horizons via awc
+    # adjust legend title
+    # add alternate label (vertical text) containing component percent
+    # move horizon names into the profile sketches
+    # make profiles wider
+    aqp::groupedProfilePlot(x,
+                            groups = 'nationalmusym',
+                            label = 'compname',
+                            color = 'awc_r',
+                            col.label = 'Available Water Holding Capacity (cm / cm)',
+                            alt.label = 'comppct_r',
+                            name.style = 'center-center',
+                            width = 0.3
+    )
+    
+    mtext(
+      'STATSGO (1:250,000) map units contain a lot of components!',
+      side = 1,
+      adj = 0,
+      line = -1.5,
+      at = 0.25,
+      font = 4
+    )
+  }
 }
-
-
 }
 \seealso{
 \code{\link{SDA_query}}

--- a/man/SoilWeb_spatial_query.Rd
+++ b/man/SoilWeb_spatial_query.Rd
@@ -36,9 +36,7 @@ include a switch to determine the data source: "official" data via USDA-NRCS
 servers, or a "snapshot" via SoilWeb.
 }
 \note{
-This function should be considered experimental; arguments, results,
-and side-effects could change at any time. SDA now supports spatial queries,
-consider using \code{\link{SDA_query_features}} instead.
+SDA now supports spatial queries, consider using \code{\link{SDA_spatialQuery}} instead.
 }
 \examples{
 

--- a/man/mapunit_geom_by_ll_bbox.Rd
+++ b/man/mapunit_geom_by_ll_bbox.Rd
@@ -23,45 +23,6 @@ The SDA website can be found at \url{https://sdmdataaccess.nrcs.usda.gov}. See e
 \note{
 SDA does not return the spatial intersection of map unit polygons and bounding box. Rather, just those polygons that are completely within the bounding box / overlap with the bbox. This function requires the 'rgdal' package.
 }
-\examples{
-## fetch map unit geometry from a bounding-box:
-# 
-#         +------------- (-120.41, 38.70)
-#         |                     |
-#         |                     |
-# (-120.54, 38.61) --------------+
-# 
-\donttest{
-if(requireNamespace("curl") &
-curl::has_internet() &
-  require(sp) & 
-  require(rgdal)) {
-    
-    # basic usage
-    b <- c(-120.54,38.61,-120.41,38.70)
-    x <- try(mapunit_geom_by_ll_bbox(b)) # about 20 seconds
-    
-    if(!inherits(x,'try-error')) {
-      # note that the returned geometry is everything overlapping the bbox
-      # and not an intersection... why?
-      plot(x)
-    rect(b[1], b[2], b[3], b[4], border='red', lwd=2)
-    
-    
-    # get map unit data for matching map unit keys
-    in.statement <- format_SQL_in_statement(unique(x$mukey))
-    
-    q <- paste("SELECT mukey, muname FROM mapunit WHERE mukey IN ", in.statement, sep="")
-    res <- SDA_query(q)
-    
-    #inspect
-    head(res)
-  } else {
-    message('could not download XML result from SDA')
-  }
- }
-}
-}
 \author{
 Dylan E. Beaudette
 }

--- a/man/processSDA_WKT.Rd
+++ b/man/processSDA_WKT.Rd
@@ -2,24 +2,27 @@
 % Please edit documentation in R/SDA-spatial.R
 \name{processSDA_WKT}
 \alias{processSDA_WKT}
-\title{Post-process WKT returned from SDA.}
+\title{Post-process Well-Known Text from Soil Data Access}
 \usage{
-processSDA_WKT(d, g = "geom", p4s = "+proj=longlat +datum=WGS84")
+processSDA_WKT(d, g = "geom", crs = 4326, p4s = NULL, as_sf = TRUE)
 }
 \arguments{
-\item{d}{\code{data.frame} returned by \code{SDA_query}, containing WKT
-representation of geometry}
+\item{d}{\code{data.frame} returned by \code{SDA_query}, containing WKT representation of geometry}
 
 \item{g}{name of column in \code{d} containing WKT geometry}
 
-\item{p4s}{PROJ4 CRS definition, typically GCS WGS84}
+\item{crs}{CRS definition (e.g. an EPSG code). Default \code{4326} for WGS84 Geographic Coordinate System}
+
+\item{p4s}{Deprecated: PROJ4 CRS definition}
+
+\item{as_sf}{Return an \code{sf} \code{data.frame}? If \code{FALSE} return a \verb{Spatial*} object.}
 }
 \value{
-A \code{Spatial*} object.
+An \code{sf} object or if \code{as_sf} is \code{FALSE} a \verb{Spatial*} object.
 }
 \description{
-This is a helper function, commonly used with \code{SDA_query} to extract
-WKT (well-known text) representation of geometry to an sp-class object.
+This is a helper function commonly used with \code{SDA_query} to extract
+WKT (well-known text) representation of geometry to an \code{sf} or \code{sp} object.
 }
 \details{
 The SDA website can be found at \url{https://sdmdataaccess.nrcs.usda.gov}.
@@ -28,13 +31,10 @@ See the \href{http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html}{SDA Tutor
 The SDA website can be found at \url{https://sdmdataaccess.nrcs.usda.gov}. See the \href{http://ncss-tech.github.io/AQP/soilDB/SDA-tutorial.html}{SDA Tutorial} for detailed examples.
 }
 \note{
-This function requires the \code{httr}, \code{jsonlite}, \code{XML} ,  and \code{sf} packages.
-
-This function requires the \code{httr}, \code{jsonlite}, \code{XML},
-and \code{rgeos} packages.
+This function requires the \code{sf} package.
 }
 \author{
-D.E. Beaudette
+D.E. Beaudette, A.G. Brown
 
 D.E. Beaudette
 }


### PR DESCRIPTION
- Update docs
- Use {sf} internally for all SDA spatial processing (with full {sp} support)
- Simplify `get_SDA_coecoclass()` results
- `mapunit_geom_by_ll_bbox()` is deprecated; see example in `?SDA_spatialQuery` for getting SDA mapunit polygon geometry from SSURGO, STATSGO or SAPOLYGON using a WGS84 longitude/latitude bounding box