### PR TITLE
Improving support for `get_SDA*()` component filters

### DIFF
--- a/R/get_SDA_coecoclass.R
+++ b/R/get_SDA_coecoclass.R
@@ -12,7 +12,7 @@
 #' @param ecoclasstypename If `NULL` no constraint on `ecoclasstypename` is used in the query.
 #' @param ecoclassref Default: `"Ecological Site Description Database"`. If `NULL` no constraint on `ecoclassref` is used in the query.
 #' @param not_rated_value Default: `"Not assigned"`
-#' @param miscellaneous_areas Include miscellaneous areas (non-soil components)?
+#' @param miscellaneous_areas logical. Include miscellaneous areas (non-soil components)?
 #' @param dsn Path to local SQLite database or a DBIConnection object. If `NULL` (default) use Soil Data Access API via `SDA_query()`.
 #' @export 
 get_SDA_coecoclass <- function(method = "None",

--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -1199,6 +1199,6 @@ get_SDA_interpretation <- function(rulename,
 }
 
 .LIMIT_N <- function(query, n = 1, sqlite = FALSE) {
-  if (!sqlite) return(gsub("SELECT ", paste("SELECT TOP", n), query))
-  paste(query, paste("LIMIT", n))
+  if (!sqlite) return(gsub("SELECT ", paste("SELECT TOP", n, ""), query))
+  paste(query, paste("LIMIT", n, ""))
 }

--- a/R/get_SDA_pmgroupname.R
+++ b/R/get_SDA_pmgroupname.R
@@ -11,6 +11,7 @@
 #' @param WHERE character containing SQL WHERE clause specified in terms of fields in `legend`, `mapunit`, `component`, or `copmgrp` tables, used in lieu of `mukeys` or `areasymbols`
 #' @param method One of: `"Dominant Component"`, `"Dominant Condition"`, `"None"`
 #' @param simplify logical; group into generalized parent material groups? Default `TRUE`
+#' @param miscellaneous_areas Include miscellaneous areas  (non-soil components) in results? Default: `FALSE`. 
 #' @param query_string Default: `FALSE`; if `TRUE` return a character string containing query that would be sent to SDA via `SDA_query`
 #' @param dsn Path to local SQLite database or a DBIConnection object. If `NULL` (default) use Soil Data Access API via `SDA_query()`.
 #' @author Jason Nemecek, Chad Ferguson, Andrew Brown
@@ -21,6 +22,7 @@ get_SDA_pmgroupname <- function(areasymbols = NULL,
                                 WHERE = NULL,
                                 method = "DOMINANT COMPONENT",
                                 simplify = TRUE,
+                                miscellaneous_areas = FALSE,
                                 query_string = FALSE,
                                 dsn = NULL) {
 
@@ -155,21 +157,28 @@ get_SDA_pmgroupname <- function(areasymbols = NULL,
 
 
         if (method %in% c("DOMINANT COMPONENT", "DOMINANT CONDITION")) {
-                comp_selection <- sprintf("AND component.cokey = (%s)", .LIMIT_N("SELECT c1.cokey FROM component AS c1
+                dcq <- sprintf("SELECT c1.cokey FROM component AS c1
+                 INNER JOIN mapunit AS mu1 ON c1.mukey = mu1.mukey AND c1.mukey = mapunit.mukey %s ORDER BY c1.comppct_r DESC, c1.cokey ",
+                      ifelse(miscellaneous_areas, "", " AND NOT c1.compkind = 'Miscellaneous area'"))
+                comp_selection <- sprintf("AND component.cokey = (%s)", .LIMIT_N(
+                  "SELECT c1.cokey FROM component AS c1
                  INNER JOIN mapunit AS mu1 ON c1.mukey = mu1.mukey AND c1.mukey = mapunit.mukey ORDER BY c1.comppct_r DESC, c1.cokey ", n = 1, sqlite = !is.null(dsn)))
         } else {
                 comp_selection <- ""
         }
 
         if (method == "DOMINANT CONDITION") {
-                pm_selection <- sprintf("AND pmgroupname = (%s)", .LIMIT_N("SELECT pmgroupname FROM mapunit AS mu
+                dcq <- sprintf("SELECT pmgroupname FROM mapunit AS mu
                 INNER JOIN component AS c1 ON c1.mukey = mapunit.mukey AND mapunit.mukey = mu.mukey
-                INNER JOIN copmgrp ON copmgrp.cokey = component.cokey
-                GROUP BY pmgroupname, comppct_r ORDER BY SUM(comppct_r) OVER (PARTITION BY pmgroupname) DESC", n = 1, sqlite = !is.null(dsn)))
+                INNER JOIN copmgrp ON copmgrp.cokey = component.cokey %s
+                GROUP BY pmgroupname, comppct_r ORDER BY SUM(comppct_r) OVER (PARTITION BY pmgroupname) DESC",
+                               ifelse(miscellaneous_areas, "", " AND NOT c1.compkind = 'Miscellaneous area'"))
+                pm_selection <- sprintf("AND pmgroupname = (%s)", .LIMIT_N(dcq, n = 1, sqlite = !is.null(dsn)))
         } else {
                 pm_selection <- ""
         }
 
+        misc_area_join_type <- ifelse(miscellaneous_areas, "LEFT", "INNER")
         q <- sprintf(
                 paste0("SELECT DISTINCT
                          legend.areasymbol AS areasymbol,
@@ -180,12 +189,12 @@ get_SDA_pmgroupname <- function(areasymbols = NULL,
                          "%s
                          FROM legend
                          INNER JOIN mapunit ON mapunit.lkey = legend.lkey AND %s
-                         INNER JOIN component ON component.mukey = mapunit.mukey %s
-                         INNER JOIN copmgrp ON copmgrp.cokey = component.cokey %s"),
+                         %s JOIN component ON component.mukey = mapunit.mukey %s %s
+                         %s JOIN copmgrp ON copmgrp.cokey = component.cokey %s"),
                 case_pmgroupname,
                 WHERE,
-                comp_selection,
-                pm_selection
+                misc_area_join_type, comp_selection, ifelse(miscellaneous_areas, "", " AND NOT component.compkind = 'Miscellaneous area'"),
+                misc_area_join_type, pm_selection
         )
 
    if (query_string) {

--- a/R/get_SDA_pmgroupname.R
+++ b/R/get_SDA_pmgroupname.R
@@ -149,7 +149,7 @@ get_SDA_pmgroupname <- function(areasymbols = NULL,
              WHEN pmgroupname LIKE '%shale-calcareous%' THEN 'Miscoded - should be pmorigin'
              WHEN pmgroupname LIKE '%siltstone%' THEN 'Miscoded - should be pmorigin'
              WHEN pmgroupname LIKE '%mixed%' THEN 'Miscellaneous Deposits'
-             WHEN pmgroupname LIKE '%NULL%' THEN 'NULL' ELSE 'NULL' END AS pmgroupname"
+             WHEN pmgroupname LIKE '%NULL%' THEN NULL ELSE NULL END AS pmgroupname"
 
         if (!simplify) {
                 case_pmgroupname <- "pmgroupname"

--- a/man/get_SDA_coecoclass.Rd
+++ b/man/get_SDA_coecoclass.Rd
@@ -34,7 +34,7 @@ get_SDA_coecoclass(
 
 \item{not_rated_value}{Default: \code{"Not assigned"}}
 
-\item{miscellaneous_areas}{Include miscellaneous areas (non-soil components)?}
+\item{miscellaneous_areas}{logical. Include miscellaneous areas (non-soil components)?}
 
 \item{dsn}{Path to local SQLite database or a DBIConnection object. If \code{NULL} (default) use Soil Data Access API via \code{SDA_query()}.}
 }

--- a/man/get_SDA_cosurfmorph.Rd
+++ b/man/get_SDA_cosurfmorph.Rd
@@ -10,6 +10,7 @@ get_SDA_cosurfmorph(
   areasymbols = NULL,
   mukeys = NULL,
   WHERE = NULL,
+  miscellaneous_areas = FALSE,
   db = c("SSURGO", "STATSGO"),
   dsn = NULL,
   query_string = FALSE
@@ -25,6 +26,8 @@ get_SDA_cosurfmorph(
 \item{mukeys}{A vector of map unit keys (e.g. \code{466627})}
 
 \item{WHERE}{WHERE clause added to SQL query. For example: \code{areasymbol = 'CA067'}}
+
+\item{miscellaneous_areas}{Include miscellaneous areas  (non-soil components) in results? Default: \code{FALSE}.}
 
 \item{db}{Either \code{'SSURGO'} (default) or \code{'STATSGO'}. If \code{'SSURGO'} is specified \code{areasymbol = 'US'} records are excluded. If \code{'STATSGO'} only \code{areasymbol = 'US'} records are included.}
 

--- a/man/get_SDA_pmgroupname.Rd
+++ b/man/get_SDA_pmgroupname.Rd
@@ -10,6 +10,7 @@ get_SDA_pmgroupname(
   WHERE = NULL,
   method = "DOMINANT COMPONENT",
   simplify = TRUE,
+  miscellaneous_areas = FALSE,
   query_string = FALSE,
   dsn = NULL
 )
@@ -24,6 +25,8 @@ get_SDA_pmgroupname(
 \item{method}{One of: \code{"Dominant Component"}, \code{"Dominant Condition"}, \code{"None"}}
 
 \item{simplify}{logical; group into generalized parent material groups? Default \code{TRUE}}
+
+\item{miscellaneous_areas}{Include miscellaneous areas  (non-soil components) in results? Default: \code{FALSE}.}
 
 \item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 

--- a/tests/testthat/test-get_SDA_pmgroupname.R
+++ b/tests/testthat/test-get_SDA_pmgroupname.R
@@ -7,13 +7,21 @@ test_that("get_SDA_pmgroupname works", {
   skip_if(is.null(res))
   expect_equal(nrow(res), length(unique(res$mukey)))
   
-  res <- get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE)
+  # some misc areas have geomorph populated (e.g. "Mixed alluvial land", but others, like "Water" are NULL)
+  res <- get_SDA_pmgroupname(mukeys = c(462409, 2462630), simplify = FALSE, method = "dominant condition") # default is miscellaneous_areas=FALSE
+  expect_null(res)
+  
+  res <- get_SDA_pmgroupname(mukeys = c(462409, 2462630), simplify = FALSE, miscellaneous_areas = TRUE, method = "dominant condition")
   skip_if(is.null(res))
   expect_equal(nrow(res), 2)
   
   res <- get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE, method = "none")
   skip_if(is.null(res))
-  expect_equal(nrow(res), 7)
+  expect_equal(nrow(res), 7)  
+  
+  res <- get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE, method = "none", miscellaneous_areas = TRUE)
+  skip_if(is.null(res))
+  expect_equal(nrow(res), 11)
   
   res <- get_SDA_pmgroupname(mukeys = c(461994, 461995), simplify = FALSE, method = "dominant condition")
   skip_if(is.null(res))


### PR DESCRIPTION
- `get_SDA_pmgroupname()`: support for including or excluding misc. areas via `miscellaneous_areas` argument
- `get_SDA_cosurfmorph()`: add `miscellaneous_areas`