### PR TITLE
Fix waterDayYear for CRAN

### DIFF
--- a/R/waterDayYear.R
+++ b/R/waterDayYear.R
@@ -47,7 +47,7 @@ waterDayYear <- function(d, end = "09-30", format = "%Y-%m-%d", tz = "") {
   
   # compute water "day" as days since start of water year
   # ideas from: https://stackoverflow.com/questions/48123049/create-day-index-based-on-water-year
-  water_day <- as.integer(difftime(d, lastWY, units = 'days'))
+  water_day <- as.integer(difftime(dLT, lastWY, units = 'days'))
   
   res <- data.frame(
     wy = water_year, 


### PR DESCRIPTION
Finally this will allow us to resolve binary build missing on r-release-macos-arm64 platform (broken since v2.6.5 on CRAN...)

Took me long enough to test this properly after blindly hacking away over the past several releases.

![image](https://user-images.githubusercontent.com/20842828/152617097-7f629409-bea9-475c-a0c4-7daa0bcc9f3d.png)


```r
# test waterDayYear in another timezone
waterDayYearTest <- function(x, tz) {
  tzorig <- Sys.getenv("TZ")
  Sys.setenv(TZ = tz)
  x <- soilDB::waterDayYear(x, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")
  Sys.setenv(TZ = tzorig)
  x$wd
}
```
### Before
```r
# test waterDayYear in another timezone
waterDayYearTest <- function(x, tz) {
  tzorig <- Sys.getenv("TZ")
  Sys.setenv(TZ = tz)
  x <- soilDB::waterDayYear(x, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")
  Sys.setenv(TZ = tzorig)
  x$wd
}

res <- sapply(OlsonNames(), function(x) waterDayYearTest("2000-12-05 12:00:00", x))
which(res != 66)
#>    Antarctica/McMurdo Antarctica/South_Pole            Etc/GMT-13 
#>                   227                   230                   397 
#>            Etc/GMT-14            Etc/GMT+12                    NZ 
#>                   398                   411                   523 
#>               NZ-CHAT      Pacific/Auckland       Pacific/Chatham 
#>                   524                   526                   528 
#>     Pacific/Enderbury        Pacific/Kanton    Pacific/Kiritimati 
#>                   532                   542                   543 
#>     Pacific/Tongatapu 
#>                   564

res <- sapply(OlsonNames(), function(x) waterDayYearTest("2000-12-05 15:00:00", x))
which(res != 66)
#>      America/Adak America/Anchorage      America/Atka    America/Juneau 
#>                55                56                76               140 
#>      America/Nome     America/Sitka   America/Yakutat        Etc/GMT+10 
#>               171               202               220               409 
#>        Etc/GMT+11        Etc/GMT+12         Etc/GMT+9               HST 
#>               410               411               419               497 
#>      Pacific/Apia   Pacific/Fakaofo   Pacific/Gambier  Pacific/Honolulu 
#>               525               533               537               540 
#>  Pacific/Johnston Pacific/Marquesas    Pacific/Midway      Pacific/Niue 
#>               541               547               548               550 
#> Pacific/Pago_Pago Pacific/Rarotonga     Pacific/Samoa    Pacific/Tahiti 
#>               553               559               561               562 
#>         US/Alaska       US/Aleutian         US/Hawaii          US/Samoa 
#>               579               580               585               590
```

### After
```r
res <- sapply(OlsonNames(), function(x) waterDayYearTest("2000-12-05 12:00:00", x))
which(res != 66)
#> named integer(0)

res <- sapply(OlsonNames(), function(x) waterDayYearTest("2000-12-05 15:00:00", x))
which(res != 66)
#> named integer(0)
```