### PR TITLE
fetchSDA_spatial: add `geom.src='mlrapolygon'` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# soilDB 2.7.9.9000 (2023-09-18)
+ - `fetchSDA_spatial()` gains `geom.src="mlrapolygon"` for obtaining Major Land Resource Area (MLRA) polygon boundaries. When using this geometry source `x` is a vector of `MLRARSYM` (MLRA Symbols).
+ 
+   - The geometry source is the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access. Instead of SDA, GDAL utilities are used to read a zipped ESRI Shapefile from a remote URL: <https://www.nrcs.usda.gov/sites/default/files/2022-10/MLRA_52_2022.zip>. Therefore, most additional `fetchSDA_spatial()` arguments are _not_ currently supported for the MLRA geometry source. In the future a `mlrapolygon` table may be added to SDA (analogous to  `mupolygon` and `sapolygon`), and the function will be updated accordingly at that time.
+
+
 # soilDB 2.7.9 (2023-09-01)
 
 ## Bug Fixes

--- a/man/fetchSDA_spatial.Rd
+++ b/man/fetchSDA_spatial.Rd
@@ -52,7 +52,7 @@ Note that STATSGO data are fetched where \code{CLIPAREASYMBOL = 'US'} to avoid d
 
 A prototype interface, \code{geom.src="mlrapolygon"}, is provided for obtaining Major Land Resource Area (MLRA) polygon
 boundaries. When using this geometry source \code{x} is a vector of \code{MLRARSYM} (MLRA Symbols). The geometry source is
