### PR TITLE
Use LEFT join for component parent material and geomorph

### DIFF
--- a/R/get_component_data_from_NASIS_db.R
+++ b/R/get_component_data_from_NASIS_db.R
@@ -256,9 +256,9 @@ get_component_cogeomorph_data_from_NASIS_db <- function(SS = TRUE, dsn = NULL) {
 
   FROM
   component_View_1 AS co
-  INNER JOIN cogeomordesc_View_1 AS cogeo ON co.coiid = cogeo.coiidref
-  INNER JOIN geomorfeat ON geomorfeat.geomfiid = cogeo.geomfiidref
-  INNER JOIN geomorfeattype ON geomorfeattype.geomftiid = geomorfeat.geomftiidref
+  LEFT JOIN cogeomordesc_View_1 AS cogeo ON co.coiid = cogeo.coiidref
+  LEFT JOIN geomorfeat ON geomorfeat.geomfiid = cogeo.geomfiidref
+  LEFT JOIN geomorfeattype ON geomorfeattype.geomftiid = geomorfeat.geomftiidref
 
   ORDER BY coiid, geomfeatid ASC;"
 
@@ -287,9 +287,9 @@ get_component_cogeomorph_data_from_NASIS_db2 <- function(SS = TRUE, dsn = NULL) 
 
   FROM
   component_View_1 AS co
-  INNER JOIN cogeomordesc_View_1 AS cogeo ON co.coiid = cogeo.coiidref
-  INNER JOIN geomorfeat ON geomorfeat.geomfiid = cogeo.geomfiidref
-  INNER JOIN geomorfeattype ON geomorfeattype.geomftiid = geomorfeat.geomftiidref
+  LEFT JOIN cogeomordesc_View_1 AS cogeo ON co.coiid = cogeo.coiidref
+  LEFT JOIN geomorfeat ON geomorfeat.geomfiid = cogeo.geomfiidref
+  LEFT JOIN geomorfeattype ON geomorfeattype.geomftiid = geomorfeat.geomftiidref
   LEFT JOIN cosurfmorphhpp ON cosurfmorphhpp.cogeomdiidref = cogeo.cogeomdiid
   LEFT JOIN cosurfmorphgc ON cosurfmorphgc.cogeomdiidref = cogeo.cogeomdiid
   LEFT JOIN cosurfmorphmr ON cosurfmorphmr.cogeomdiidref = cogeo.cogeomdiid
@@ -324,12 +324,12 @@ get_component_copm_data_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
   
-  q <- "SELECT cpmg.coiidref as coiid, cpm.seqnum as seqnum, pmorder, pmdept_r, pmdepb_r, pmmodifier, pmgenmod, pmkind, pmorigin
+  q <- "SELECT co.coiid as coiid, cpm.seqnum as seqnum, pmorder, pmdept_r, pmdepb_r, pmmodifier, pmgenmod, pmkind, pmorigin
 
   FROM
   component_View_1 AS co
-  INNER JOIN copmgrp_View_1 AS cpmg ON cpmg.coiidref = co.coiid
-  INNER JOIN copm_View_1 AS cpm ON cpm.copmgrpiidref = cpmg.copmgrpiid
+  LEFT JOIN copmgrp_View_1 AS cpmg ON cpmg.coiidref = co.coiid
+  LEFT JOIN copm_View_1 AS cpm ON cpm.copmgrpiidref = cpmg.copmgrpiid
 
   ORDER BY coiidref, seqnum, pmorder, copmgrpiid ASC;"
 


### PR DESCRIPTION
This closes a long-standing issue #31.

For quality control and completeness reasons, LEFT joins work better in this context as all component IDs are included in the results. While INNER and LEFT join results are both safely joined into `fetchNASIS()` result regardless, users of the lower-level functions (or those doing QC directly on those results) will benefit from this change.

See also https://github.com/ncss-tech/soilDB/pull/287