### PR TITLE
Missing silent=TRUE in try() call

### DIFF
--- a/R/SDA_query.R
+++ b/R/SDA_query.R
@@ -200,7 +200,7 @@ SDA_query <- function(q) {
   if (inherits(r.content,'try-error'))
       return(invisible(r.content))
 
-  d <- try(jsonlite::fromJSON(r.content))
+  d <- try(jsonlite::fromJSON(r.content), silent=TRUE)
 
   if (inherits(d, 'try-error'))
     return(invisible(d))


### PR DESCRIPTION
Without silent=TRUE, try() will break if there's really an error. So next line (`inherits(d, 'try-error')`) could never be true