-the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access.Instead of SDA, GDAL utilities
+the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access. Instead of SDA, GDAL utilities
 are used to read a zipped ESRI Shapefile from a remote URL: \url{https://www.nrcs.usda.gov/sites/default/files/2022-10/MLRA_52_2022.zip}.
 Therefore, most additional \code{fetchSDA_spatial()} arguments are \emph{not} currently supported for the MLRA geometry source.
 In the future a \code{mlrapolygon} table may be added to SDA (analogous to  \code{mupolygon} and \code{sapolygon}),

--- a/man/fetchSDA_spatial.Rd
+++ b/man/fetchSDA_spatial.Rd
@@ -17,15 +17,15 @@ fetchSDA_spatial(
 )
 }
 \arguments{
-\item{x}{A vector of map unit keys (\code{mukey}) or national map unit symbols (\code{nmusym}) for \code{mupolygon} geometry OR legend keys (\code{lkey}) or soil survey area symbols (\code{areasymbol}) for \code{sapolygon} geometry}
+\item{x}{A vector of map unit keys (\code{mukey}) or national map unit symbols (\code{nmusym}) for \code{mupolygon} geometry OR legend keys (\code{lkey}) or soil survey area symbols (\code{areasymbol}) for \code{sapolygon} geometry. If \code{geom.src="mlrapolygon"} then \code{x} refers to \code{MLRARSYM} (major land resource area symbols).}
 
-\item{by.col}{Column name containing map unit identifier \code{"mukey"}, \code{"nmusym"}/\code{"nationalmusym"} for \code{geom.src} \code{mupolygon} OR \code{"areasymbol"}, \code{"areaname"}, \code{"mlraoffice"}, \code{"mouagncyresp"} for \code{geom.src} \code{sapolygon}; default is determined by \code{is.numeric(x)} \code{TRUE} for \code{mukey} or \code{lkey} and \code{nationalmusym} or \code{areasymbol} otherwise.}
+\item{by.col}{Column name containing map unit identifier \code{"mukey"}, \code{"nmusym"}/\code{"nationalmusym"} for \code{geom.src="mupolygon"} OR \code{"areasymbol"}, \code{"areaname"}, \code{"mlraoffice"}, \code{"mouagncyresp"} for \code{geom.src="sapolygon"}; default is determined by \code{is.numeric(x)} \code{TRUE} for \code{mukey} or \code{lkey} and \code{nationalmusym} or \code{areasymbol} otherwise.}
 
 \item{method}{geometry result type: \code{"feature"} returns polygons, \code{"bbox"} returns the bounding box of each polygon (via \code{STEnvelope()}), and \code{"point"} returns a single point (via \code{STPointOnSurface()}) within each polygon.}
 
-\item{geom.src}{Either \code{mupolygon} (map unit polygons) or \code{sapolygon} (soil survey area boundary polygons)}
+\item{geom.src}{Either \code{mupolygon} (map unit polygons), \code{sapolygon} (soil survey area boundary polygons), or \code{mlrapolygon} (major land resource area boundary polygons)}
 
-\item{db}{Default: \code{"SSURGO"}. When \code{geom.src} is \code{mupolygon}, use STATSGO polygon geometry instead of SSURGO by setting \code{db = "STATSGO"}}
+\item{db}{Default: \code{"SSURGO"}. When \code{geom.src} is \code{mupolygon}, use STATSGO polygon geometry instead of SSURGO by setting \code{db = "STATSGO"}.}
 
 \item{add.fields}{Column names from \code{mapunit} or \code{legend} table to add to result. Must specify parent table name as the prefix before column name e.g. \code{mapunit.muname}.}
 
@@ -49,10 +49,17 @@ This function automatically "chunks" the input vector (using \code{makeChunks()}
 Querying regions with complex mapping may require smaller \code{chunk.size}. Numerically adjacent IDs in the input vector may share common qualities (say, all from same soil survey area or region) which could cause specific chunks to perform "poorly" (slow or error) no matter what the chunk size is. Shuffling the order of the inputs using \code{sample()} may help to eliminate problems related to this, depending on how you obtained your set of MUKEY/nationalmusym to query. One could feasibly use \code{muacres} as a heuristic to adjust for total acreage within chunks.
 
 Note that STATSGO data are fetched where \code{CLIPAREASYMBOL = 'US'} to avoid duplicating state and national subsets of the geometry.
+
+A prototype interface, \code{geom.src="mlrapolygon"}, is provided for obtaining Major Land Resource Area (MLRA) polygon
+boundaries. When using this geometry source \code{x} is a vector of \code{MLRARSYM} (MLRA Symbols). The geometry source is
+the MLRA Geographic Database v5.2 (2022) which is not (yet) part of Soil Data Access.Instead of SDA, GDAL utilities
+are used to read a zipped ESRI Shapefile from a remote URL: \url{https://www.nrcs.usda.gov/sites/default/files/2022-10/MLRA_52_2022.zip}.
+Therefore, most additional \code{fetchSDA_spatial()} arguments are \emph{not} currently supported for the MLRA geometry source.
+In the future a \code{mlrapolygon} table may be added to SDA (analogous to  \code{mupolygon} and \code{sapolygon}),
+and the function will be updated accordingly at that time.
 }
 \examples{
 \dontshow{if (curl::has_internet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-\dontshow{\}) # examplesIf}
 \donttest{
  
     # get spatial data for a single mukey
@@ -77,6 +84,7 @@ Note that STATSGO data are fetched where \code{CLIPAREASYMBOL = 'US'} to avoid d
     # demo adding a field (`muname`) to attribute table of result
     head(try(fetchSDA_spatial(x = "2x8l5", by="nmusym", add.fields="muname")))
 }
+\dontshow{\}) # examplesIf}
 }
 \author{
 Andrew G. Brown, Dylan E. Beaudette


### PR DESCRIPTION
`fetchSDA_spatial()`: add `geom.src='mlrapolygon'` for querying MLRA boundaries by MLRARSYM

 - currently `mlrapolygon` is not a SSURGO table, but the official ZIP file can be queried directly via GDAL using MLRARSYM as the query attribute
 - in the future, if SDA ever provides MLRA geometry, the GDAL /vsizip/ method will be replaced with a T-SQL equivalent (and full support for other agg methods wil be added)

TODO:
 - [x] rename `"_ogr_geometry_"` column => <strike>`"geometry"`</strike> `"geom"`