### PR TITLE
fetchNASIS("components"): use `duplicates` argument and custom profile ID for many:1 relationships of legend, mapunit to datamapunit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# soilDB 2.7.2 (2022-06-24)
+
+ * `fetchNASIS("components')`: Fix and refactor ( **breaking change** from 2.7.1, which introduced a bug/inconsistency) of recent change; `duplicates` argument is now _required_ to merge in data from mapunit/legend tables (where many:1 relationships between legend/mapunit and datamapunit are possible). In 2.7.1 possibly incomplete mapunit/legend tables could be joined to SoilProfileCollection result (if and only if the tables were populated in selected set/local DB). Does not change historic (<=2.7.0) default behavior. Thanks to @dylanbeaudette for suggesting use of `get_component_correlation_data_from_NASIS_db()` here.
+
+ * Several fixes for Roxygen documentation (notably for `ROSETTA()` and various NASIS web report related functions) that were missing `@export` tags. Several previously-exported functions missed being explicitly exported in the new Roxygen-generate NAMESPACE. These unintentional omissions from 2.7.1 NAMESPACE have been resolved.
+ 
 # soilDB 2.7.1 (2022-06-10)
    - `get_SDA_coecoclass()` better handling of `NULL` `ecoclassref`; support for filtering on `ecoclasstypename`; `not_assigned_value` now applies to `ecoclassname`, `ecoclasstypename` and `ecoclassref` columns in addition to `ecoclassid`; Thanks to Andy Paolucci and Jason Nemecek. Also, added additional columns from legend/mapunit tables (`areasymbol`, `lkey`, `muname`).
    - `fetchNASIS(from="components")` now returns mapunit and legend information (if loaded in local NASIS database); results now contain `mustatus` and `repdmu` which can be used to remove components from additional mapunits and non-representative data mapunits; thanks to Nathan Roe

--- a/R/fetchNASIS.R
+++ b/R/fetchNASIS.R
@@ -56,9 +56,11 @@
 #' @param lab should the `phlabresults` child table be fetched with
 #' site/pedon/horizon data (default: `FALSE`)
 #' @param fill include pedon or component records without horizon data in result? (default: `FALSE`)
+#' @param dropAdditional Used only for `from='components'` with `duplicates=TRUE`. Prevent "duplication" of `mustatus=="additional"`  mapunits? Default: `TRUE`
+#' @param dropNonRepresentative Used only for `from='components'` with `duplicates=TRUE`. Prevent "duplication" of non-representative data mapunits? Default: `TRUE`
+#' @param duplicates Used only for `from='components'`. Duplicate components for all instances of use (i.e. one for each legend data mapunit is used on; optionally for additional mapunits, and/or non-representative data mapunits?)
 #' @param stringsAsFactors deprecated
-#' @param dsn Optional: path to local SQLite database containing NASIS
-#' table structure; default: `NULL`
+#' @param dsn Optional: path to local SQLite database containing NASIS table structure; default: `NULL`
 #' @return A SoilProfileCollection object
 #' @seealso `get_component_data_from_NASIS()`
 #' @author D. E. Beaudette, J. M. Skovlin, S.M. Roecker, A.G. Brown
@@ -73,6 +75,9 @@ fetchNASIS <- function(from = 'pedons',
                        mixColors = TRUE,
                        lab = FALSE,
                        fill = FALSE,
+                       dropAdditional = TRUE,
+                       dropNonRepresentative = TRUE,
+                       duplicates = FALSE,
                        stringsAsFactors = NULL,
                        dsn = NULL) {
 
@@ -114,7 +119,10 @@ fetchNASIS <- function(from = 'pedons',
                                   rmHzErrors = rmHzErrors,
                                   nullFragsAreZero = nullFragsAreZero,
                                   fill = fill,
-                                  dsn = dsn)
+                                  dsn = dsn,
+                                  dropAdditional = dropAdditional,
+                                  dropNotRepresentative = dropNonRepresentative,
+                                  duplicates = duplicates)
   }
 
   if (from == 'pedon_report') {

--- a/R/get_component_data_from_NASIS_db.R
+++ b/R/get_component_data_from_NASIS_db.R
@@ -180,7 +180,7 @@ get_component_correlation_data_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
   
-  q <- "SELECT lmapunitiid, mu.muiid, musym, nationalmusym, mu.muname, mukind, mutype, mustatus, muacres, farmlndcl, repdmu, dmuiid, areasymbol, areaname, ssastatus, cordate
+  q <- "SELECT lmapunitiid, lmapunitiid AS mukey, mu.muiid, musym, nationalmusym, mu.muname, mukind, mutype, mustatus, muacres, farmlndcl, repdmu, dmuiid, areasymbol, areaname, ssastatus, cordate
 
   FROM  mapunit_View_1 AS mu
 

--- a/man/fetchNASIS.Rd
+++ b/man/fetchNASIS.Rd
@@ -19,6 +19,9 @@ fetchNASIS(
   mixColors = TRUE,
   lab = FALSE,
   fill = FALSE,
+  dropAdditional = TRUE,
+  dropNonRepresentative = TRUE,
+  duplicates = FALSE,
   stringsAsFactors = NULL,
   dsn = NULL
 )
@@ -57,10 +60,15 @@ site/pedon/horizon data (default: \code{FALSE})}
 
 \item{fill}{include pedon or component records without horizon data in result? (default: \code{FALSE})}
 
+\item{dropAdditional}{Used only for \code{from='components'} with \code{duplicates=TRUE}. Prevent "duplication" of \code{mustatus=="additional"}  mapunits? Default: \code{TRUE}}
+
+\item{dropNonRepresentative}{Used only for \code{from='components'} with \code{duplicates=TRUE}. Prevent "duplication" of non-representative data mapunits? Default: \code{TRUE}}
+
+\item{duplicates}{Used only for \code{from='components'}. Duplicate components for all instances of use (i.e. one for each legend data mapunit is used on; optionally for additional mapunits, and/or non-representative data mapunits?)}
+
 \item{stringsAsFactors}{deprecated}
 
-\item{dsn}{Optional: path to local SQLite database containing NASIS
-table structure; default: \code{NULL}}
+\item{dsn}{Optional: path to local SQLite database containing NASIS table structure; default: \code{NULL}}
 }
 \value{
 A SoilProfileCollection object


### PR DESCRIPTION
Many mapunits. Uses `get_component_correlation_data_from_NASIS_db()`, provides `dropAdditional` `dropNonRepresentative` and `duplicates` as optional arguments to `fetchNASIS()`. Creates a non-standard "coiidcmb" from the combination of `lmapunitiid:muiid:dmuiid:coiid` which is used as the result SPC ID column.

This seems to now be working as I intended after checking to make sure all joins have an appropriate ID on left and right hand side.