### PR TITLE
`mukey.wcs()`: fix areas containing all NoData and resolution for AOI at edge of WCS extent

### DIFF
--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -190,18 +190,21 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   test_y <- round((ymax2 - ymin) / res) != nrow(r)
   test_x <- round((xmax2 - xmin) / res) != ncol(r)
   
-  # warn about requested vs. received grid dimensions
+  # fix requested vs. received grid dimensions
   if (test_x || test_y) {
     if (test_x)
-      warning("Request outside boundary of coverage source data: expected ", 
-              (xmax2 - xmin) / res, " columns, received ", ncol(r), call. = FALSE)
+      message("Request partially outside boundary of coverage source data: expected ", 
+              (xmax2 - xmin) / res, " columns, received ", ncol(r))
     if (test_y)
-      warning("Request outside boundary of coverage source data: expected ", 
-              (ymax2 - ymin) / res, " rows, received ", nrow(r), call. = FALSE)
+      message("Request partially outside boundary of coverage source data: expected ", 
+              (ymax2 - ymin) / res, " rows, received ", nrow(r))
     
     # fix extent of result due to rounding error/incomplete pixels at edges of map
     rex <- terra::ext(r) 
     terra::ext(r) <- terra::ext(c(rex[1], rex[1] + ncol(r) * res, rex[3], rex[3] + nrow(r) * res))
+    
+    # extend to input extent
+    r <- terra::extend(r, terra::ext(c(xmin, xmax2, ymin, ymax2)))
   }
   
   ## TODO: is this needed? (yes, still needed; AGB 2023/09/30)

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -209,11 +209,11 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   # remove tempfile 
   unlink(tf)
 
-  # build RAT
-  r <- terra::as.factor(r)
-  
   # set layer name in object
   names(r) <- 'mukey'
+  
+  # build RAT
+  r <- terra::as.factor(r)
   
   # and as an attribute
   attr(r, 'layer name') <- var.spec$desc

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -209,13 +209,8 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   # remove tempfile 
   unlink(tf)
 
-  ## TODO: use terra::as.factor()
   # build RAT
-  # NB: unique() takes na.rm argument on terra >1.5-21 <https://github.com/rspatial/terra/issues/561>
-  uids <- na.omit(terra::unique(r)[[1]])  
-  rat <- data.frame(ID = uids, 
-                    mukey = uids)
-  levels(r)[[1]] <- rat
+  r <- terra::as.factor(r)
   
   # set layer name in object
   names(r) <- 'mukey'


### PR DESCRIPTION
Fix for #304, issue raised by @kevinwolz who provided example AOI in that issue from the FL keys

Uses `terra::as.factor()` for result that has categorical representation of mukey (resolves TODO)

```r
library(soilDB)
library(sf)
setwd("~/workspace/gh/soilDB/304")
aoi <- sf::st_read("/vsizip/aoi_FL_keys.kml.zip")
#> Reading layer `aoi_FL_keys' from data source `/vsizip/aoi_FL_keys.kml.zip' using driver `KML'
#> Simple feature collection with 1 feature and 2 fields
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -82.32659 ymin: 24.47644 xmax: -81.97248 ymax: 24.75134
#> Geodetic CRS:  WGS 84
res <- soilDB::mukey.wcs(aoi = aoi, db = "gssurgo", res = 30, quiet = FALSE)
#> Warning: expected 1167 rows, received 893; Y resolution may be affected. Try
#> requesting a smaller extent.
#> Warning: [] no labels
res
#> class       : SpatRaster 
#> dimensions  : 893, 1344, 1  (nrow, ncol, nlyr)
#> resolution  : 30, 30.0127  (x, y)
#> extent      : 1396280, 1436600, 270015, 296816.3  (xmin, xmax, ymin, ymax)
#> coord. ref. : NAD83 / Conus Albers (EPSG:5070) 
#> source(s)   : memory
#> name        : mukey 
#> min value   :   NaN 
#> max value   :   NaN
```

The warnings indicate that the coverage service does not return the expected grid size. The corresponding dimension(s) out of bounds may have their resolution affected (i.e. they do not match the input `res` argument, or the other dimension)

Note that the warnings are "expected" but unfortunate result of the boundary of the source raster for the CONUS gSSURGO on SoilWeb. We have most commonly encountered this issue with raster soil surveys which are of limited extent. One server side option we could implement to avoid bumping up against resolution problems  frequently is increase the buffer of NoData surrounding the current extent. 