### PR TITLE
get_SDA_coecoclass: add `method="all"`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.7.9
+Version: 2.7.9.9000
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov"),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,6 @@
 
  - `get_SDA_coecoclass()` gains `method="all"` for aggregating information about ecological sites and related components. The method performs a condition-based aggregation for each ecological site condition in the map unit, producing a "wide" data.frame result with as many columns as needed to portray all site conditions.
  
- - `fetchSDA_spatial()` gains `geom.src="mlrapolygon"` for obtaining Major Land Resource Area (MLRA) polygon boundaries. When using this geometry source `x` is a vector of `MLRARSYM` (MLRA Symbols).
- 
-   - The geometry source is the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access. Instead of SDA, GDAL utilities are used to read a zipped ESRI Shapefile from a remote URL: <https://www.nrcs.usda.gov/sites/default/files/2022-10/MLRA_52_2022.zip>. Therefore, most additional `fetchSDA_spatial()` arguments are _not_ currently supported for the MLRA geometry source. In the future a `mlrapolygon` table may be added to SDA (analogous to  `mupolygon` and `sapolygon`), and the function will be updated accordingly at that time.
-
 # soilDB 2.7.9 (2023-09-01)
 
 ## Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# soilDB 2.7.9.9000 (2023-09-18)
+
+ - `get_SDA_coecoclass()` gains `method="all"` for aggregating information about ecological sites and related components. The method performs a condition-based aggregation for each ecological site condition in the map unit, producing a "wide" data.frame result with as many columns as needed to portray all site conditions.
+ 
+ - `fetchSDA_spatial()` gains `geom.src="mlrapolygon"` for obtaining Major Land Resource Area (MLRA) polygon boundaries. When using this geometry source `x` is a vector of `MLRARSYM` (MLRA Symbols).
+ 
+   - The geometry source is the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access. Instead of SDA, GDAL utilities are used to read a zipped ESRI Shapefile from a remote URL: <https://www.nrcs.usda.gov/sites/default/files/2022-10/MLRA_52_2022.zip>. Therefore, most additional `fetchSDA_spatial()` arguments are _not_ currently supported for the MLRA geometry source. In the future a `mlrapolygon` table may be added to SDA (analogous to  `mupolygon` and `sapolygon`), and the function will be updated accordingly at that time.
+
 # soilDB 2.7.9 (2023-09-01)
 
 ## Bug Fixes

--- a/R/SSURGO_query.R
+++ b/R/SSURGO_query.R
@@ -1,0 +1,31 @@
+#' Query arbitrary data sources that use the SSURGO data model
+#'
+#' This is a simple wrapper function allowing queries to be passed to a variety of database drivers. It is assumed the database generally follows the SSURGO schema, regardless of the driver being used. 
+#' 
+#' @param x An SQL query. If `dsn` is NULL `x` is in T-SQL dialect. If `dsn` is a _character_ (file path), the SQLite dialect is used. If `dsn` is a `DBIConnection`, any SQL dialect compatible with the DBI source can be used.
+#' @param dsn Default: `NULL` uses Soil Data Access remote data source via REST API. Alternately `dsn` may be a _character_ file path to an SQLite database, or a `DBIConnection` that has already been created.
+#'
+#' @details No processing of the query string is performed by this function, so all values of `x` must be adjusted according to the value of `dsn`.
+#'
+#' @return A _data.frame_, or _try-error_ on error
+#' @noRd
+.SSURGO_query <- function(x, dsn = NULL) {
+  if (is.null(dsn)) {
+    return(SDA_query(x))
+  } else {
+    if (inherits(dsn, 'DBIConnection')) {
+      return(DBI::dbGetQuery(con, x))
+    } else if (file.exists(dsn)) {
+      if (requireNamespace("RSQLite")) {
+        con <- try(RSQLite::dbConnect(RSQLite::SQLite(), dsn))
+        if (!inherits(con, 'try-error')) {
+          return(RSQLite::dbGetQuery(con, x))
+        } else {
+          return(invisible(con))
+        }
+      }
+    } else {
+      stop("Invalid data source name: ", dsn, call. = FALSE)
+    }
+  }
+}

