### PR TITLE
Bump minimum R version due to anonymous function shorthand usage.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Maintainer: Andrew Brown <andrew.g.brown@usda.gov>
 Description: A collection of functions for reading data from USDA-NCSS soil databases.
 License: GPL (>= 3)
 LazyLoad: yes
-Depends: R (>= 3.5.0)
+Depends: R (>= 4.1.0)
 Imports: grDevices, graphics, stats, utils, methods, aqp, data.table, DBI, curl
 Suggests: jsonlite, httr, xml2, rvest, sf, wk, terra, raster, odbc, RSQLite, testthat, scales
 Repository: CRAN


### PR DESCRIPTION
`r/uncode.R` uses the new `\(x)` anonymous function shorthand introduced in R 4.1, so the minimum R version needs a bump.

Alternatively use of the shorthand could be removed to keep the current minimum version.