### PR TITLE
fetchKSSL: Fix for "status was 'SSL connect error'"

### DIFF
--- a/R/fetchKSSL.R
+++ b/R/fetchKSSL.R
@@ -46,13 +46,15 @@
 .getExtended_SoilWeb <- function(f) {
 
   # KSSL geochem, XRD, glass
-  extended.url <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=extended', f))
-
+  x <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=extended', f))
+  
+  tf <- tempfile()
+  curl::curl_download(x, tf, quiet = TRUE, mode = "wb", handle = .soilDB_curl_handle())
+  
   ## get data
-  # note: missing data are returned as FALSE by the API
-  # when data are available, list of data.frame objects
-  ext <- jsonlite::fromJSON(gzcon(url(extended.url)))
-  # unlink(tf)
+  # list of dataframe objects; note: missing data are returned as FALSE
+  ext <- jsonlite::fromJSON(gzfile(tf))
+  unlink(tf)
 
   # done
   return(ext)
@@ -62,13 +64,16 @@
 .getMorphologic_SoilWeb <- function(f) {
 
   # NASIS morphology
-  morph.url <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=nasis_morphologic', f))
+  x <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=nasis_morphologic', f))
 
+  tf <- tempfile()
+  curl::curl_download(x, tf, quiet = TRUE, mode = "wb", handle = .soilDB_curl_handle())
+  
   ## get data
-  # note: missing data are returned as FALSE
-  # list of dataframe objects
-  m <- jsonlite::fromJSON(gzcon(url(morph.url)))
-
+  # list of dataframe objects; note: missing data are returned as FALSE
+  m <- jsonlite::fromJSON(gzfile(tf))
+  unlink(tf)
+  
   # done
   return(m)
 }
@@ -78,13 +83,16 @@
 .getKSSL_SoilWeb <- function(f) {
 
   # KSSL site + horizon
-  site_hz.url <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=site_hz', f))
+  x <- URLencode(paste0('https://casoilresource.lawr.ucdavis.edu/soil_web/kssl/query.php?gzip=1&format=json&what=site_hz', f))
 
-  # ## get data
-  # # note: missing data are returned as FALSE
-  # # list of dataframe objects
-  site_hz <- jsonlite::fromJSON(gzcon(url(site_hz.url)))
-
+  tf <- tempfile()
+  curl::curl_download(x, tf, quiet = TRUE, mode = "wb", handle = .soilDB_curl_handle())
+  
+  ## get data
+  # list of dataframe objects; note: missing data are returned as FALSE
+  site_hz <- jsonlite::fromJSON(gzfile(tf))
+  unlink(tf)
+  
   # report missing data
   if(
     all(


### PR DESCRIPTION
Thanks to Ben Marshall @Kramdog for bringing this up / reminding me that the SSL verification was still an issue in some cases. Since jsonlite changed behind the scenes, we need to attend to fetchKSSL-related downloads.

This updates `fetchKSSL()` to use {curl} internally for downloading the gzipped JSON from SoilWeb. This was what was done implicitly w/ `fromJSON()` w/ jsonlite <1.8.1, but with the `ssl_verifyhost` option set in the header.

While the base R approach / default headers included in jsonlite >1.8.1 work fine on non-gov machines we occasionally encounter errors related to SSL verification when in the office or connected to VPN, i.e.
![image](https://user-images.githubusercontent.com/20842828/193907294-98c6a752-aa4d-4408-bbc4-d9a66c0eb814.png)

Since we recently set up {curl}-based approach for replacing `download.file()` (due to timeout and SSL limitations), we just need to use the standard soilDB curl handle (including  ssl_verifyhost=0) to sort this out. The gzipped json is downloaded to a temporary file with curl, then read as a `gzfile()` connection into `jsonlite::fromJSON()`, and then the temp file is unlinked