--- a/R/SSURGO_query.R
+++ b/R/SSURGO_query.R
@@ -18,6 +18,7 @@
     } else if (file.exists(dsn)) {
       if (requireNamespace("RSQLite")) {
         con <- try(RSQLite::dbConnect(RSQLite::SQLite(), dsn))
+        on.exit(DBI::dbDisconnect(con), add = TRUE)
         if (!inherits(con, 'try-error')) {
           return(RSQLite::dbGetQuery(con, x))
         } else {

--- a/R/get_SDA_coecoclass.R
+++ b/R/get_SDA_coecoclass.R
@@ -1,10 +1,11 @@
 #' Get mapunit ecological sites from Soil Data Access 
 #' 
-#' @details When `method="Dominant Condition"` an additional field `ecoclasspct_r` is returned in the result with the sum of `comppct_r` that have the dominant condition `ecoclassid`. The component with the greatest `comppct_r` is returned for the `component` and `coecosite` level information. 
+#' @details When `method="Dominant Condition"` an additional field `ecoclasspct_r` is returned in the result
+#' with the sum of `comppct_r` that have the dominant condition `ecoclassid`. The component with the greatest 
+#' `comppct_r` is returned for the `component` and `coecosite` level information. 
 #' 
 #' Note that if there are multiple `coecoclasskey` per `ecoclassid` there may be more than one record per component.
-#' 
-#' @param method aggregation method. One of: "Dominant Component", "Dominant Condition", "None". If "None" is selected one row will be returned per component, otherwise one row will be returned per map unit.
+#' @param method aggregation method. One of: `"Dominant Component"`, `"Dominant Condition"`, `"All"` or `"None"` (default). If `method="all"` multiple numbered columns represent site composition within each map unit e.g. `site1...`, `site2...`. If `method="none"` is selected one row will be returned per _component_; in all other cases one row will be returned per _map unit_.
 #' @param areasymbols vector of soil survey area symbols
 #' @param mukeys vector of map unit keys
 #' @param WHERE character containing SQL WHERE clause specified in terms of fields in `legend`, `mapunit`, `component` or `coecosite` tables, used in lieu of `mukeys` or `areasymbols`
@@ -25,7 +26,26 @@ get_SDA_coecoclass <- function(method = "None",
                                miscellaneous_areas = TRUE,
                                include_minors = TRUE,
                                dsn = NULL) {
-  method <- match.arg(toupper(method), c('NONE', "DOMINANT COMPONENT", "DOMINANT CONDITION"))
+  method <- match.arg(toupper(method), c("NONE", "ALL", "DOMINANT COMPONENT", "DOMINANT CONDITION"))
+  
+  if (method == "ALL") {
+    if (!is.null(WHERE)) {
+      stop("`method='all'` does not support custom `WHERE` clause", call. = FALSE)
+    }
+    
+    if (isTRUE(query_string)) {
+      stop("`method='all'` does not support custom `query_string=TRUE`", call. = FALSE)
+    } 
+    
+    return(.get_SDA_coecoclass_agg(areasymbols = areasymbols, 
+                                   mukeys = mukeys, 
+                                   ecoclasstypename = ecoclasstypename,
+                                   ecoclassref = ecoclassref,
+                                   not_rated_value = not_rated_value,
+                                   miscellaneous_areas = miscellaneous_areas,
+                                   include_minors = include_minors,
+                                   dsn = dsn))
+  }
   
   if (!is.null(ecoclassref)) {
     ecoclassref_in <- soilDB::format_SQL_in_statement(ecoclassref)
@@ -120,5 +140,148 @@ get_SDA_coecoclass <- function(method = "None",
   res2 <- res[idx2$idx, ]
   res2$ecoclasspct_r <- idx2$ecoclasspct_r
   res2
+}
+
+.get_SDA_coecoclass_agg <- function(areasymbols = NULL,
+                                    mukeys = NULL,
+                                    ecoclasstypename = NULL,
+                                    ecoclassref = "Ecological Site Description Database",
+                                    not_rated_value = "Not assigned",
+                                    miscellaneous_areas = TRUE,
+                                    include_minors = TRUE,
+                                    dsn = NULL,
+                                    threshold = 0) {
+                                      
+  comppct_r <- NULL; condpct_r <- NULL; compname <- NULL; ecoclasstypename <- NULL
+  areasymbol <- NULL; compnames <- NULL; unassigned <- NULL;
+  mukey <- NULL; .N <- NULL; .SD <- NULL; .GRP <- NULL;
+  
+  if (!is.null(areasymbols)) {
+    res0 <- do.call('rbind', lapply(areasymbols, function(x) {
+      soilDB::SDA_query(paste0(
+        "SELECT DISTINCT mukey, nationalmusym, muname FROM mapunit
+        INNER JOIN legend ON legend.lkey = mapunit.lkey
+        WHERE areasymbol = '", x, "'"
+      ))
+    }))
+    idx <- soilDB::makeChunks(res0$mukey, 1000)
+    l <- split(res0$mukey, idx)
+  } else {
+    idx <- soilDB::makeChunks(mukeys, 1000)
+    l <- split(mukeys, idx)
+    res0 <- do.call('rbind', lapply(l, function(x) {
+      soilDB::SDA_query(paste0(
+        "SELECT DISTINCT mukey, nationalmusym, muname FROM mapunit
+        INNER JOIN legend ON legend.lkey = mapunit.lkey
+        WHERE mukey IN ", format_SQL_in_statement(x), ""
+      ))
+    }))
+    idx <- soilDB::makeChunks(res0$mukey, 1000)
+    l <- split(res0$mukey, idx)
+  }
+  
+  res1 <- do.call('rbind', lapply(l, function(x) {
+    soilDB::get_SDA_coecoclass(mukeys = x, 
+                               ecoclasstypename = ecoclasstypename,
+                               ecoclassref = ecoclassref,
+                               not_rated_value = not_rated_value,
+                               miscellaneous_areas = miscellaneous_areas,
+                               include_minors = include_minors,
+                               dsn = dsn)
+  }))
+  
+  res1 <- data.table::data.table(res1)[, .SD[order(comppct_r, decreasing = TRUE), ], by = "mukey"]
+  res2 <- data.table::data.table(subset(res1, areasymbol != "US"))
+  
+  # remove FSG etc. some components have no ES assigned, but have other eco class
+  idx <- !res2$ecoclassref %in% c(not_rated_value, "Not assigned", "Ecological Site Description Database") &
+    !res2$ecoclasstypename %in% c(not_rated_value, "Not assigned", "NRCS Rangeland Site", "NRCS Forestland Site")
+  res2$ecoclassid[idx] <- not_rated_value
+  res2$ecoclassref[idx] <- not_rated_value
+  res2$ecoclassname[idx] <- not_rated_value
+  res2$ecoclasstypename[idx] <- not_rated_value
+  
+  res3 <- res2[, list(
+    condpct_r = sum(comppct_r, na.rm = TRUE),
+    compnames = paste0(compname[ecoclasstypename %in% c("NRCS Rangeland Site", 
+                                                        "NRCS Forestland Site")],
+                       collapse = ", "),
+    unassigned = paste0(compname[!ecoclasstypename %in% c("NRCS Rangeland Site", 
+                                                          "NRCS Forestland Site")],
+                        collapse = ", ")
+  ), by = c("mukey", "ecoclassid", "ecoclassname")][, rbind(
+    .SD[, 1:4],
+    data.frame(
+      ecoclassid = not_rated_value,
+      ecoclassname = not_rated_value,
+      condpct_r = 100 - sum(condpct_r[nchar(compnames) > 0], na.rm = TRUE),
+      compnames = paste0(unassigned[nchar(unassigned) > 0 & !unassigned %in% compnames],
+                         collapse = ",")
+    )
+  ), by = c("mukey")][order(mukey, -condpct_r), ]
+  res3 <- res3[nchar(res3$compnames) > 0,]
+  
+  # could do up to max_sites, but generally cut to some minimum condition percentage `threshold`
+  max_sites <- max(res3[, .N, by = "mukey"]$N)
+  res3 <- res3[res3$condpct_r >= threshold, ]
+  max_sites_pruned <- max(res3[, .N, by = "mukey"]$N)
+  res3$condpct_r <- as.integer(res3$condpct_r)
+  
+  if (max_sites > max_sites_pruned) {
+    message("maximum number of sites per mukey: ", max_sites)
+    message("using maximum number of sites above threshold (",
+            threshold, "%) per mukey: ", max_sites_pruned)
+  }
+  
+  .coecoclass_long_to_wide <- function(x, group) {
+    res <- data.frame(grpid = group)
+    for (i in 1:max_sites_pruned) {
+      if (i > nrow(x)) {
+        d <- data.frame(
+          siten = NA_character_,
+          sitenname = NA_character_,
+          sitencompname = NA_character_,
+          sitenpct_r = NA_integer_,
+          sitenlink = NA_character_
+        )
+      } else {
+        d <- data.frame(
+          siten = ifelse(isTRUE(is.na(x$ecoclassid[i])), not_rated_value, x$ecoclassid[i]),
+          sitenname = ifelse(isTRUE(is.na(x$ecoclassname[i])), not_rated_value, x$ecoclassname[i]),
+          sitencompname = ifelse(isTRUE(is.na(x$compnames[i])), NA_character_, x$compnames[i]),
+          sitenpct_r = ifelse(isTRUE(is.na(x$condpct_r[i])), 0, x$condpct_r[i]),
+          sitenlink = ifelse(
+            isTRUE(x$ecoclassid[i] == not_rated_value | is.na(x$ecoclassid[i])),
+            NA_character_,
+            paste0(
+              "https://edit.jornada.nmsu.edu/catalogs/esd/",
+              substr(x$ecoclassid[i], 2, 5),
+              "/",
+              x$ecoclassid[i]
+            )
+          )
+        )
+        # sitenpdf = ifelse(isTRUE(x$ecoclassid[i] == "Not assigned"), NA_character_,
+        #                   paste0(
+        #                     "https://edit.jornada.nmsu.edu/services/descriptions/esd/",
+        #                     substr(x$ecoclassid[i], 2, 5), "/", x$ecoclassid[i], ".pdf"
+        #                   )))
+      }
+      colnames(d) <- c(
+        paste0("site", i), paste0("site", i, "name"), paste0("site", i, "compname"),
+        paste0("site", i, "pct_r"), paste0("site", i, "link")
+      )
+      res <- cbind(res, d)
+    }
+    res
+  }
+  
+  res <- merge(data.table::data.table(res0), res3, 
+               by = "mukey", all.x = TRUE)[, 
+          .coecoclass_long_to_wide(.SD, .GRP), 
+          by = c("mukey", "muname", "nationalmusym"), ]
+  
+  res$grpid <- NULL
+  res
 }
 

--- a/man/get_SDA_coecoclass.Rd
+++ b/man/get_SDA_coecoclass.Rd
@@ -19,7 +19,7 @@ get_SDA_coecoclass(
 )
 }
 \arguments{
-\item{method}{aggregation method. One of: "Dominant Component", "Dominant Condition", "None". If "None" is selected one row will be returned per component, otherwise one row will be returned per map unit.}
+\item{method}{aggregation method. One of: \code{"Dominant Component"}, \code{"Dominant Condition"}, \code{"All"} or \code{"None"} (default). If \code{method="all"} multiple numbered columns represent site composition within each map unit e.g. \code{site1...}, \code{site2...}. If \code{method="none"} is selected one row will be returned per \emph{component}; in all other cases one row will be returned per \emph{map unit}.}
 
 \item{areasymbols}{vector of soil survey area symbols}
 
@@ -45,7 +45,9 @@ get_SDA_coecoclass(
 Get mapunit ecological sites from Soil Data Access
 }
 \details{
-When \code{method="Dominant Condition"} an additional field \code{ecoclasspct_r} is returned in the result with the sum of \code{comppct_r} that have the dominant condition \code{ecoclassid}. The component with the greatest \code{comppct_r} is returned for the \code{component} and \code{coecosite} level information.
+When \code{method="Dominant Condition"} an additional field \code{ecoclasspct_r} is returned in the result
+with the sum of \code{comppct_r} that have the dominant condition \code{ecoclassid}. The component with the greatest
+\code{comppct_r} is returned for the \code{component} and \code{coecosite} level information.
 
 Note that if there are multiple \code{coecoclasskey} per \code{ecoclassid} there may be more than one record per component.
 }

--- a/man/get_SDA_coecoclass.Rd
+++ b/man/get_SDA_coecoclass.Rd
@@ -40,7 +40,7 @@ get_SDA_coecoclass(
 
 \item{include_minors}{logical. Include minor components? Default: \code{TRUE}.}
 
-\item{threshold}{integer. Default: \code{0}. Minimum component percentage (RV) for inclusion. Used only for \code{method="all"}.}
+\item{threshold}{integer. Default: \code{0}. Minimum combined component percentage (RV) for inclusion of a mapunit's ecological site in wide-format tabular sumamry. Used only for \code{method="all"}.}
 
 \item{dsn}{Path to local SQLite database or a DBIConnection object. If \code{NULL} (default) use Soil Data Access API via \code{SDA_query()}.}
 }

--- a/man/get_SDA_coecoclass.Rd
+++ b/man/get_SDA_coecoclass.Rd
@@ -15,6 +15,7 @@ get_SDA_coecoclass(
   not_rated_value = "Not assigned",
   miscellaneous_areas = TRUE,
   include_minors = TRUE,
+  threshold = 0,
   dsn = NULL
 )
 }
@@ -38,6 +39,8 @@ get_SDA_coecoclass(
 \item{miscellaneous_areas}{logical. Include miscellaneous areas (non-soil components)?}
 
 \item{include_minors}{logical. Include minor components? Default: \code{TRUE}.}
+
+\item{threshold}{integer. Default: \code{0}. Minimum component percentage (RV) for inclusion. Used only for \code{method="all"}.}
 
 \item{dsn}{Path to local SQLite database or a DBIConnection object. If \code{NULL} (default) use Soil Data Access API via \code{SDA_query()}.}
 }


### PR DESCRIPTION
The method performs a condition-based aggregation for each ecological site condition in the map unit, producing a "wide" data.frame result with as many columns as needed to portray all site conditions. Used to produce aggregate mapunit level (1:1 with mukey) ecological site composition summaries. 

Ecological site conditions have been a recurring theme for me so I am now in this PR considering putting the code I use to boil down ES:mapunit relationships into soilDB.

For example:

``` r
soilDB::get_SDA_coecoclass(method = "all", areasymbols = "CA630") 
#> single result set, returning a data.frame
#>        mukey
#>   1: 1865918
#>   2: 1865926
#>   3: 1865927
#>   4: 1865928
#>   5: 1865929
#>  ---        
#> 124: 2924955
#> 125: 3225132
#> 126: 3225133
#> 127: 3225134
#> 128: 3225135
#>                                                                                   muname
#>   1:                         Goldwall-Toomes-Rock outcrop complex, 1 to 8 percent slopes
#>   2:                             Loafercreek-Gopheridge complex, 30 to 60 percent slopes
#>   3:                                  Crimeahouse-Sixbit complex, 3 to 15 percent slopes
#>   4:                                 Crimeahouse-Sixbit complex, 15 to 30 percent slopes
#>   5:                        Copperopolis-Whiterock complex, 2 to 8 percent slopes, rocky
#>  ---                                                                                    
#> 124: Psammentic Haploxerolls-Mollic Fluvaquents-Riverwash-complex, 0 to 8 percent slopes
#> 125:              Bonanza-Loafercreek complex, 3 to 15 percent slopes, low precipitation
#> 126:                     Bonanza-Loafercreek-Jasperpeak complex, 15 to 30 percent slopes
#> 127:                     Trabuco-Jasperpeak-Rock outcrop complex, 8 to 30 percent slopes
#> 128:                 Gopheridge-Jasperpeak-Rock outcrop complex, 30 to 60 percent slopes
#>      nationalmusym       site1
#>   1:         20mmx R018XI101CA
#>   2:         20mn5 F018XI201CA
#>   3:         20mn6 R018XI102CA
#>   4:         20mn7 R018XI102CA
#>   5:         20mn8 F018XI200CA
#>  ---                          
#> 124:         2x4d2 R018XX101CA
#> 125:         2z5lk R018XI163CA
#> 126:         2z5ll R018XI163CA
#> 127:         2z5lq F018XI205CA
#> 128:         2z5ln R018XI106CA
#>                                                                                      site1name
#>   1:                                                                  Shallow Latite Ridgetops
#>   2:                                                         Moderately Deep Thermic Foothills
#>   3: Thermic Ultramafic Foothills Extremely High Magnesium Content (Ca:Mg Ratio Less Than 0.5)
#>   4: Thermic Ultramafic Foothills Extremely High Magnesium Content (Ca:Mg Ratio Less Than 0.5)
#>   5:                                                                   Low Elevation Foothills
#>  ---                                                                                          
#> 124:                                           Mid Gradient Riparian Complex, 4Th Order Stream
#> 125:                                                                 Thermic Low Rolling Hills
#> 126:                                                                 Thermic Low Rolling Hills
#> 127:                                                                Thermic Granitic Foothills
#> 128:                                                 Steep Thermic Hillslopes and Canyon Walls
#>                                                        site1compname site1pct_r
#>   1:                            Goldwall, Toomes, Aquic Haploxeralfs         75
#>   2:                             Loafercreek, Gopheridge, Motherlode         84
#>   3:                                    Crimeahouse, Sixbit, Fancher         97
#>   4:                                             Crimeahouse, Sixbit         94
#>   5:                                         Copperopolis, Whiterock         83
#>  ---                                                                           
#> 124: Psammentic Haploxerolls, Mollic Fluvaquents, Ultic Haploxerolls         67
#> 125:                                                Bonanza, Redding         76
#> 126:                                Bonanza, Jasperpeak, Vistarobles         72
#> 127:                                                         Trabuco         55
#> 128:                                          Gopheridge, Jasperpeak         74
#>                                                        site1link        site2
#>   1: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI101CA Not assigned
#>   2: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI201CA Not assigned
#>   3: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI102CA Not assigned
#>   4: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI102CA Not assigned
#>   5: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI200CA Not assigned
#>  ---                                                                         
#> 124: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XX101CA Not assigned
#> 125: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI163CA  F018XI208CA
#> 126: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI163CA  F018XI200CA
#> 127: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI205CA  F018XI200CA
#> 128: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI106CA Not assigned
#>                                site2name
#>   1:                        Not assigned
#>   2:                        Not assigned
#>   3:                        Not assigned
#>   4:                        Not assigned
#>   5:                        Not assigned
#>  ---                                    
#> 124:                        Not assigned
#> 125: Deep Low Rolling Hills and Terraces
#> 126:             Low Elevation Foothills
#> 127:             Low Elevation Foothills
#> 128:                        Not assigned
#>                                 site2compname site2pct_r
#>   1:                             Rock outcrop         20
#>   2:                 Rock outcrop, Mined land          6
#>   3:                 Rock outcrop, Mined land          3
#>   4:                 Rock outcrop, Mined land          6
#>   5:                 Rock outcrop, Mined land         12
#>  ---                                                    
#> 124: Riverwash, Anthraltic Xerorthents, Water         33
#> 125:                              Loafercreek         18
#> 126:                              Loafercreek         22
#> 127:                               Jasperpeak         24
#> 128:                 Rock outcrop, Mined land         16
#>                                                        site2link        site3
#>   1:                                                        <NA>  F018XI207CA
#>   2:                                                        <NA>  F018XI202CA
#>   3:                                                        <NA>         <NA>
#>   4:                                                        <NA>         <NA>
#>   5:                                                        <NA>  R018XI111CA
#>  ---                                                                         
#> 124:                                                        <NA>         <NA>
#> 125: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI208CA Not assigned
#> 126: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI200CA Not assigned
#> 127: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI200CA Not assigned
#> 128:                                                        <NA>  F018XI202CA
#>                              site3name            site3compname site3pct_r
#>   1:  Deep Volcanic Plateaus and Hills        Ultic Argixerolls          5
#>   2:     Deep Thermic Steep Hillslopes              Gardellones          5
#>   3:                              <NA>                     <NA>         NA
#>   4:                              <NA>                     <NA>         NA
#>   5: Low Gradient, Concave Depressions       Aquic Haploxeralfs          5
#>  ---                                                                      
#> 124:                              <NA>                     <NA>         NA
#> 125:                      Not assigned Rock outcrop, Mined land          6
#> 126:                      Not assigned Rock outcrop, Mined land          6
#> 127:                      Not assigned Rock outcrop, Mined land         14
#> 128:     Deep Thermic Steep Hillslopes                  Trabuco         10
#>                                                        site3link       site4
#>   1: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI207CA        <NA>
#>   2: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI202CA F018XI200CA
#>   3:                                                        <NA>        <NA>
#>   4:                                                        <NA>        <NA>
#>   5: https://edit.jornada.nmsu.edu/catalogs/esd/018X/R018XI111CA        <NA>
#>  ---                                                                        
#> 124:                                                        <NA>        <NA>
#> 125:                                                        <NA>        <NA>
#> 126:                                                        <NA>        <NA>
#> 127:                                                        <NA> F018XI201CA
#> 128: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI202CA        <NA>
#>                              site4name site4compname site4pct_r
#>   1:                              <NA>          <NA>         NA
#>   2:           Low Elevation Foothills    Jasperpeak          5
#>   3:                              <NA>          <NA>         NA
#>   4:                              <NA>          <NA>         NA
#>   5:                              <NA>          <NA>         NA
#>  ---                                                           
#> 124:                              <NA>          <NA>         NA
#> 125:                              <NA>          <NA>         NA
#> 126:                              <NA>          <NA>         NA
#> 127: Moderately Deep Thermic Foothills   Loafercreek          7
#> 128:                              <NA>          <NA>         NA
#>                                                        site4link site5
#>   1:                                                        <NA>  <NA>
#>   2: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI200CA  <NA>
#>   3:                                                        <NA>  <NA>
#>   4:                                                        <NA>  <NA>
#>   5:                                                        <NA>  <NA>
#>  ---                                                                  
#> 124:                                                        <NA>  <NA>
#> 125:                                                        <NA>  <NA>
#> 126:                                                        <NA>  <NA>
#> 127: https://edit.jornada.nmsu.edu/catalogs/esd/018X/F018XI201CA  <NA>
#> 128:                                                        <NA>  <NA>
#>      site5name site5compname site5pct_r site5link
#>   1:      <NA>          <NA>         NA      <NA>
#>   2:      <NA>          <NA>         NA      <NA>
#>   3:      <NA>          <NA>         NA      <NA>
#>   4:      <NA>          <NA>         NA      <NA>
#>   5:      <NA>          <NA>         NA      <NA>
#>  ---                                             
#> 124:      <NA>          <NA>         NA      <NA>
#> 125:      <NA>          <NA>         NA      <NA>
#> 126:      <NA>          <NA>         NA      <NA>
#> 127:      <NA>          <NA>         NA      <NA>
#> 128:      <NA>          <NA>         NA      <NA>
```

This is a generalization of the routine used for "ESPOLYGON" QA tool developed for QA/QC in southwest region.

TODO:
 - [x] Make robust to local (SQLite) or remote (SDA_query()/MSSQL) data sources
 - [x] Expose `threshold` argument /9via `get_SDA_coecoclass()`)
 - [x] Consider how to do custom extensions and aggregations within existing framework--e.g. calculate weighted average properties across all components within "site1". This may warrant a new function and/or use of `get_SDA_property()`