### PR TITLE
`get_SDA_interpretation()`: add subrule ratings to "reason" field

### DIFF
--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -791,7 +791,7 @@ get_SDA_interpretation <- function(rulename,
     (%s) AS [rating_%s],
     (%s) AS [total_comppct_%s],
     (%s) AS [class_%s],
-    (SELECT %s FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth != 0 AND interphrc NOT LIKE 'Not%%' AND mrulename LIKE '%s') AS [reason_%s]",
+    (SELECT %s FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth != 0 AND mrulename LIKE '%s') AS [reason_%s]",
    .q1(x), .cleanRuleColumnName(x),
    .q2(x), .cleanRuleColumnName(x),
    .q3(x), .cleanRuleColumnName(x),
@@ -810,7 +810,7 @@ get_SDA_interpretation <- function(rulename,
                 paste0(sapply(interp, function(x) sprintf("
   (SELECT interphr FROM component AS c0 INNER JOIN cointerp ON c0.cokey = cointerp.cokey AND component.cokey = c0.cokey AND ruledepth = 0 AND mrulename LIKE '%s') as [rating_%s],
   (SELECT interphrc FROM component AS c1 INNER JOIN cointerp ON c1.cokey = cointerp.cokey AND c1.cokey = component.cokey AND ruledepth = 0 AND mrulename LIKE '%s') as [class_%s],
-  (SELECT %s FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey AND mu.mukey = mapunit.mukey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND ruledepth != 0 AND interphrc NOT LIKE 'Not%%' AND mrulename = '%s') as [reason_%s]",
+  (SELECT %s FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey AND mu.mukey = mapunit.mukey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND ruledepth != 0 AND mrulename = '%s') as [reason_%s]",
                                       x, .cleanRuleColumnName(x),
                                       x, .cleanRuleColumnName(x),
                                       aggfun,
@@ -856,7 +856,7 @@ get_SDA_interpretation <- function(rulename,
                    FROM mapunit AS mu
                    INNER JOIN component AS c ON c.mukey = mu.mukey AND compkind != 'miscellaneous area'
                    INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey
-                   AND ruledepth != 0 AND interphrc NOT LIKE 'Not%%' AND mrulename LIKE '%s'
+                   AND ruledepth != 0 AND mrulename LIKE '%s'
                    GROUP BY mu.mukey) AS [reason_%s]",
                                                     x, .cleanRuleColumnName(x),
                                                     x, .cleanRuleColumnName(x),

--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -775,8 +775,8 @@ get_SDA_interpretation <- function(rulename,
 .cleanRuleColumnName <- function(x) gsub("[^A-Za-z0-9]", "", x)
 
 .interpretation_by_condition <- function(interp, where_clause, dominant = TRUE, sqlite = FALSE) {
-  aggfun <- "STRING_AGG(CONCAT(interphrc, ' (', interphr, ')'), '; ')"
-  if (sqlite) aggfun <- "GROUP_CONCAT(interphrc || ' (' || interphr || ')' || '; ')"
+  aggfun <- "STRING_AGG(CONCAT(rulename, ' \"', interphrc, '\" (', interphr, ')'), '; ')"
+  if (sqlite) aggfun <- "GROUP_CONCAT(rulename || ' ' || interphrc || ' (' || interphr || ')' || '; ')"
   .q0 <- function(q, x) .LIMIT_N(sprintf(q, x), n = 1, sqlite = sqlite)
   .q1 <- function(x) .q0("SELECT ROUND (AVG(interphr) OVER (PARTITION BY interphrc), 2) FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth = 0 AND mrulename LIKE '%s' GROUP BY interphrc, interphr ORDER BY SUM (comppct_r) DESC", x)
   .q2 <- function(x) .q0("SELECT SUM(comppct_r) FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth = 0 AND mrulename LIKE '%s' GROUP BY interphrc, comppct_r ORDER BY SUM(comppct_r) OVER (PARTITION BY interphrc) DESC", x)
@@ -800,8 +800,8 @@ get_SDA_interpretation <- function(rulename,
 }
 
 .interpretation_aggregation <- function(interp, where_clause, dominant = FALSE, sqlite = FALSE) {
-  aggfun <- "STRING_AGG(CONCAT(interphrc, ' (', interphr, ')'), '; ')"
-  if (sqlite) aggfun <- "GROUP_CONCAT(interphrc || ' (' || interphr || ')' || '; ')"
+  aggfun <- "STRING_AGG(CONCAT(rulename, ' \"', interphrc, '\" (', interphr, ')'), '; ')"
+  if (sqlite) aggfun <- "GROUP_CONCAT(rulename || ' ' || interphrc || ' (' || interphr || ')' || '; ')"
   sprintf("SELECT mapunit.mukey, component.cokey, areasymbol, musym, muname, compname, compkind, comppct_r, majcompflag,
                 %s
                 FROM legend

--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -791,7 +791,7 @@ get_SDA_interpretation <- function(rulename,
     (%s) AS [rating_%s],
     (%s) AS [total_comppct_%s],
     (%s) AS [class_%s],
-    (SELECT %s(interphrc, '; ') FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth != 0 AND interphrc NOT LIKE 'Not%%' AND mrulename LIKE '%s') AS [reason_%s]",
+    (SELECT %s FROM mapunit AS mu INNER JOIN component AS c ON c.mukey = mu.mukey AND c.compkind != 'miscellaneous area' AND c.cokey = component.cokey INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth != 0 AND interphrc NOT LIKE 'Not%%' AND mrulename LIKE '%s') AS [reason_%s]",
    .q1(x), .cleanRuleColumnName(x),
    .q2(x), .cleanRuleColumnName(x),
    .q3(x), .cleanRuleColumnName(x),
@@ -852,7 +852,7 @@ get_SDA_interpretation <- function(rulename,
                   INNER JOIN component AS c ON c.mukey = mu.mukey
                   INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey AND ruledepth = 0 AND mrulename LIKE '%s'
                   AND (interphr) IS NOT NULL GROUP BY mu.mukey),2) AS [sum_com_%s],
-                  (SELECT STRING_AGG(CONCAT(interphrc, ' (', interphr, ')', '; ')
+                  (SELECT STRING_AGG(CONCAT(interphrc, ' (', interphr, ')'), '; ')
                    FROM mapunit AS mu
                    INNER JOIN component AS c ON c.mukey = mu.mukey AND compkind != 'miscellaneous area'
                    INNER JOIN cointerp ON c.cokey = cointerp.cokey AND mapunit.mukey = mu.mukey

--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -26,633 +26,651 @@
 #'
 #' ## Rule Names in `cointerp` table
 #'
-#' - AGR-Agronomic Concerns (ND)
-#' - AGR-Available Water Capacity (ND)
-#' - AGR-Natural Fertility (ND)
-#' - AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
-#' - AGR-Pesticide and Nutrient Runoff Potential (ND)
-#' - AGR-Physical Limitations (ND)
-#' - AGR-Rooting Depth (ND)
-#' - AGR-Sodicity (ND)
-#' - AGR-Subsurface Salinity (ND)
-#' - AGR-Surface Crusting (ND)
-#' - AGR-Surface Salinity (ND)
-#' - AGR-Water Erosion (ND)
-#' - AGR-Wind Erosion (ND)
-#' - AGR - Air Quality; PM10 (TX)
-#' - AGR - Air Quality; PM2_5 (TX)
 #' - AGR - Avocado Root Rot Hazard (CA)
-#' - AGR - Barley Yield (MT)
 #' - AGR - California Revised Storie Index (CA)
-#' - AGR - Conventional Tillage (TX)
-#' - AGR - Filter Strips (TX)
-#' - AGR - Grape non-irrigated (MO)
 #' - AGR - Hops Site Suitability (WA)
-#' - AGR - Index for alfalfa hay, irrigated (NV)
 #' - AGR - Map Unit Cropland Productivity (MN)
-#' - AGR - Mulch Till (TX)
-#' - AGR - Nitrate Leaching Potential, Irrigated (WA)
-#' - AGR - Nitrate Leaching Potential, Nonirrigated (MA)
-#' - AGR - Nitrate Leaching Potential, Nonirrigated (MT)
 #' - AGR - Nitrate Leaching Potential, Nonirrigated (WA)
 #' - AGR - No Till (TX)
-#' - AGR - No Till (VT)
-#' - AGR - No Till, Tile Drained (TX)
-#' - AGR - Oats Yield (MT)
-#' - AGR - Orchard Groups (TX)
-#' - AGR - Pasture hayland (MO)
-#' - AGR - Pesticide Loss Potential-Leaching
-#' - AGR - Pesticide Loss Potential-Leaching (NE)
-#' - AGR - Pesticide Loss Potential-Soil Surface Runoff
 #' - AGR - Pesticide Loss Potential-Soil Surface Runoff (NE)
-#' - AGR - Plant Growth Index PGI no Climate Adj. (TX)
-#' - AGR - Plant Growth Index PGI with Climate Adj. (TX)
-#' - AGR - Plant Growth Index PGI with Climate Adj. MAP,MAAT (TX)
-#' - AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
 #' - AGR - Ridge Till (TX)
-#' - AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
-#' - AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
 #' - AGR - Selenium Leaching Potential (CO)
-#' - AGR - Spring Wheat Yield (MT)
-#' - AGR - Water Erosion Potential (TX)
-#' - AGR - Water Erosion Potential Wide Ratings Array (TX)
+#' - AGR - Water Erosion Potential (NE)
 #' - AGR - Wind Erosion Potential (TX)
-#' - AGR - Wind Erosion Potential Wide Ratings Array (TX)
-#' - AGR - Wine Grape Site Suitability (WA)
 #' - AGR - Winter Wheat Yield (MT)
-#' - Alaska Exempt Wetland Potential (AK)
+#' - AGR-Pesticide and Nutrient Runoff Potential (ND)
+#' - AGR-Rooting Depth (ND)
 #' - American Wine Grape Varieties Site Desirability (Long)
 #' - American Wine Grape Varieties Site Desirability (Medium)
-#' - American Wine Grape Varieties Site Desirability (Short)
 #' - American Wine Grape Varieties Site Desirability (Very Long)
 #' - AWM - Animal Mortality Disposal (Catastrophic) (MO)
-#' - AWM - Filter Group (OH)
-#' - AWM - Irrigation Disposal of Wastewater
-#' - AWM - Irrigation Disposal of Wastewater (DE)
-#' - AWM - Irrigation Disposal of Wastewater (MD)
 #' - AWM - Irrigation Disposal of Wastewater (OH)
-#' - AWM - Irrigation Disposal of Wastewater (VT)
+#' - AWM - Irrigation Disposal of Wastewater (VT)s
+#' - AWM - Land Application of Municipal Biosolids, summer (OR)
+#' - AWM - Manure and Food Processing Waste (MD)
+#' - AWM - Manure and Food Processing Waste (OH)
+#' - AWM - Overland Flow Process Treatment of Wastewater (VT)
+#' - AWM - Rapid Infil Disposal of Wastewater (DE)
+#' - AWM - Sensitive Soil Features (MN)
+#' - AWM - Sensitive Soil Features (WI)
+#' - BLM - Fencing
+#' - BLM - Fire Damage Susceptibility
+#' - BLM - Mechanical Treatment, Rolling Drum
+#' - BLM - Rangeland Drill
+#' - BLM - Rangeland Seeding, Colorado Plateau Ecoregion
+#' - BLM - Rangeland Seeding, Great Basin Ecoregion
+#' - BLM-Reclamation Suitability (MT)
+#' - CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
+#' - CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
+#' - CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
+#' - CLR-pastureland limitation (IN)
+#' - Commodity Crop Productivity Index (Soybeans) (TN)
+#' - CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+#' - CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
+#' - CPI - Small Grains, IRR - Snake River Plains (ID)
+#' - CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
+#' - CZSS - Salinization due to Coastal Saltwater Inundation (CT)
+#' - DHS - Catastrophic Event, Large Animal Mortality, Burial
+#' - DHS - Catastrophic Mortality, Large Animal Disposal, Pit
+#' - DHS - Catastrophic Mortality, Large Animal Disposal, Trench
+#' - DHS - Potential for Radioactive Bioaccumulation
+#' - DHS - Potential for Radioactive Sequestration
+#' - DHS - Suitability for Composting Medium and Final Cover
+#' - ENG - Construction Materials; Gravel Source
+#' - ENG - Construction Materials; Gravel Source (AK)
+#' - ENG - Construction Materials; Gravel Source (ID)
+#' - ENG - Construction Materials; Gravel Source (OH)
+#' - ENG - Construction Materials; Gravel Source (VT)
+#' - ENG - Construction Materials; Gravel Source (WA)
+#' - ENG - Construction Materials; Roadfill (OH)
+#' - ENG - Construction Materials; Sand Source (OR)
+#' - ENG - Construction Materials; Sand Source (WA)
+#' - ENG - Construction Materials; Topsoil (GA)
+#' - ENG - Construction Materials; Topsoil (MD)
+#' - ENG - Daily Cover for Landfill
+#' - ENG - Daily Cover for Landfill (AK)
+#' - ENG - Disposal Field Suitability Class (NJ)
+#' - ENG - Dwellings W/O Basements (OH)
+#' - ENG - Dwellings with Basements (AK)
+#' - ENG - Large Animal Disposal, Pit (CT)
+#' - ENG - Lawn, landscape, golf fairway (CT)
+#' - ENG - Lined Retention Systems
+#' - ENG - Local Roads and Streets (OH)
+#' - ENG - On-Site Waste Water Absorption Fields (MO)
+#' - ENG - Septic Tank Absorption Fields
+#' - ENG - Septic Tank Absorption Fields (MD)
+#' - ENG - Septic Tank Absorption Fields (TX)
+#' - ENG - Septic Tank, Gravity Disposal (TX)
+#' - ENG - Sewage Lagoons
+#' - ENG - Small Commercial Buildings (OH)
+#' - ENG - Soil Potential Ratings of SSDS (CT)
+#' - FOR (USFS) - Road Construction/Maintenance (Natural Surface)
+#' - FOR - Compaction Potential (WA)
+#' - FOR - Conservation Tree/Shrub Groups (MT)
+#' - FOR - Damage by Fire (OH)
+#' - FOR - General Harvest Season (VT)
+#' - FOR - Hand Planting Suitability
+#' - FOR - Hand Planting Suitability, MO13 (DE)
+#' - FOR - Hand Planting Suitability, MO13 (MD)
+#' - FOR - Log Landing Suitability
+#' - FOR - Log Landing Suitability (ME)
+#' - FOR - Log Landing Suitability (VT)
+#' - FOR - Log Landing Suitability (WA)
+#' - FOR - Mechanical Planting Suitability (CT)
+#' - FOR - Mechanical Planting Suitability, MO13 (MD)
+#' - FOR - Mechanical Site Preparation (Deep)
+#' - FOR - Mechanical Site Preparation (Deep) (DE)
+#' - FOR - Mechanical Site Preparation (Surface) (DE)
+#' - FOR - Mechanical Site Preparation (Surface) (MI)
+#' - FOR - Mechanical Site Preparation; Surface (ME)
+#' - FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
+#' - FOR - Potential Seedling Mortality (PIA)
+#' - FOR - Potential Seedling Mortality(ME)
+#' - FOR - Puddling Hazard
+#' - FOR - Road Suitability (Natural Surface) (ME)
+#' - FOR - Road Suitability (Natural Surface) (WA)
+#' - FOR - Soil Rutting Hazard (OH)
+#' - FOR - Soil Sustainability Forest Biomass Harvesting (CT)
+#' - FOR - White Oak Suitability (MO)
+#' - FOR-Biomass Harvest (WI)
+#' - FOTG - Indiana Corn Yield Calculation (IN)
+#' - GRL - Excavations to 24 inches for Plastic Pipelines (TX)
+#' - GRL - Fencing, 24 inch Post Depth (MT)
+#' - GRL - NV range seeding (Wind C = 100) (NV)
+#' - GRL - NV range seeding (Wind C = 40) (NV)
+#' - GRL - NV range seeding (Wind C = 60) (NV)
+#' - GRL - NV range seeding (Wind C = 80) (NV)
+#' - GRL - NV range seeding (Wind C >= 160) (NV)
+#' - GRL - Rangeland Planting by Mechanical Seeding (TX)
+#' - GRL - Rangeland Root Plowing (TX)
+#' - Hybrid Wine Grape Varieties Site Desirability (Long)
+#' - Low Pressure Pipe Septic System (DE)
+#' - MIL - Bivouac Areas (DOD)
+#' - MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
+#' - MIL - Excavations for Individual Fighting Position (DOD)
+#' - MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 7 dry season (DOD)
+#' - NCCPI - Irrigated National Commodity Crop Productivity Index
+#' - Nitrogen Loss Potential (ND)
+#' - Potential Windthrow Hazard (TN)
+#' - REC - Foot and ATV Trails (AK)
+#' - REC - Playgrounds (AK)
+#' - Reclamation Suitability (ND)
+#' - RSK-risk assessment for manure application (OH)
+#' - SAS - CMECS Substrate Origin
+#' - SAS - CMECS Substrate Subclass/Group/Subgroup
+#' - SAS - Mooring Anchor - Deadweight
+#' - Septic System A/B Soil System (Alternate) (PA)
+#' - Septic System CO-OP RFS III w/Spray Irrigation (PA)
+#' - Septic System Dual Field Trench (conventional) (WV)
+#' - Septic System Elevated Field (alternative) (WV)
+#' - Septic System In Ground Trench (conventional) (PA)
+#' - Septic System In Ground Trench (conventional) (WV)
+#' - AGR - Filter Strips (TX)
+#' - AGR - Hops Site Suitability (ID)
+#' - AGR - Mulch Till (TX)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (MT)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (WV)
+#' - AGR - No Till (VT)
+#' - AGR - Oats Yield (MT)
+#' - AGR - Pesticide Loss Potential-Leaching
+#' - AGR - Pesticide Loss Potential-Leaching (NE)
+#' - AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
+#' - AGR - S. Highbush Blueberry Suitability MLRA 153 (SC)
+#' - AGR - Wind Erosion Potential (NE)
+#' - AGR-Available Water Capacity (ND)
+#' - AGR-Physical Limitations (ND)
+#' - AGR-Sodicity (ND)
+#' - AGR-Surface Crusting (ND)
+#' - AGR-Wind Erosion (ND)
+#' - AWM - Irrigation Disposal of Wastewater (DE)
 #' - AWM - Land App of Municipal Sewage Sludge (DE)
 #' - AWM - Land App of Municipal Sewage Sludge (MD)
-#' - AWM - Land Application of Dry and Slurry Manure (TX)
 #' - AWM - Land Application of Milk (CT)
 #' - AWM - Land Application of Municipal Biosolids, spring (OR)
-#' - AWM - Land Application of Municipal Biosolids, summer (OR)
-#' - AWM - Land Application of Municipal Biosolids, winter (OR)
 #' - AWM - Land Application of Municipal Sewage Sludge
 #' - AWM - Land Application of Municipal Sewage Sludge (OH)
 #' - AWM - Land Application of Municipal Sewage Sludge (VT)
 #' - AWM - Large Animal Disposal, Pit (MN)
 #' - AWM - Manure and Food Processing Waste
-#' - AWM - Manure and Food Processing Waste (DE)
-#' - AWM - Manure and Food Processing Waste (MD)
-#' - AWM - Manure and Food Processing Waste (OH)
 #' - AWM - Manure and Food Processing Waste (VT)
-#' - AWM - Manure Stacking - Site Evaluation (TX)
-#' - AWM - Overland Flow Process Treatment of Wastewater
-#' - AWM - Overland Flow Process Treatment of Wastewater (VT)
-#' - AWM - Phosphorus Management (TX)
-#' - AWM - Rapid Infil Disposal of Wastewater (DE)
 #' - AWM - Rapid Infil Disposal of Wastewater (MD)
-#' - AWM - Rapid Infiltration Disposal of Wastewater
 #' - AWM - Rapid Infiltration Disposal of Wastewater (VT)
-#' - AWM - Sensitive Soil Features (MN)
-#' - AWM - Slow Rate Process Treatment of Wastewater
 #' - AWM - Slow Rate Process Treatment of Wastewater (VT)
-#' - AWM - Vegetated Treatment Area (PIA)
-#' - AWM - Waste Field Storage Area (VT)
-#' - BLM-Reclamation Suitability (MT)
 #' - BLM - Chaining Suitability
-#' - BLM - Fencing
-#' - BLM - Fire Damage Susceptibility
 #' - BLM - Fugitive Dust Resistance
-#' - BLM - Mechanical Treatment, Rolling Drum
-#' - BLM - Mechanical Treatment, Shredder
-#' - BLM - Medusahead Invasion Susceptibility
-#' - BLM - Pygmy Rabbit Habitat Potential
-#' - BLM - Rangeland Drill
-#' - BLM - Rangeland Seeding, Colorado Plateau Ecoregion
-#' - BLM - Rangeland Seeding, Great Basin Ecoregion
-#' - BLM - Rangeland Tillage
-#' - BLM - Site Degradation Susceptibility
-#' - BLM - Soil Compaction Resistance
 #' - BLM - Soil Restoration Potential
 #' - BLM - Yellow Star-thistle Invasion Susceptibility
-#' - CA Prime Farmland (CA)
+#' - CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
+#' - CLR-cropland limitation for corn and soybeans (IN)
+#' - Commodity Crop Productivity Index (Corn) (WI)
+#' - CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
+#' - CPI - Potatoes Productivity Index (AK)
+#' - CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
+#' - CPI - Small Grains, NIRR - Palouse Prairies (ID)
+#' - DHS - Emergency Animal Mortality Disposal by Shallow Burial
+#' - DHS - Rubble and Debris Disposal, Large-Scale Event
+#' - ENG - Aquifer Assessment - 7081 (MN)
+#' - ENG - Construction Materials - Gravel Source (MN)
+#' - ENG - Construction Materials; Gravel Source (MI)
+#' - ENG - Construction Materials; Gravel Source (OR)
+#' - ENG - Construction Materials; Reclamation
+#' - ENG - Construction Materials; Reclamation (OH)
+#' - ENG - Construction Materials; Sand Source
+#' - ENG - Construction Materials; Sand Source (AK)
+#' - ENG - Construction Materials; Sand Source (ID)
+#' - ENG - Construction Materials; Sand Source (IN)
+#' - ENG - Construction Materials; Sand Source (OH)
+#' - ENG - Construction Materials; Topsoil
+#' - ENG - Construction Materials; Topsoil (WA)
+#' - ENG - Ground-based Solar Arrays, Soil-based Anchor Systems
+#' - ENG - Local Roads and Streets
+#' - ENG - New Ohio Septic Rating (OH)
+#' - ENG - Sanitary Landfill (Trench) (OH)
+#' - ENG - Septic Tank Absorption Fields (AK)
+#' - ENG - Septic Tank Absorption Fields (DE)
+#' - ENG - Septic Tank Absorption Fields (NY)
+#' - ENG - Sewage Lagoons (OH)
+#' - ENG - Shallow Excavations (AK)
+#' - ENG - Shallow Excavations (MI)
+#' - ENG - Unpaved Local Roads and Streets
+#' - FOR - Black Walnut Suitability Index (MO)
+#' - FOR - Conservation Tree and Shrub Groups (TX)
+#' - FOR - Construction Limitations - Haul Roads/Log Landing (OH)
+#' - FOR - Construction Limitations For Haul Roads (MI)
+#' - FOR - Hand Planting Suitability (ME)
+#' - FOR - Harvest Equipment Operability (MD)
+#' - FOR - Harvest Equipment Operability (OH)
+#' - FOR - Harvest Equipment Operability (VT)
+#' - FOR - Mechanical Planting Suitability
+#' - FOR - Mechanical Planting Suitability (ME)
+#' - FOR - Mechanical Planting Suitability, MO13 (DE)
+#' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+#' - FOR - Potential Erosion Hazard (Road/Trail) (PIA)
+#' - FOR - Potential Seedling Mortality (VT)
+#' - FOR - Potential Windthrow Hazard (NY)
+#' - FOR - Potential Windthrow Hazard (VT)
+#' - FOR - Puddling Potential (WA)
+#' - FOR - Road Suitability (Natural Surface)
+#' - FOR - Road Suitability (Natural Surface) (OH)
+#' - FOR - Road Suitability (Natural Surface) (OR)
+#' - FOR - Rutting Hazard by Season
+#' - FOR - Shortleaf pine littleleaf disease susceptibility
+#' - FOR - Soil Compactibility Risk
+#' - FOR - Soil Rutting Hazard (ME)
+#' - FOR - Windthrow Hazard
+#' - FOR-Construction Limitations for Haul Roads/Log Landings(ME)
+#' - FOTG - Indiana Slippage Potential (IN)
+#' - Gravity Full Depth Septic System (DE)
+#' - GRL - Fencing, Post Depth =<36 inches
+#' - GRL - NV range seeding (Wind C = 50) (NV)
+#' - GRL - Ranch Access Roads (TX)
+#' - GRL - Rangeland Roller Chopping (TX)
+#' - Ground Penetrating Radar Penetration
+#' - Ground-based Solar Arrays_bedrock(ME)
+#' - Ground-based Solar Arrays_bedrock_slope_ballast(ME)
+#' - Hybrid Wine Grape Varieties Site Desirability (Short)
+#' - ISDH Septic Tank Interpretation (IN)
+#' - Land Application of Municipal Sewage Sludge (PA)
+#' - MIL - Helicopter Landing Zones (DOD)
+#' - MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 5 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
+#' - NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
+#' - REC - Camp and Picnic Areas (AK)
+#' - REC - Picnic Areas (CT)
+#' - REC - Playgrounds (CT)
+#' - SAS - CMECS Substrate Subclass
+#' - Septic System Drip Irrigation (Alternate) (PA)
+#' - Septic System Free Access Sand Filter w/Drip Irrigation (PA)
+#' - Septic System In Ground Bed (conventional) (PA)
+#' - Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
+#' - Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
+#' - Septic System Sand Mound Bed or Trench (PA)
+#' - Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
+#' - SOH - Aggregate Stability (ND)
+#' - SOH - Agricultural Organic Soil Subsidence
+#' - SOH - Dynamic Soil Properties Response to Biochar
+#' - SOH - Organic Matter Depletion
+#' - SOIL HEALTH ASSESSMENT (NJ)
+#' - URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
+#' - URB - Reinforced Concrete Slab (TX)
+#' - URB/REC - Camp Areas
+#' - URB/REC - Camp Areas (OH)
+#' - URB/REC - Off-Road Motorcycle Trails (OH)
+#' - URB/REC - Paths and Trails (OH)
+#' - URB/REC - Picnic Areas
+#' - URB/REC - Playgrounds
+#' - URB/REC - Playgrounds (GA)
+#' - Vinifera Wine Grape Site Desirability (Short to Medium)
+#' - WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
+#' - WLF - Upland Coniferous Trees (TX)
+#' - WLF - Upland Deciduous Trees (TX)
+#' - WLF - Upland Desertic Shrubs & Trees (TX)
+#' - WLF - Upland Native Herbaceous Plants (TX)
+#' - WLF - Upland Shrubs & Vines (TX)
+#' - WLF-Soil Suitability - Karner Blue Butterfly (WI)
+#' - WMS - Drainage (IL)
+#' - WMS - Drainage - (MI)
+#' - WMS - Embankments, Dikes, and Levees
+#' - WMS - Embankments, Dikes, and Levees (OH)
+#' - WMS - Grassed Waterways - (MI)
+#' - AGR - Air Quality; PM10 (TX)
+#' - AGR - Air Quality; PM2_5 (TX)
+#' - AGR - Aronia Berry Suitability (SD)
+#' - AGR - Farmland of Statewide Importance (TX)
+#' - AGR - Index for alfalfa hay, irrigated (NV)
+#' - AGR - Nitrate Leaching Potential, Nonirrigated (MA)
+#' - AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
+#' - AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
+#' - AGR - Water Erosion Potential (TX)
+#' - AGR - Wine Grape Site Suitability (WA)
+#' - AGR-Natural Fertility (ND)
+#' - AGR-Subsurface Salinity (ND)
+#' - AWM - Filter Group (OH)
+#' - AWM - Irrigation Disposal of Wastewater
+#' - AWM - Land Application of Dry and Slurry Manure (TX)
+#' - AWM - Land Application of Municipal Biosolids, winter (OR)
+#' - AWM - Overland Flow Process Treatment of Wastewater
+#' - AWM - Rapid Infiltration Disposal of Wastewater
+#' - AWM - Vegetated Treatment Area (PIA)
+#' - AWM - Waste Field Storage Area (VT)
+#' - BLM - Mechanical Treatment, Shredder
+#' - BLM - Medusahead Invasion Susceptibility
+#' - BLM - Soil Compaction Resistance
 #' - Capping Fill Gravity Septic System (DE)
 #' - CLASS RULE - Depth to any bedrock kind (5 classes) (NPS)
-#' - CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
-#' - CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
-#' - CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
-#' - CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
-#' - CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
-#' - CLR-cropland limitation for corn and soybeans (IN)
-#' - CLR-pastureland limitation (IN)
-#' - Commodity Crop Productivity Index (Corn) (WI)
 #' - CPI - Alfalfa Hay, IRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Alfalfa Hay, IRR - Klamath Valley and Basins (OR)
 #' - CPI - Alfalfa Hay, IRR - Snake River Plains (ID)
 #' - CPI - Alfalfa Hay, NIRR- Eastern Idaho Plateaus (ID)
+#' - CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+#' - CPI - Small Grains Productivity Index (AK)
+#' - DHS - Catastrophic Event, Large Animal Mortality, Incinerate
+#' - DHS - Emergency Land Disposal of Milk
+#' - DHS - Site for Composting Facility - Subsurface
+#' - DHS - Suitability for Clay Liner Material
+#' - ENG - Cohesive Soil Liner (MN)
+#' - ENG - Construction Materials - Sand Source (MN)
+#' - ENG - Construction Materials; Gravel Source (CT)
+#' - ENG - Construction Materials; Gravel Source (NY)
+#' - ENG - Construction Materials; Reclamation (DE)
+#' - ENG - Construction Materials; Roadfill
+#' - ENG - Construction Materials; Roadfill (AK)
+#' - ENG - Construction Materials; Sand Source (NY)
+#' - ENG - Construction Materials; Sand Source (VT)
+#' - ENG - Construction Materials; Topsoil (AK)
+#' - ENG - Construction Materials; Topsoil (DE)
+#' - ENG - Construction Materials; Topsoil (MI)
+#' - ENG - Construction Materials; Topsoil (OR)
+#' - ENG - Conventional On-Site Septic Systems (TN)
+#' - ENG - Deep Infiltration Systems
+#' - ENG - Disposal Field Gravity (DE)
+#' - ENG - Dwellings With Basements (OH)
+#' - ENG - Ground-based Solar Arrays, Ballast Anchor Systems
+#' - ENG - Large Animal Disposal, Trench (CT)
+#' - ENG - Lawn, Landscape, Golf Fairway (MI)
+#' - ENG - Lawn, Landscape, Golf Fairway (VT)
+#' - ENG - Sanitary Landfill (Area) (OH)
+#' - ENG - Sanitary Landfill (Trench)
+#' - ENG - Sanitary Landfill (Trench) (AK)
+#' - ENG - Septage Application - Surface (MN)
+#' - ENG - Septic Tank Absorption Fields - At-Grade (MN)
+#' - ENG - Septic Tank Absorption Fields - Mound (MN)
+#' - ENG - Septic Tank Leaching Chamber (TX)
+#' - ENG - Septic Tank, Subsurface Drip Irrigation (TX)
+#' - ENG - Shallow Excavations
+#' - ENG - Shallow Infiltration Systems
+#' - ENG - Small Commercial Buildings
+#' - ENG - Soil Potential of Road Salt Applications (CT)
+#' - ENG - Source of Caliche (TX)
+#' - ENG - Stormwater Management / Ponds (NY)
+#' - ENG - Unlined Retention Systems
+#' - Farm and Garden Composting Facility - Surface
+#' - FOR - Biomass Harvest (MA)
+#' - FOR - Black Walnut Suitability Index (KS)
+#' - FOR - Displacement Potential (WA)
+#' - FOR - Drought Vulnerable Soils
+#' - FOR - General Harvest Season (ME)
+#' - FOR - Harvest Equipment Operability
+#' - FOR - Mechanical Site Preparation (Deep) (MD)
+#' - FOR - Mechanical Site Preparation (Surface)
+#' - FOR - Mechanical Site Preparation; Deep (CT)
+#' - FOR - Potential Erosion Hazard (Road/Trail)
+#' - FOR - Potential Fire Damage Hazard
+#' - FOR - Potential Seedling Mortality
+#' - FOR - Potential Seedling Mortality (MI)
+#' - FOR - Potential Windthrow Hazard (ME)
+#' - FOR - Potential Windthrow Hazard (MI)
+#' - FOR - Road Suitability (Natural Surface) (ID)
+#' - FOR - Rutting Hazard by Month
+#' - FOR - Windthrow Hazard (WA)
+#' - FOTG - NLI Interp Calculation - (IN)
+#' - Fragile Soil Index
+#' - GRL - Juniper Encroachment Potential (NM)
+#' - GRL - NV range seeding (Wind C = 20) (NV)
+#' - GRL - Pasture and Hayland SG (OH)
+#' - GRL - Rangeland Prescribed Burning (TX)
+#' - GRL - Rangeland Soil Seed Bank Suitability (NM)
+#' - GRL-FSG-NP-W (MT)
+#' - GRL-SHSI Soil Health Sustainability Index (MT)
+#' - Ground-based Solar Arrays_saturationt(ME)
+#' - Ground-based Solar Arrays_slope(ME)
+#' - Inland Wetlands (CT)
+#' - IRR-restrictive features for irrigation (OH)
+#' - MIL - Excavations for Vehicle Fighting Position (DOD)
+#' - MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 2 dry season (DOD)
+#' - MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
+#' - MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
+#' - MIL - Trafficability Veh. Type 6 dry season (DOD)
+#' - Muscadine Wine Grape Site Desirability (Very Long)
+#' - NCCPI - NCCPI Cotton Submodel (II)
+#' - Permafrost Sensitivity (AK)
+#' - Pressure Dose Capping Fill Septic System (DE)
+#' - REC - Camp Areas (CT)
+#' - REC - Off-Road Motorcycle Trails (CT)
+#' - SAS - CMECS Substrate Class
+#' - SAS - CMECS Substrate Subclass/Group
+#' - SAS - Eelgrass Restoration Suitability
+#' - SAS - Land Utilization of Dredged Materials
+#' - SAS - Northern Quahog (Hard Clam) Habitat Suitability
+#' - Septic System At Grade Shallow Field (alternative) (WV)
+#' - Septic System At-Grade Bed (Alternate) (PA)
+#' - Septic System CO-OP RFS III w/Drip Irrigation (PA)
+#' - Septic System Drip Irrigation (alternative) (WV)
+#' - Septic System Free Access Sand Filterw/Spray Irrigation (PA)
+#' - Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
+#' - Septic System Spray Irrigation (PA)
+#' - Septic System Steep Slope Sand Mound (Alternate) (PA)
+#' - Shallow Infiltration Systems
+#' - SOH - Organic Matter Depletion Potential, Irrigated (CA)
+#' - SOH - Soil Surface Sealing
+#' - TROP - Plantains Productivity
+#' - URB/REC - Camp Areas (GA)
+#' - URB/REC - Camp Areas (MI)
+#' - URB/REC - Golf Fairways (OH)
+#' - URB/REC - Off-Road Motorcycle Trails
+#' - URB/REC - Paths and Trails (MI)
+#' - URB/REC - Playgrounds (OH)
+#' - Vinifera Wine Grape Site Desirability (Long to Medium)
+#' - WLF - Chufa for Turkey Forage (LA)
+#' - WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
+#' - WLF - Freshwater Wetland Plants (TX)
+#' - WLF - Irrigated Saline Water Wetland Plants (TX)
+#' - WLF - Riparian Herbaceous Plants (TX)
+#' - WLF - Riparian Shrubs, Vines, & Trees (TX)
+#' - WLF - Saline Water Wetland Plants (TX)
+#' - WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
+#' - WMS - Constructing Grassed Waterways (TX)
+#' - WMS - Constructing Terraces and Diversions (OH)
+#' - WMS - Embankments, Dikes, and Levees (VT)
+#' - WMS - Irrigation, Sprinkler (close spaced outlet drops)
+#' - WMS - Irrigation, Sprinkler (general)
+#' - WMS - Pond Reservoir Area (GA)
+#' - WMS-Subsurface Water Management, Installation (ND)
+#' - WMS-Subsurface Water Management, Outflow Quality (ND)
+#' - AGR - Barley Yield (MT)
+#' - AGR - Conventional Tillage (TX)
+#' - AGR - Grape non-irrigated (MO)
+#' - AGR - Industrial Hemp for Fiber and Seed Production
+#' - AGR - Nitrate Leaching Potential, Irrigated (WA)
+#' - AGR - Pasture hayland (MO)
+#' - AGR - Pesticide Loss Potential-Soil Surface Runoff
+#' - AGR - Prime Farmland (TX)
+#' - AGR - Spring Wheat Yield (MT)
+#' - AGR-Agronomic Concerns (ND)
+#' - AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
+#' - AGR-Surface Salinity (ND)
+#' - AGR-Water Erosion Potential (ND)
+#' - Alaska Exempt Wetland Potential (AK)
+#' - American Wine Grape Varieties Site Desirability (Short)
+#' - AWM - Irrigation Disposal of Wastewater (MD)
+#' - AWM - Manure and Food Processing Waste (DE)
+#' - AWM - Manure Stacking - Site Evaluation (TX)
+#' - AWM - Phosphorus Management (TX)
+#' - AWM - Slow Rate Process Treatment of Wastewater
+#' - BLM - Pygmy Rabbit Habitat Potential
+#' - BLM - Rangeland Tillage
+#' - BLM - Site Degradation Susceptibility
+#' - CA Prime Farmland (CA)
+#' - CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
+#' - Commodity Crop Productivity Index (Corn) (TN)
 #' - CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
-#' - CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
-#' - CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Barley, NIRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Grass Hay, IRR - Eastern Idaho Plateaus (ID)
-#' - CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
-#' - CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
 #' - CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
-#' - CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
-#' - CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Potatoes, IRR - Snake River Plains (ID)
-#' - CPI - Small Grains Productivity Index (AK)
-#' - CPI - Small Grains, IRR - Snake River Plains (ID)
-#' - CPI - Small Grains, NIRR - Palouse Prairies (ID)
 #' - CPI - Small Grains, NIRR - Palouse Prairies (OR)
 #' - CPI - Small Grains, NIRR - Palouse Prairies (WA)
 #' - CPI - Small Grains, NIRR - Snake River Plains (ID)
-#' - CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Wheat, NIRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Wild Hay, NIRR - Eastern Idaho Plateaus (ID)
 #' - CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
 #' - CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
 #' - Deep Infiltration Systems
-#' - DHS - Catastrophic Event, Large Animal Mortality, Burial
-#' - DHS - Catastrophic Event, Large Animal Mortality, Incinerate
-#' - DHS - Catastrophic Mortality, Large Animal Disposal, Pit
-#' - DHS - Catastrophic Mortality, Large Animal Disposal, Trench
-#' - DHS - Emergency Animal Mortality Disposal by Shallow Burial
-#' - DHS - Emergency Land Disposal of Milk
-#' - DHS - Potential for Radioactive Bioaccumulation
-#' - DHS - Potential for Radioactive Sequestration
-#' - DHS - Rubble and Debris Disposal, Large-Scale Event
-#' - DHS - Site for Composting Facility - Subsurface
 #' - DHS - Site for Composting Facility - Surface
-#' - DHS - Suitability for Clay Liner Material
-#' - DHS - Suitability for Composting Medium and Final Cover
 #' - Elevated Sand Mound Septic System (DE)
 #' - ENG - Animal Disposal by Composting (Catastrophic) (WV)
 #' - ENG - Application of Municipal Sludge (TX)
-#' - ENG - Aquifer Assessment - 7081 (MN)
 #' - ENG - Closed-Loop Horizontal Geothermal Heat Pump (CT)
-#' - ENG - Cohesive Soil Liner (MN)
-#' - ENG - Construction Materials - Gravel Source (MN)
-#' - ENG - Construction Materials - Sand Source (MN)
-#' - ENG - Construction Materials; Gravel Source
-#' - ENG - Construction Materials; Gravel Source (AK)
-#' - ENG - Construction Materials; Gravel Source (CT)
-#' - ENG - Construction Materials; Gravel Source (ID)
 #' - ENG - Construction Materials; Gravel Source (IN)
-#' - ENG - Construction Materials; Gravel Source (MI)
 #' - ENG - Construction Materials; Gravel Source (NE)
-#' - ENG - Construction Materials; Gravel Source (NY)
-#' - ENG - Construction Materials; Gravel Source (OH)
-#' - ENG - Construction Materials; Gravel Source (OR)
-#' - ENG - Construction Materials; Gravel Source (VT)
-#' - ENG - Construction Materials; Gravel Source (WA)
-#' - ENG - Construction Materials; Reclamation
-#' - ENG - Construction Materials; Reclamation (DE)
 #' - ENG - Construction Materials; Reclamation (MD)
 #' - ENG - Construction Materials; Reclamation (MI)
-#' - ENG - Construction Materials; Reclamation (OH)
-#' - ENG - Construction Materials; Roadfill
-#' - ENG - Construction Materials; Roadfill (AK)
 #' - ENG - Construction Materials; Roadfill (GA)
-#' - ENG - Construction Materials; Roadfill (OH)
-#' - ENG - Construction Materials; Sand Source
-#' - ENG - Construction Materials; Sand Source (AK)
 #' - ENG - Construction Materials; Sand Source (CT)
 #' - ENG - Construction Materials; Sand Source (GA)
-#' - ENG - Construction Materials; Sand Source (ID)
-#' - ENG - Construction Materials; Sand Source (IN)
-#' - ENG - Construction Materials; Sand Source (NY)
-#' - ENG - Construction Materials; Sand Source (OH)
-#' - ENG - Construction Materials; Sand Source (OR)
-#' - ENG - Construction Materials; Sand Source (VT)
-#' - ENG - Construction Materials; Sand Source (WA)
-#' - ENG - Construction Materials; Topsoil
-#' - ENG - Construction Materials; Topsoil (AK)
-#' - ENG - Construction Materials; Topsoil (DE)
-#' - ENG - Construction Materials; Topsoil (GA)
 #' - ENG - Construction Materials; Topsoil (ID)
-#' - ENG - Construction Materials; Topsoil (MD)
-#' - ENG - Construction Materials; Topsoil (MI)
 #' - ENG - Construction Materials; Topsoil (OH)
-#' - ENG - Construction Materials; Topsoil (OR)
-#' - ENG - Construction Materials; Topsoil (WA)
-#' - ENG - Daily Cover for Landfill
-#' - ENG - Daily Cover for Landfill (AK)
 #' - ENG - Daily Cover for Landfill (OH)
 #' - ENG - Disposal Field (NJ)
-#' - ENG - Disposal Field Gravity (DE)
-#' - ENG - Disposal Field Suitability Class (NJ)
 #' - ENG - Disposal Field Type Inst (NJ)
 #' - ENG - Dwellings W/O Basements
-#' - ENG - Dwellings W/O Basements (OH)
 #' - ENG - Dwellings With Basements
-#' - ENG - Dwellings with Basements (AK)
-#' - ENG - Dwellings With Basements (OH)
 #' - ENG - Dwellings without Basements (AK)
-#' - ENG - Large Animal Disposal, Pit (CT)
-#' - ENG - Large Animal Disposal, Trench (CT)
 #' - ENG - Lawn and Landscape (OH)
 #' - ENG - Lawn, Landscape, Golf Fairway
-#' - ENG - Lawn, landscape, golf fairway (CT)
-#' - ENG - Lawn, Landscape, Golf Fairway (MI)
-#' - ENG - Lawn, Landscape, Golf Fairway (VT)
-#' - ENG - Local Roads and Streets
 #' - ENG - Local Roads and Streets (AK)
 #' - ENG - Local Roads and Streets (GA)
-#' - ENG - Local Roads and Streets (OH)
-#' - ENG - New Ohio Septic Rating (OH)
-#' - ENG - On-Site Waste Water Absorption Fields (MO)
 #' - ENG - On-Site Waste Water Lagoons (MO)
-#' - ENG - OSHA Soil Types (TX)
 #' - ENG - Pier Beam Building Foundations (TX)
 #' - ENG - Sanitary Landfill (Area)
 #' - ENG - Sanitary Landfill (Area) (AK)
-#' - ENG - Sanitary Landfill (Area) (OH)
-#' - ENG - Sanitary Landfill (Trench)
-#' - ENG - Sanitary Landfill (Trench) (AK)
-#' - ENG - Sanitary Landfill (Trench) (OH)
 #' - ENG - Septage Application - Incorporation or Injection (MN)
-#' - ENG - Septage Application - Surface (MN)
 #' - ENG - Septic System; Disinfection, Surface Application (TX)
-#' - ENG - Septic Tank Absorption Fields
-#' - ENG - Septic Tank Absorption Fields - At-Grade (MN)
-#' - ENG - Septic Tank Absorption Fields - Mound (MN)
-#' - ENG - Septic Tank Absorption Fields - Trench (MN)
-#' - ENG - Septic Tank Absorption Fields (AK)
-#' - ENG - Septic Tank Absorption Fields (DE)
 #' - ENG - Septic Tank Absorption Fields (FL)
-#' - ENG - Septic Tank Absorption Fields (MD)
-#' - ENG - Septic Tank Absorption Fields (NY)
 #' - ENG - Septic Tank Absorption Fields (OH)
-#' - ENG - Septic Tank Absorption Fields (TX)
-#' - ENG - Septic Tank Leaching Chamber (TX)
-#' - ENG - Septic Tank, Gravity Disposal (TX)
-#' - ENG - Septic Tank, Subsurface Drip Irrigation (TX)
-#' - ENG - Sewage Lagoons
+#' - ENG - Septic Tank Absorption Fields - Trench (MN)
 #' - ENG - Sewage Lagoons (AK)
-#' - ENG - Sewage Lagoons (OH)
-#' - ENG - Shallow Excavations
-#' - ENG - Shallow Excavations (AK)
-#' - ENG - Shallow Excavations (MI)
 #' - ENG - Shallow Excavations (OH)
-#' - ENG - Small Commercial Buildings
-#' - ENG - Small Commercial Buildings (OH)
-#' - ENG - Soil Potential of Road Salt Applications (CT)
-#' - ENG - Soil Potential Ratings of SSDS (CT)
-#' - ENG - Source of Caliche (TX)
+#' - ENG - Soil Suitability for SLAMM Marsh Migration (CT)
 #' - ENG - Stormwater Management / Infiltration (NY)
-#' - ENG - Stormwater Management / Ponds (NY)
 #' - ENG - Stormwater Management / Wetlands (NY)
-#' - ENG - Unpaved Local Roads and Streets
-#' - Farm and Garden Composting Facility - Surface
-#' - FOR-Biomass Harvest (WI)
-#' - FOR-Construction Limitations for Haul Roads/Log Landings(ME)
-#' - FOR - Biomass Harvest (MA)
-#' - FOR - Black Walnut Suitability Index (KS)
-#' - FOR - Black Walnut Suitability Index (MO)
-#' - FOR - Compaction Potential (WA)
-#' - FOR - Construction Limitations - Haul Roads/Log Landing (OH)
-#' - FOR - Construction Limitations For Haul Roads (MI)
+#' - FOR - Black Walnut Suitability (WI)
+#' - FOR - Black Walnut Suitability (WV)
 #' - FOR - Construction Limitations for Haul Roads/Log Landings
-#' - FOR - Damage by Fire (OH)
 #' - FOR - Displacement Hazard
-#' - FOR - Displacement Potential (WA)
-#' - FOR - General Harvest Season (ME)
-#' - FOR - General Harvest Season (VT)
-#' - FOR - Hand Planting Suitability
-#' - FOR - Hand Planting Suitability (ME)
-#' - FOR - Hand Planting Suitability, MO13 (DE)
-#' - FOR - Hand Planting Suitability, MO13 (MD)
-#' - FOR - Harvest Equipment Operability
 #' - FOR - Harvest Equipment Operability (DE)
-#' - FOR - Harvest Equipment Operability (MD)
 #' - FOR - Harvest Equipment Operability (ME)
 #' - FOR - Harvest Equipment Operability (MI)
-#' - FOR - Harvest Equipment Operability (OH)
-#' - FOR - Harvest Equipment Operability (VT)
-#' - FOR - Log Landing Suitability
 #' - FOR - Log Landing Suitability (ID)
-#' - FOR - Log Landing Suitability (ME)
 #' - FOR - Log Landing Suitability (MI)
 #' - FOR - Log Landing Suitability (OR)
-#' - FOR - Log Landing Suitability (VT)
-#' - FOR - Log Landing Suitability (WA)
-#' - FOR - Mechanical Planting Suitability
-#' - FOR - Mechanical Planting Suitability (CT)
-#' - FOR - Mechanical Planting Suitability (ME)
 #' - FOR - Mechanical Planting Suitability (OH)
-#' - FOR - Mechanical Planting Suitability, MO13 (DE)
-#' - FOR - Mechanical Planting Suitability, MO13 (MD)
-#' - FOR - Mechanical Site Preparation (Deep)
-#' - FOR - Mechanical Site Preparation (Deep) (DE)
-#' - FOR - Mechanical Site Preparation (Deep) (MD)
-#' - FOR - Mechanical Site Preparation (Surface)
-#' - FOR - Mechanical Site Preparation (Surface) (DE)
 #' - FOR - Mechanical Site Preparation (Surface) (MD)
-#' - FOR - Mechanical Site Preparation (Surface) (MI)
 #' - FOR - Mechanical Site Preparation (Surface) (OH)
-#' - FOR - Mechanical Site Preparation; Deep (CT)
-#' - FOR - Mechanical Site Preparation; Surface (ME)
-#' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+#' - FOR - Mechanical Site Preparation; Surface (CT)
 #' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (MI)
 #' - FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (OH)
-#' - FOR - Potential Erosion Hazard (Road/Trail)
-#' - FOR - Potential Erosion Hazard (Road/Trail) (PIA)
-#' - FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
-#' - FOR - Potential Fire Damage Hazard
-#' - FOR - Potential Seedling Mortality
 #' - FOR - Potential Seedling Mortality (FL)
-#' - FOR - Potential Seedling Mortality (MI)
 #' - FOR - Potential Seedling Mortality (OH)
-#' - FOR - Potential Seedling Mortality (PIA)
-#' - FOR - Potential Seedling Mortality (VT)
-#' - FOR - Potential Seedling Mortality(ME)
-#' - FOR - Potential Windthrow Hazard (ME)
-#' - FOR - Potential Windthrow Hazard (MI)
-#' - FOR - Potential Windthrow Hazard (NY)
-#' - FOR - Potential Windthrow Hazard (VT)
-#' - FOR - Puddling Hazard
-#' - FOR - Puddling Potential (WA)
-#' - FOR - Road Suitability (Natural Surface)
-#' - FOR - Road Suitability (Natural Surface) (ID)
-#' - FOR - Road Suitability (Natural Surface) (ME)
-#' - FOR - Road Suitability (Natural Surface) (OH)
-#' - FOR - Road Suitability (Natural Surface) (OR)
 #' - FOR - Road Suitability (Natural Surface) (VT)
-#' - FOR - Road Suitability (Natural Surface) (WA)
-#' - FOR - Rutting Hazard by Month
-#' - FOR - Rutting Hazard by Season
-#' - FOR - Shortleaf pine littleleaf disease susceptibility
-#' - FOR - Soil Compactibility Risk
 #' - FOR - Soil Rutting Hazard
-#' - FOR - Soil Rutting Hazard (ME)
-#' - FOR - Soil Rutting Hazard (OH)
-#' - FOR - Soil Sustainability Forest Biomass Harvesting (CT)
-#' - FOR - White Oak Suitability (MO)
-#' - FOR - Windthrow Hazard
-#' - FOR - Windthrow Hazard (WA)
-#' - FOR (USFS) - Road Construction/Maintenance (Natural Surface)
-#' - FOTG - Indiana Corn Yield Calculation (IN)
-#' - FOTG - Indiana Slippage Potential (IN)
 #' - FOTG - Indiana Soy Bean Yield Calculation (IN)
 #' - FOTG - Indiana Wheat Yield Calculation (IN)
-#' - Fragile Soil Index
-#' - Gravity Full Depth Septic System (DE)
-#' - GRL-FSG-NP-W (MT)
-#' - GRL - Excavations to 24 inches for Plastic Pipelines (TX)
-#' - GRL - Fencing, 24 inch Post Depth (MT)
+#' - FOTG - NLI report Calculation - (IN)
 #' - GRL - Fencing, Post Depth =<24 inches
-#' - GRL - Fencing, Post Depth =<36 inches
 #' - GRL - Fencing, Post Depth Less Than 24 inches (TX)
 #' - GRL - Fencing, Post Depth Less Than 36 inches (TX)
-#' - GRL - Juniper Encroachment Potential (NM)
 #' - GRL - NV range seeding (Wind C = 10) (NV)
-#' - GRL - NV range seeding (Wind C = 100) (NV)
-#' - GRL - NV range seeding (Wind C = 20) (NV)
 #' - GRL - NV range seeding (Wind C = 30) (NV)
-#' - GRL - NV range seeding (Wind C = 40) (NV)
-#' - GRL - NV range seeding (Wind C = 50) (NV)
-#' - GRL - NV range seeding (Wind C = 60) (NV)
-#' - GRL - NV range seeding (Wind C = 80) (NV)
-#' - GRL - NV range seeding (Wind C >= 160) (NV)
-#' - GRL - Pasture and Hayland SG (OH)
-#' - GRL - Ranch Access Roads (TX)
 #' - GRL - Rangeland Chaining (TX)
 #' - GRL - Rangeland Disking (TX)
 #' - GRL - Rangeland Dozing/Grubbing (TX)
-#' - GRL - Rangeland Planting by Mechanical Seeding (TX)
-#' - GRL - Rangeland Prescribed Burning (TX)
-#' - GRL - Rangeland Roller Chopping (TX)
-#' - GRL - Rangeland Root Plowing (TX)
 #' - GRL - Utah Juniper Encroachment Potential
 #' - GRL - Western Juniper Encroachment Potential (OR)
-#' - Ground-based Solar Arrays, Ballast Anchor Systems
-#' - Ground-based Solar Arrays, Soil-penetrating Anchor Systems
-#' - Ground Penetrating Radar Penetration
-#' - Hybrid Wine Grape Varieties Site Desirability (Long)
+#' - Ground-based Solar Arrays_bedrock_slope_anchor(ME)
+#' - Ground-based Solar Arrays_saturation_flooding_Frost(ME)
 #' - Hybrid Wine Grape Varieties Site Desirability (Medium)
-#' - Hybrid Wine Grape Varieties Site Desirability (Short)
-#' - Inland Wetlands (CT)
-#' - IRR-restrictive features for irrigation (OH)
-#' - ISDH Septic Tank Interpretation (IN)
-#' - Land Application of Municipal Sewage Sludge (PA)
 #' - Lined Retention Systems
-#' - Low Pressure Pipe Septic System (DE)
-#' - MIL - Bivouac Areas (DOD)
-#' - MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
-#' - MIL - Excavations for Individual Fighting Position (DOD)
-#' - MIL - Excavations for Vehicle Fighting Position (DOD)
-#' - MIL - Helicopter Landing Zones (DOD)
-#' - MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
 #' - MIL - Trafficability Veh. Type 1 dry season (DOD)
-#' - MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
-#' - MIL - Trafficability Veh. Type 2 dry season (DOD)
 #' - MIL - Trafficability Veh. Type 3 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
 #' - MIL - Trafficability Veh. Type 3 dry season (DOD)
-#' - MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
 #' - MIL - Trafficability Veh. Type 4 dry season (DOD)
 #' - MIL - Trafficability Veh. Type 5 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
-#' - MIL - Trafficability Veh. Type 5 dry season (DOD)
-#' - MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
-#' - MIL - Trafficability Veh. Type 6 dry season (DOD)
-#' - MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
-#' - MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
-#' - MIL - Trafficability Veh. Type 7 dry season (DOD)
-#' - MT - Conservation Tree/Shrub Groups (MT)
-#' - Muscadine Wine Grape Site Desirability (Very Long)
-#' - NCCPI - Irrigated National Commodity Crop Productivity Index
-#' - NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
 #' - NCCPI - NCCPI Corn Submodel (I)
-#' - NCCPI - NCCPI Cotton Submodel (II)
 #' - NCCPI - NCCPI Small Grains Submodel (II)
 #' - NCCPI - NCCPI Soybeans Submodel (I)
-#' - Nitrogen Loss Potential (ND)
-#' - Permafrost Sensitivity (AK)
-#' - Pressure Dose Capping Fill Septic System (DE)
+#' - Peony Flowers Site Suitability (AK)
 #' - Pressure Dose Full Depth Septic System (DE)
-#' - REC - Camp and Picnic Areas (AK)
-#' - REC - Camp Areas (CT)
 #' - REC - Camp Areas; Primitive (AK)
-#' - REC - Foot and ATV Trails (AK)
-#' - REC - Off-Road Motorcycle Trails (CT)
 #' - REC - Paths and Trails (CT)
-#' - REC - Picnic Areas (CT)
-#' - REC - Playgrounds (AK)
-#' - REC - Playgrounds (CT)
-#' - RSK-risk assessment for manure application (OH)
-#' - Salinity Risk Index, Discharge Model (ND)
-#' - SAS - CMECS Substrate Class
-#' - SAS - CMECS Substrate Origin
-#' - SAS - CMECS Substrate Subclass
-#' - SAS - CMECS Substrate Subclass/Group
-#' - SAS - CMECS Substrate Subclass/Group/Subgroup
+#' - Salinity Risk Index (ND)
 #' - SAS - Eastern Oyster Habitat Restoration Suitability
-#' - SAS - Eelgrass Restoration Suitability
-#' - SAS - Land Utilization of Dredged Materials
-#' - SAS - Mooring Anchor - Deadweight
 #' - SAS - Mooring Anchor - Mushroom
-#' - SAS - Northern Quahog (Hard Clam) Habitat Suitability
-#' - Septic System A/B Soil System (Alternate) (PA)
-#' - Septic System At-Grade Bed (Alternate) (PA)
-#' - Septic System At Grade Shallow Field (alternative) (WV)
 #' - Septic System CO-OP RFS III w/At-Grade Bed (PA)
-#' - Septic System CO-OP RFS III w/Drip Irrigation (PA)
-#' - Septic System CO-OP RFS III w/Spray Irrigation (PA)
-#' - Septic System Drip Irrigation (Alternate) (PA)
-#' - Septic System Drip Irrigation (alternative) (WV)
-#' - Septic System Dual Field Trench (conventional) (WV)
-#' - Septic System Elevated Field (alternative) (WV)
 #' - Septic System Free Access Sand Filter w/At-Grade Bed (PA)
-#' - Septic System Free Access Sand Filter w/Drip Irrigation (PA)
-#' - Septic System Free Access Sand Filterw/Spray Irrigation (PA)
-#' - Septic System In Ground Bed (conventional) (PA)
-#' - Septic System In Ground Trench (conventional) (PA)
-#' - Septic System In Ground Trench (conventional) (WV)
-#' - Septic System Low Pressure Pipe (alternative) (WV)
 #' - Septic System Modified Subsurface Sand Filter (Alt.) (PA)
-#' - Septic System Mound (alternative) (WV)
-#' - Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
-#' - Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
-#' - Septic System Peat Based Option2 w/Spray Irrigation (PA)
-#' - Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
-#' - Septic System Sand Mound Bed or Trench (PA)
 #' - Septic System Shallow In Ground Trench (conventional) (WV)
-#' - Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
-#' - Septic System Spray Irrigation (PA)
-#' - Septic System Steep Slope Mound (alternative) (WV)
-#' - Septic System Steep Slope Sand Mound (Alternate) (PA)
 #' - Septic System Subsurface Sand Filter Bed (conventional) (PA)
 #' - Septic System Subsurface Sand Filter Trench (standard) (PA)
-#' - Shallow Infiltration Systems
-#' - SOH -  Suitability for Aerobic Soil Organisms
-#' - SOH - Agricultural Organic Soil Subsidence
-#' - SOH - Concentration of Salts- Soil Surface
-#' - SOH - Organic Matter Depletion
-#' - SOH - Soil Surface Sealing
-#' - SOH - Soil Susceptibility to Compaction
-#' - Soil Habitat for Saprophyte Stage of Coccidioides
-#' - SOIL HEALTH ASSESSMENT (NJ)
-#' - Soil Vegetative Groups (CA)
-#' - Surface Runoff Class (CA)
-#' - Unlined Retention Systems
-#' - URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
-#' - URB - Commercial Brick Buildings w/Concrete Slab (TX)
-#' - URB - Commercial Metal Bldg; w/Concrete Slab (TX)
-#' - URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
-#' - URB - Commercial Metal Buildings w/o Concrete Slab (TX)
+#' - SOH - Limitations for Aerobic Soil Organisms
 #' - URB - Concrete Driveways and Sidewalks (TX)
 #' - URB - Dwellings on Concrete Slab (TX)
-#' - URB - Dwellings With Basements (TX)
 #' - URB - Lawns and Ornamental Plantings (TX)
-#' - URB - Reinforced Concrete Slab (TX)
-#' - URB - Rural Residential Development on Concrete Slab (TX)
-#' - URB - Rural Residential Development w/Basement (TX)
-#' - URB - Urban Residential Development on Concrete Slab (TX)
-#' - URB - Urban Residential Development w/Basement (TX)
-#' - URB/REC - Camp Areas
-#' - URB/REC - Camp Areas (GA)
-#' - URB/REC - Camp Areas (HI)
-#' - URB/REC - Camp Areas (MI)
-#' - URB/REC - Camp Areas (OH)
-#' - URB/REC - Golf Fairways (OH)
-#' - URB/REC - Off-Road Motorcycle Trails
-#' - URB/REC - Off-Road Motorcycle Trails (OH)
 #' - URB/REC - Paths and Trails
 #' - URB/REC - Paths and Trails (GA)
-#' - URB/REC - Paths and Trails (MI)
-#' - URB/REC - Paths and Trails (OH)
-#' - URB/REC - Picnic Areas
+#' - URB/REC - Playgrounds (MI)
+#' - Vinifera Wine Grape Site Desirability (Long)
+#' - WLF - Crawfish Aquaculture (TX)
+#' - WLF - Desertic Herbaceous Plants (TX)
+#' - WLF - Gopher Tortoise Burrowing Suitability
+#' - WLF - Grain & Seed Crops for Food and Cover (TX)
+#' - WMS - Constructing Grassed Waterways (OH)
+#' - WMS - Irrigation, Surface (graded)
+#' - WMS - Subsurface Drains - Installation (VT)
+#' - WMS - Subsurface Water Management, System Performance
+#' - WMS - Surface Drains (TX)
+#' - WMS - Surface Irrigation Intake Family (TX)
+#' - Septic System Low Pressure Pipe (alternative) (WV)
+#' - Septic System Mound (alternative) (WV)
+#' - Septic System Peat Based Option2 w/Spray Irrigation (PA)
+#' - Septic System Steep Slope Mound (alternative) (WV)
+#' - SOH - Concentration of Salts- Soil Surface
+#' - SOH - Soil Susceptibility to Compaction
+#' - Soil Habitat for Saprophyte Stage of Coccidioides
+#' - Unlined Retention Systems
+#' - URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
 #' - URB/REC - Picnic Areas (GA)
 #' - URB/REC - Picnic Areas (MI)
 #' - URB/REC - Picnic Areas (OH)
-#' - URB/REC - Playgrounds
-#' - URB/REC - Playgrounds (GA)
-#' - URB/REC - Playgrounds (MI)
-#' - URB/REC - Playgrounds (OH)
-#' - Vinifera Wine Grape Site Desirability (Long to Medium)
-#' - Vinifera Wine Grape Site Desirability (Long)
-#' - Vinifera Wine Grape Site Desirability (Short to Medium)
 #' - Vinifera Wine Grape Site Desirability (Short)
-#' - WAQ - Soil Pesticide Absorbed Runoff Potential (TX)
-#' - WAQ - Soil Pesticide Leaching Potential (TX)
-#' - WAQ - Soil Pesticide Solution Runoff Potential (TX)
-#' - WLF-Soil Suitability - Karner Blue Butterfly (WI)
 #' - WLF - Burrowing Mammals & Reptiles (TX)
-#' - WLF - Chufa for Turkey Forage (LA)
-#' - WLF - Crawfish Aquaculture (TX)
 #' - WLF - Desert Tortoise (CA)
-#' - WLF - Desertic Herbaceous Plants (TX)
 #' - WLF - Domestic Grasses & Legumes for Food and Cover (TX)
-#' - WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
-#' - WLF - Freshwater Wetland Plants (TX)
-#' - WLF - Gopher Tortoise Burrowing Suitability
-#' - WLF - Grain & Seed Crops for Food and Cover (TX)
-#' - WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
-#' - WLF - Irrigated Freshwater Wetland Plants (TX)
 #' - WLF - Irrigated Grain & Seed Crops for Food & Cover (TX)
-#' - WLF - Irrigated Saline Water Wetland Plants (TX)
-#' - WLF - Riparian Herbaceous Plants (TX)
-#' - WLF - Riparian Shrubs, Vines, & Trees (TX)
-#' - WLF - Saline Water Wetland Plants (TX)
-#' - WLF - Upland Coniferous Trees (TX)
-#' - WLF - Upland Deciduous Trees (TX)
-#' - WLF - Upland Desertic Shrubs & Trees (TX)
-#' - WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
-#' - WLF - Upland Native Herbaceous Plants (TX)
-#' - WLF - Upland Shrubs & Vines (TX)
-#' - WMS-Subsurface Water Management, Installation (ND)
-#' - WMS-Subsurface Water Management, Outflow Quality (ND)
-#' - WMS-Subsurface Water Management, Performance (ND)
-#' - WMS - Constructing Grassed Waterways (OH)
-#' - WMS - Constructing Grassed Waterways (TX)
-#' - WMS - Constructing Terraces & Diversions (TX)
-#' - WMS - Constructing Terraces and Diversions (OH)
-#' - WMS - Drainage - (MI)
-#' - WMS - Drainage (IL)
-#' - WMS - Drainage (OH)
-#' - WMS - Embankments, Dikes, and Levees
-#' - WMS - Embankments, Dikes, and Levees (OH)
-#' - WMS - Embankments, Dikes, and Levees (VT)
 #' - WMS - Excavated Ponds (Aquifer-fed)
-#' - WMS - Excavated Ponds (Aquifer-fed) (OH)
 #' - WMS - Excavated Ponds (Aquifer-fed) (VT)
-#' - WMS - Grape Production with Drip Irrigation (TX)
-#' - WMS - Grassed Waterways - (MI)
 #' - WMS - Irrigation, General
 #' - WMS - Irrigation, Micro (above ground)
 #' - WMS - Irrigation, Micro (above ground) (VT)
 #' - WMS - Irrigation, Micro (subsurface drip)
-#' - WMS - Irrigation, Micro (subsurface drip) (VT)
-#' - WMS - Irrigation, Sprinkler (close spaced outlet drops)
-#' - WMS - Irrigation, Sprinkler (general)
 #' - WMS - Irrigation, Sprinkler (general) (VT)
-#' - WMS - Irrigation, Surface (graded)
-#' - WMS - Irrigation, Surface (level)
 #' - WMS - Pond Reservoir Area
-#' - WMS - Pond Reservoir Area (GA)
-#' - WMS - Pond Reservoir Area (MI)
 #' - WMS - Pond Reservoir Area (OH)
+#' - WMS - Subsurface Water Management, System Installation
+#' - WMS - Constructing Terraces & Diversions (TX)
+#' - WMS - Drainage (OH)
+#' - WMS - Excavated Ponds (Aquifer-fed) (OH)
+#' - WMS - Grape Production with Drip Irrigation (TX)
+#' - WMS - Irrigation, Micro (subsurface drip) (VT)
+#' - WMS - Irrigation, Surface (level)
+#' - WMS - Pond Reservoir Area (MI)
+#' - WMS - Pond Reservoir Area (VT)
 #' - WMS - Sprinkler Irrigation (MT)
 #' - WMS - Sprinkler Irrigation RDC (IL)
-#' - WMS - Subsurface Drains - Installation (VT)
 #' - WMS - Subsurface Drains - Performance (VT)
-#' - WMS - Subsurface Drains < 3 Feet Deep (TX)
-#' - WMS - Subsurface Drains > 3 Feet Deep (TX)
 #' - WMS - Subsurface Water Management, Outflow Quality
-#' - WMS - Subsurface Water Management, System Installation
-#' - WMS - Subsurface Water Management, System Performance
-#' - WMS - Surface Drains (TX)
-#' - WMS - Surface Irrigation Intake Family (TX)
 #' - WMS - Surface Water Management, System
+#' - WMS-Subsurface Water Management, Performance (ND)
 #'
 #' @author Jason Nemecek, Chad Ferguson, Andrew Brown
 #' @return a data.frame
@@ -665,6 +683,7 @@ get_SDA_interpretation <- function(rulename,
                                    areasymbols = NULL,
                                    mukeys = NULL,
                                    WHERE = NULL,
+                                   ruledepth = 0,
                                    query_string = FALSE,
                                    not_rated_value = NA_real_,
                                    dsn = NULL) {
@@ -673,6 +692,7 @@ get_SDA_interpretation <- function(rulename,
       interp = rulename,
       areasymbols = areasymbols,
       mukeys = mukeys,
+      ruledepth = ruledepth,
       WHERE = WHERE,
       sqlite = !is.null(dsn)
     )
@@ -709,330 +729,6 @@ get_SDA_interpretation <- function(rulename,
     y
   })
   return(res)
-}
-
-.cointerpRuleNames <- function() {
-  # dput(soilDB::SDA_query("select distinct mrulename from cointerp"))
-  c("AGR - Barley Yield (MT)", "AGR - Grape non-irrigated (MO)",
-    "AGR - Industrial Hemp for Fiber and Seed Production", "AGR - Nitrate Leaching Potential, Irrigated (WA)",
-    "AGR - Pasture hayland (MO)", "AGR - Pesticide Loss Potential-Soil Surface Runoff",
-    "AGR - Prime Farmland (TX)", "AGR - Spring Wheat Yield (MT)",
-    "AGR-Agronomic Concerns (ND)", "AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)",
-    "AGR-Surface Salinity (ND)", "AGR-Water Erosion Potential (ND)",
-    "Alaska Exempt Wetland Potential (AK)", "American Wine Grape Varieties Site Desirability (Short)",
-    "AWM - Irrigation Disposal of Wastewater (MD)", "AWM - Manure and Food Processing Waste (DE)",
-    "AWM - Manure Stacking - Site Evaluation (TX)", "AWM - Phosphorus Management (TX)",
-    "AWM - Slow Rate Process Treatment of Wastewater", "BLM - Pygmy Rabbit Habitat Potential",
-    "BLM - Rangeland Tillage", "BLM - Site Degradation Susceptibility",
-    "CLASS RULE - Depth to root limiting layer (5 classes) (NPS)",
-    "Commodity Crop Productivity Index (Corn) (TN)", "CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)",
-    "CPI - Barley, NIRR - Eastern Idaho Plateaus (ID)", "CPI - Grass Hay, IRR - Eastern Idaho Plateaus (ID)",
-    "CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)",
-    "CPI - Potatoes, IRR - Snake River Plains (ID)", "CPI - Small Grains, NIRR - Palouse Prairies (OR)",
-    "CPI - Small Grains, NIRR - Palouse Prairies (WA)", "CPI - Small Grains, NIRR - Snake River Plains (ID)",
-    "CPI - Wheat, NIRR - Eastern Idaho Plateaus (ID)", "CPI - Wild Hay, NIRR - Eastern Idaho Plateaus (ID)",
-    "CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)",
-    "CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)",
-    "Deep Infiltration Systems", "DHS - Site for Composting Facility - Surface",
-    "Elevated Sand Mound Septic System (DE)", "ENG - Animal Disposal by Composting (Catastrophic) (WV)",
-    "ENG - Closed-Loop Horizontal Geothermal Heat Pump (CT)", "ENG - Construction Materials; Gravel Source (IN)",
-    "ENG - Construction Materials; Gravel Source (NE)", "ENG - Construction Materials; Reclamation (MD)",
-    "ENG - Construction Materials; Reclamation (MI)", "ENG - Construction Materials; Roadfill (GA)",
-    "ENG - Construction Materials; Sand Source (CT)", "ENG - Construction Materials; Sand Source (GA)",
-    "ENG - Construction Materials; Topsoil (ID)", "ENG - Construction Materials; Topsoil (OH)",
-    "ENG - Daily Cover for Landfill (OH)", "ENG - Disposal Field (NJ)",
-    "ENG - Disposal Field Type Inst (NJ)", "ENG - Dwellings W/O Basements",
-    "ENG - Dwellings With Basements", "ENG - Dwellings without Basements (AK)",
-    "ENG - Lawn and Landscape (OH)", "ENG - Lawn, Landscape, Golf Fairway",
-    "ENG - Local Roads and Streets (AK)", "ENG - Local Roads and Streets (GA)",
-    "ENG - On-Site Waste Water Lagoons (MO)", "ENG - Pier Beam Building Foundations (TX)",
-    "ENG - Sanitary Landfill (Area)", "ENG - Sanitary Landfill (Area) (AK)",
-    "ENG - Septage Application - Incorporation or Injection (MN)",
-    "ENG - Septic System; Disinfection, Surface Application (TX)",
-    "ENG - Septic Tank Absorption Fields (FL)", "ENG - Septic Tank Absorption Fields (OH)",
-    "ENG - Septic Tank Absorption Fields - Trench (MN)", "ENG - Sewage Lagoons (AK)",
-    "ENG - Shallow Excavations (OH)", "ENG - Stormwater Management / Infiltration (NY)",
-    "ENG - Stormwater Management / Wetlands (NY)", "FOR - Black Walnut Suitability (WV)",
-    "FOR - Construction Limitations for Haul Roads/Log Landings",
-    "FOR - Displacement Hazard", "FOR - Harvest Equipment Operability (DE)",
-    "FOR - Harvest Equipment Operability (ME)", "FOR - Harvest Equipment Operability (MI)",
-    "FOR - Log Landing Suitability (ID)", "FOR - Log Landing Suitability (MI)",
-    "FOR - Log Landing Suitability (OR)", "FOR - Mechanical Planting Suitability (OH)",
-    "FOR - Mechanical Site Preparation (Surface) (MD)", "FOR - Mechanical Site Preparation (Surface) (OH)",
-    "FOR - Mechanical Site Preparation; Surface (CT)", "FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (MI)",
-    "FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (OH)", "FOR - Potential Seedling Mortality (FL)",
-    "FOR - Potential Seedling Mortality (OH)", "FOR - Road Suitability (Natural Surface) (VT)",
-    "FOR - Soil Rutting Hazard", "FOTG - Indiana Soy Bean Yield Calculation (IN)",
-    "FOTG - Indiana Wheat Yield Calculation (IN)", "GRL - Fencing, Post Depth =<24 inches",
-    "GRL - Fencing, Post Depth Less Than 24 inches (TX)", "GRL - Fencing, Post Depth Less Than 36 inches (TX)",
-    "GRL - NV range seeding (Wind C = 10) (NV)", "GRL - NV range seeding (Wind C = 30) (NV)",
-    "GRL - Rangeland Chaining (TX)", "GRL - Rangeland Disking (TX)",
-    "GRL - Rangeland Dozing/Grubbing (TX)", "GRL - Utah Juniper Encroachment Potential",
-    "GRL - Western Juniper Encroachment Potential (OR)", "Ground-based Solar Arrays_saturation_flooding_Frost(ME)",
-    "Hybrid Wine Grape Varieties Site Desirability (Medium)", "Lined Retention Systems",
-    "MIL - Trafficability Veh. Type 1 dry season (DOD)", "MIL - Trafficability Veh. Type 3 1-pass wet season (DOD)",
-    "MIL - Trafficability Veh. Type 3 dry season (DOD)", "MIL - Trafficability Veh. Type 4 dry season (DOD)",
-    "MIL - Trafficability Veh. Type 5 1-pass wet season (DOD)", "NCCPI - NCCPI Corn Submodel (I)",
-    "NCCPI - NCCPI Small Grains Submodel (II)", "NCCPI - NCCPI Soybeans Submodel (I)",
-    "Peony Flowers Site Suitability (AK)", "Pressure Dose Full Depth Septic System (DE)",
-    "REC - Camp Areas; Primitive (AK)", "REC - Paths and Trails (CT)",
-    "Salinity Risk Index (ND)", "SAS - Eastern Oyster Habitat Restoration Suitability",
-    "SAS - Mooring Anchor - Mushroom", "Septic System CO-OP RFS III w/At-Grade Bed (PA)",
-    "Septic System Free Access Sand Filter w/At-Grade Bed (PA)",
-    "Septic System Modified Subsurface Sand Filter (Alt.) (PA)",
-    "Septic System Shallow In Ground Trench (conventional) (WV)",
-    "Septic System Subsurface Sand Filter Bed (conventional) (PA)",
-    "Septic System Subsurface Sand Filter Trench (standard) (PA)",
-    "SOH - Limitations for Aerobic Soil Organisms", "URB - Concrete Driveways and Sidewalks (TX)",
-    "URB - Dwellings on Concrete Slab (TX)", "URB - Lawns and Ornamental Plantings (TX)",
-    "URB/REC - Paths and Trails", "URB/REC - Paths and Trails (GA)",
-    "URB/REC - Playgrounds (MI)", "Vinifera Wine Grape Site Desirability (Long)",
-    "WLF - Crawfish Aquaculture (TX)", "WLF - Desertic Herbaceous Plants (TX)",
-    "WLF - Gopher Tortoise Burrowing Suitability", "WLF - Grain & Seed Crops for Food and Cover (TX)",
-    "WMS - Constructing Grassed Waterways (OH)", "WMS - Constructing Terraces & Diversions (TX)",
-    "WMS - Drainage (OH)", "WMS - Excavated Ponds (Aquifer-fed) (OH)",
-    "WMS - Irrigation, Micro (subsurface drip) (VT)", "WMS - Irrigation, Surface (level)",
-    "WMS - Pond Reservoir Area (MI)", "WMS - Sprinkler Irrigation (MT)",
-    "WMS - Sprinkler Irrigation RDC (IL)", "WMS - Subsurface Drains - Performance (VT)",
-    "WMS - Subsurface Water Management, Outflow Quality", "WMS - Surface Water Management, System",
-    "WMS-Subsurface Water Management, Performance (ND)", "AGR - Filter Strips (TX)",
-    "AGR - Mulch Till (TX)", "AGR - Nitrate Leaching Potential, Nonirrigated (MT)",
-    "AGR - Nitrate Leaching Potential, Nonirrigated (WV)", "AGR - No Till (VT)",
-    "AGR - Oats Yield (MT)", "AGR - Pesticide Loss Potential-Leaching",
-    "AGR - Pesticide Loss Potential-Leaching (NE)", "AGR - S. Highbush Blueberry Suitability MLRA 153 (SC)",
-    "AGR - Wind Erosion Potential (NE)", "AGR-Available Water Capacity (ND)",
-    "AGR-Physical Limitations (ND)", "AGR-Sodicity (ND)", "AGR-Surface Crusting (ND)",
-    "AGR-Wind Erosion (ND)", "AWM - Irrigation Disposal of Wastewater (DE)",
-    "AWM - Land App of Municipal Sewage Sludge (DE)", "AWM - Land App of Municipal Sewage Sludge (MD)",
-    "AWM - Land Application of Milk (CT)", "AWM - Land Application of Municipal Biosolids, spring (OR)",
-    "AWM - Land Application of Municipal Sewage Sludge", "AWM - Land Application of Municipal Sewage Sludge (OH)",
-    "AWM - Land Application of Municipal Sewage Sludge (VT)", "AWM - Large Animal Disposal, Pit (MN)",
-    "AWM - Manure and Food Processing Waste", "AWM - Manure and Food Processing Waste (VT)",
-    "AWM - Rapid Infil Disposal of Wastewater (MD)", "AWM - Rapid Infiltration Disposal of Wastewater (VT)",
-    "AWM - Slow Rate Process Treatment of Wastewater (VT)", "BLM - Chaining Suitability",
-    "BLM - Fugitive Dust Resistance", "BLM - Soil Restoration Potential",
-    "BLM - Yellow Star-thistle Invasion Susceptibility", "CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)",
-    "CLR-cropland limitation for corn and soybeans (IN)", "Commodity Crop Productivity Index (Corn) (WI)",
-    "CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)", "CPI - Potatoes Productivity Index (AK)",
-    "CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)", "CPI - Small Grains, NIRR - Palouse Prairies (ID)",
-    "DHS - Emergency Animal Mortality Disposal by Shallow Burial",
-    "DHS - Rubble and Debris Disposal, Large-Scale Event", "ENG - Aquifer Assessment - 7081 (MN)",
-    "ENG - Construction Materials - Gravel Source (MN)", "ENG - Construction Materials; Gravel Source (MI)",
-    "ENG - Construction Materials; Gravel Source (OR)", "ENG - Construction Materials; Reclamation",
-    "ENG - Construction Materials; Reclamation (OH)", "ENG - Construction Materials; Sand Source",
-    "ENG - Construction Materials; Sand Source (AK)", "ENG - Construction Materials; Sand Source (ID)",
-    "ENG - Construction Materials; Sand Source (IN)", "ENG - Construction Materials; Sand Source (OH)",
-    "ENG - Construction Materials; Topsoil", "ENG - Construction Materials; Topsoil (WA)",
-    "ENG - Ground-based Solar Arrays, Soil-based Anchor Systems",
-    "ENG - Local Roads and Streets", "ENG - New Ohio Septic Rating (OH)",
-    "ENG - Sanitary Landfill (Trench) (OH)", "ENG - Septic Tank Absorption Fields (AK)",
-    "ENG - Septic Tank Absorption Fields (DE)", "ENG - Septic Tank Absorption Fields (NY)",
-    "ENG - Sewage Lagoons (OH)", "ENG - Shallow Excavations (AK)",
-    "ENG - Shallow Excavations (MI)", "ENG - Unpaved Local Roads and Streets",
-    "FOR - Black Walnut Suitability Index (MO)", "FOR - Conservation Tree and Shrub Groups (TX)",
-    "FOR - Construction Limitations - Haul Roads/Log Landing (OH)",
-    "FOR - Construction Limitations For Haul Roads (MI)", "FOR - Hand Planting Suitability (ME)",
-    "FOR - Harvest Equipment Operability (MD)", "FOR - Harvest Equipment Operability (OH)",
-    "FOR - Harvest Equipment Operability (VT)", "FOR - Mechanical Planting Suitability",
-    "FOR - Mechanical Planting Suitability (ME)", "FOR - Mechanical Planting Suitability, MO13 (DE)",
-    "FOR - Potential Erosion Hazard (Off-Road/Off-Trail)", "FOR - Potential Erosion Hazard (Road/Trail) (PIA)",
-    "FOR - Potential Seedling Mortality (VT)", "FOR - Potential Windthrow Hazard (NY)",
-    "FOR - Potential Windthrow Hazard (VT)", "FOR - Puddling Potential (WA)",
-    "FOR - Road Suitability (Natural Surface)", "FOR - Road Suitability (Natural Surface) (OH)",
-    "FOR - Road Suitability (Natural Surface) (OR)", "FOR - Rutting Hazard by Season",
-    "FOR - Shortleaf pine littleleaf disease susceptibility", "FOR - Soil Compactibility Risk",
-    "FOR - Soil Rutting Hazard (ME)", "FOR - Windthrow Hazard", "FOR-Construction Limitations for Haul Roads/Log Landings(ME)",
-    "FOTG - Indiana Slippage Potential (IN)", "Gravity Full Depth Septic System (DE)",
-    "GRL - Fencing, Post Depth =<36 inches", "GRL - NV range seeding (Wind C = 50) (NV)",
-    "GRL - Ranch Access Roads (TX)", "GRL - Rangeland Roller Chopping (TX)",
-    "Ground Penetrating Radar Penetration", "Ground-based Solar Arrays, Soil-penetrating Anchor Systems",
-    "Ground-based Solar Arrays_bedrock(ME)", "Hybrid Wine Grape Varieties Site Desirability (Short)",
-    "ISDH Septic Tank Interpretation (IN)", "Land Application of Municipal Sewage Sludge (PA)",
-    "MIL - Helicopter Landing Zones (DOD)", "MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)",
-    "MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 5 dry season (DOD)", "MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)",
-    "NCCPI - National Commodity Crop Productivity Index (Ver 3.0)",
-    "REC - Camp and Picnic Areas (AK)", "REC - Picnic Areas (CT)",
-    "REC - Playgrounds (CT)", "SAS - CMECS Substrate Subclass", "Septic System Drip Irrigation (Alternate) (PA)",
-    "Septic System Free Access Sand Filter w/Drip Irrigation (PA)",
-    "Septic System In Ground Bed (conventional) (PA)", "Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)",
-    "Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)",
-    "Septic System Sand Mound Bed or Trench (PA)", "Septic System Shallow Placement Pressure Dosed (Alt.) (PA)",
-    "SOH - Aggregate Stability (ND)", "SOH - Agricultural Organic Soil Subsidence",
-    "SOH - Dynamic Soil Properties Response to Biochar", "SOH - Organic Matter Depletion",
-    "SOIL HEALTH ASSESSMENT (NJ)", "URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)",
-    "URB - Reinforced Concrete Slab (TX)", "URB/REC - Camp Areas",
-    "URB/REC - Camp Areas (OH)", "URB/REC - Off-Road Motorcycle Trails (OH)",
-    "URB/REC - Paths and Trails (OH)", "URB/REC - Picnic Areas",
-    "URB/REC - Playgrounds", "URB/REC - Playgrounds (GA)", "Vinifera Wine Grape Site Desirability (Short to Medium)",
-    "WLF - Upland Coniferous Trees (TX)", "WLF - Upland Deciduous Trees (TX)",
-    "WLF - Upland Desertic Shrubs & Trees (TX)", "WLF - Upland Native Herbaceous Plants (TX)",
-    "WLF - Upland Shrubs & Vines (TX)", "WLF-Soil Suitability - Karner Blue Butterfly (WI)",
-    "WMS - Drainage (IL)", "WMS - Drainage - (MI)", "WMS - Embankments, Dikes, and Levees",
-    "WMS - Embankments, Dikes, and Levees (OH)", "WMS - Grassed Waterways - (MI)",
-    "WMS - Irrigation, Sprinkler (general)", "WMS - Pond Reservoir Area (GA)",
-    "WMS-Subsurface Water Management, Installation (ND)", "WMS-Subsurface Water Management, Outflow Quality (ND)",
-    "AGR -  Ecosite (MO)", "AGR - Air Quality; PM10 (TX)", "AGR - Air Quality; PM2_5 (TX)",
-    "AGR - Aronia Berry Suitability (SD)", "AGR - Index for alfalfa hay, irrigated (NV)",
-    "AGR - Nitrate Leaching Potential, Nonirrigated (MA)", "AGR - Water Erosion Potential (TX)",
-    "AGR - Wine Grape Site Suitability (WA)", "AGR-Natural Fertility (ND)",
-    "AGR-Subsurface Salinity (ND)", "AWM - Filter Group (OH)", "AWM - Irrigation Disposal of Wastewater",
-    "AWM - Land Application of Municipal Biosolids, winter (OR)",
-    "AWM - Overland Flow Process Treatment of Wastewater", "AWM - Rapid Infiltration Disposal of Wastewater",
-    "AWM - Vegetated Treatment Area (PIA)", "AWM - Waste Field Storage Area (VT)",
-    "BLM - Mechanical Treatment, Shredder", "BLM - Medusahead Invasion Susceptibility",
-    "BLM - Soil Compaction Resistance", "Capping Fill Gravity Septic System (DE)",
-    "CLASS RULE - Depth to any bedrock kind (5 classes) (NPS)", "CPI - Alfalfa Hay, IRR - Eastern Idaho Plateaus (ID)",
-    "CPI - Alfalfa Hay, IRR - Klamath Valley and Basins (OR)", "CPI - Alfalfa Hay, IRR - Snake River Plains (ID)",
-    "CPI - Alfalfa Hay, NIRR- Eastern Idaho Plateaus (ID)", "CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)",
-    "CPI - Small Grains Productivity Index (AK)", "DHS - Catastrophic Event, Large Animal Mortality, Incinerate",
-    "DHS - Emergency Land Disposal of Milk", "DHS - Site for Composting Facility - Subsurface",
-    "DHS - Suitability for Clay Liner Material", "ENG - Cohesive Soil Liner (MN)",
-    "ENG - Construction Materials - Sand Source (MN)", "ENG - Construction Materials; Gravel Source (CT)",
-    "ENG - Construction Materials; Gravel Source (NY)", "ENG - Construction Materials; Reclamation (DE)",
-    "ENG - Construction Materials; Roadfill", "ENG - Construction Materials; Roadfill (AK)",
-    "ENG - Construction Materials; Sand Source (NY)", "ENG - Construction Materials; Sand Source (VT)",
-    "ENG - Construction Materials; Topsoil (AK)", "ENG - Construction Materials; Topsoil (DE)",
-    "ENG - Construction Materials; Topsoil (MI)", "ENG - Construction Materials; Topsoil (OR)",
-    "ENG - Conventional On-Site Septic Systems (TN)", "ENG - Deep Infiltration Systems",
-    "ENG - Disposal Field Gravity (DE)", "ENG - Dwellings With Basements (OH)",
-    "ENG - Ground-based Solar Arrays, Ballast Anchor Systems", "ENG - Large Animal Disposal, Trench (CT)",
-    "ENG - Lawn, Landscape, Golf Fairway (MI)", "ENG - Lawn, Landscape, Golf Fairway (VT)",
-    "ENG - Sanitary Landfill (Area) (OH)", "ENG - Sanitary Landfill (Trench)",
-    "ENG - Sanitary Landfill (Trench) (AK)", "ENG - Septage Application - Surface (MN)",
-    "ENG - Septic Tank Absorption Fields - At-Grade (MN)", "ENG - Septic Tank Absorption Fields - Mound (MN)",
-    "ENG - Septic Tank Leaching Chamber (TX)", "ENG - Septic Tank, Subsurface Drip Irrigation (TX)",
-    "ENG - Shallow Excavations", "ENG - Shallow Infiltration Systems",
-    "ENG - Small Commercial Buildings", "ENG - Soil Potential of Road Salt Applications (CT)",
-    "ENG - Source of Caliche (TX)", "ENG - Stormwater Management / Ponds (NY)",
-    "ENG - Unlined Retention Systems", "Farm and Garden Composting Facility - Surface",
-    "FOR - Biomass Harvest (MA)", "FOR - Black Walnut Suitability Index (KS)",
-    "FOR - Displacement Potential (WA)", "FOR - Drought Vulnerable Soils",
-    "FOR - General Harvest Season (ME)", "FOR - Harvest Equipment Operability",
-    "FOR - Mechanical Site Preparation (Deep) (MD)", "FOR - Mechanical Site Preparation (Surface)",
-    "FOR - Mechanical Site Preparation; Deep (CT)", "FOR - Potential Erosion Hazard (Road/Trail)",
-    "FOR - Potential Fire Damage Hazard", "FOR - Potential Seedling Mortality",
-    "FOR - Potential Seedling Mortality (MI)", "FOR - Potential Windthrow Hazard (MI)",
-    "FOR - Road Suitability (Natural Surface) (ID)", "FOR - Rutting Hazard by Month",
-    "FOR - Windthrow Hazard (WA)", "Fragile Soil Index", "GRL - Juniper Encroachment Potential (NM)",
-    "GRL - NV range seeding (Wind C = 20) (NV)", "GRL - Pasture and Hayland SG (OH)",
-    "GRL - Rangeland Prescribed Burning (TX)", "Ground-based Solar Arrays, Ballast Anchor Systems",
-    "Ground-based Solar Arrays_slope(ME)", "Inland Wetlands (CT)",
-    "IRR-restrictive features for irrigation (OH)", "MIL - Excavations for Vehicle Fighting Position (DOD)",
-    "MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)", "MIL - Trafficability Veh. Type 2 dry season (DOD)",
-    "MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)", "MIL - Trafficability Veh. Type 6 dry season (DOD)",
-    "Muscadine Wine Grape Site Desirability (Very Long)", "NCCPI - NCCPI Cotton Submodel (II)",
-    "Permafrost Sensitivity (AK)", "Pressure Dose Capping Fill Septic System (DE)",
-    "REC - Camp Areas (CT)", "REC - Off-Road Motorcycle Trails (CT)",
-    "SAS - CMECS Substrate Class", "SAS - CMECS Substrate Subclass/Group",
-    "SAS - Eelgrass Restoration Suitability", "SAS - Land Utilization of Dredged Materials",
-    "SAS - Northern Quahog (Hard Clam) Habitat Suitability", "Septic System At Grade Shallow Field (alternative) (WV)",
-    "Septic System At-Grade Bed (Alternate) (PA)", "Septic System CO-OP RFS III w/Drip Irrigation (PA)",
-    "Septic System Drip Irrigation (alternative) (WV)", "Septic System Free Access Sand Filterw/Spray Irrigation (PA)",
-    "Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)",
-    "Septic System Spray Irrigation (PA)", "Septic System Steep Slope Sand Mound (Alternate) (PA)",
-    "Shallow Infiltration Systems", "SOH - Soil Surface Sealing",
-    "URB/REC - Camp Areas (GA)", "URB/REC - Camp Areas (MI)", "URB/REC - Golf Fairways (OH)",
-    "URB/REC - Off-Road Motorcycle Trails", "URB/REC - Paths and Trails (MI)",
-    "URB/REC - Playgrounds (OH)", "Vinifera Wine Grape Site Desirability (Long to Medium)",
-    "WLF - Freshwater Wetland Plants (TX)", "WLF - Irrigated Saline Water Wetland Plants (TX)",
-    "WLF - Riparian Herbaceous Plants (TX)", "WLF - Riparian Shrubs, Vines, & Trees (TX)",
-    "WLF - Saline Water Wetland Plants (TX)", "WLF - Upland Mixed Deciduous & Coniferous Trees (TX)",
-    "WMS - Constructing Grassed Waterways (TX)", "WMS - Constructing Terraces and Diversions (OH)",
-    "WMS - Embankments, Dikes, and Levees (VT)", "WMS - Irrigation, Sprinkler (close spaced outlet drops)",
-    "WMS - Irrigation, Surface (graded)", "WMS - Subsurface Drains - Installation (VT)",
-    "WMS - Subsurface Water Management, System Performance", "WMS - Surface Drains (TX)",
-    "WMS - Surface Irrigation Intake Family (TX)", "AGR - Avocado Root Rot Hazard (CA)",
-    "AGR - California Revised Storie Index (CA)", "AGR - Hops Site Suitability (WA)",
-    "AGR - Map Unit Cropland Productivity (MN)", "AGR - Nitrate Leaching Potential, Nonirrigated (WA)",
-    "AGR - No Till (TX)", "AGR - Pesticide Loss Potential-Soil Surface Runoff (NE)",
-    "AGR - Selenium Leaching Potential (CO)", "AGR - Water Erosion Potential (NE)",
-    "AGR - Wind Erosion Potential (TX)", "AGR - Winter Wheat Yield (MT)",
-    "AGR-Pesticide and Nutrient Runoff Potential (ND)", "AGR-Rooting Depth (ND)",
-    "American Wine Grape Varieties Site Desirability (Long)", "American Wine Grape Varieties Site Desirability (Medium)",
-    "American Wine Grape Varieties Site Desirability (Very Long)",
-    "AWM - Animal Mortality Disposal (Catastrophic) (MO)", "AWM - Irrigation Disposal of Wastewater (OH)",
-    "AWM - Irrigation Disposal of Wastewater (VT)", "AWM - Land Application of Municipal Biosolids, summer (OR)",
-    "AWM - Manure and Food Processing Waste (MD)", "AWM - Manure and Food Processing Waste (OH)",
-    "AWM - Overland Flow Process Treatment of Wastewater (VT)", "AWM - Rapid Infil Disposal of Wastewater (DE)",
-    "AWM - Sensitive Soil Features (MN)", "AWM - Sensitive Soil Features (WI)",
-    "BLM - Fencing", "BLM - Fire Damage Susceptibility", "BLM - Mechanical Treatment, Rolling Drum",
-    "BLM - Rangeland Drill", "BLM - Rangeland Seeding, Colorado Plateau Ecoregion",
-    "BLM - Rangeland Seeding, Great Basin Ecoregion", "BLM-Reclamation Suitability (MT)",
-    "CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)", "CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)",
-    "CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)", "CLR-pastureland limitation (IN)",
-    "Commodity Crop Productivity Index (Soybeans) (TN)", "CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)",
-    "CPI - Barley, IRR - Eastern Idaho Plateaus (ID)", "CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)",
-    "CPI - Small Grains, IRR - Snake River Plains (ID)", "CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)",
-    "CZSS - Salinization due to Coastal Saltwater Inundation (CT)",
-    "DHS - Catastrophic Event, Large Animal Mortality, Burial", "DHS - Catastrophic Mortality, Large Animal Disposal, Pit",
-    "DHS - Catastrophic Mortality, Large Animal Disposal, Trench",
-    "DHS - Potential for Radioactive Bioaccumulation", "DHS - Potential for Radioactive Sequestration",
-    "DHS - Suitability for Composting Medium and Final Cover", "ENG - Construction Materials; Gravel Source",
-    "ENG - Construction Materials; Gravel Source (AK)", "ENG - Construction Materials; Gravel Source (ID)",
-    "ENG - Construction Materials; Gravel Source (OH)", "ENG - Construction Materials; Gravel Source (VT)",
-    "ENG - Construction Materials; Gravel Source (WA)", "ENG - Construction Materials; Roadfill (OH)",
-    "ENG - Construction Materials; Sand Source (OR)", "ENG - Construction Materials; Sand Source (WA)",
-    "ENG - Construction Materials; Topsoil (GA)", "ENG - Construction Materials; Topsoil (MD)",
-    "ENG - Daily Cover for Landfill", "ENG - Daily Cover for Landfill (AK)",
-    "ENG - Disposal Field Suitability Class (NJ)", "ENG - Dwellings W/O Basements (OH)",
-    "ENG - Dwellings with Basements (AK)", "ENG - Large Animal Disposal, Pit (CT)",
-    "ENG - Lawn, landscape, golf fairway (CT)", "ENG - Lined Retention Systems",
-    "ENG - Local Roads and Streets (OH)", "ENG - On-Site Waste Water Absorption Fields (MO)",
-    "ENG - Septic Tank Absorption Fields", "ENG - Septic Tank Absorption Fields (MD)",
-    "ENG - Septic Tank Absorption Fields (TX)", "ENG - Septic Tank, Gravity Disposal (TX)",
-    "ENG - Sewage Lagoons", "ENG - Small Commercial Buildings (OH)",
-    "ENG - Soil Potential Ratings of SSDS (CT)", "FOR (USFS) - Road Construction/Maintenance (Natural Surface)",
-    "FOR - Compaction Potential (WA)", "FOR - Conservation Tree/Shrub Groups (MT)",
-    "FOR - Damage by Fire (OH)", "FOR - General Harvest Season (VT)",
-    "FOR - Hand Planting Suitability", "FOR - Hand Planting Suitability, MO13 (DE)",
-    "FOR - Hand Planting Suitability, MO13 (MD)", "FOR - Log Landing Suitability",
-    "FOR - Log Landing Suitability (ME)", "FOR - Log Landing Suitability (VT)",
-    "FOR - Log Landing Suitability (WA)", "FOR - Mechanical Planting Suitability (CT)",
-    "FOR - Mechanical Planting Suitability, MO13 (MD)", "FOR - Mechanical Site Preparation (Deep)",
-    "FOR - Mechanical Site Preparation (Deep) (DE)", "FOR - Mechanical Site Preparation (Surface) (DE)",
-    "FOR - Mechanical Site Preparation (Surface) (MI)", "FOR - Mechanical Site Preparation; Surface (ME)",
-    "FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)",
-    "FOR - Potential Seedling Mortality (PIA)", "FOR - Potential Seedling Mortality(ME)",
-    "FOR - Puddling Hazard", "FOR - Road Suitability (Natural Surface) (ME)",
-    "FOR - Road Suitability (Natural Surface) (WA)", "FOR - Soil Rutting Hazard (OH)",
-    "FOR - Soil Sustainability Forest Biomass Harvesting (CT)", "FOR - White Oak Suitability (MO)",
-    "FOR-Biomass Harvest (WI)", "FOTG - Indiana Corn Yield Calculation (IN)",
-    "GRL - Excavations to 24 inches for Plastic Pipelines (TX)",
-    "GRL - Fencing, 24 inch Post Depth (MT)", "GRL - NV range seeding (Wind C = 100) (NV)",
-    "GRL - NV range seeding (Wind C = 40) (NV)", "GRL - NV range seeding (Wind C = 60) (NV)",
-    "GRL - NV range seeding (Wind C = 80) (NV)", "GRL - NV range seeding (Wind C >= 160) (NV)",
-    "GRL - Rangeland Planting by Mechanical Seeding (TX)", "GRL - Rangeland Root Plowing (TX)",
-    "Hybrid Wine Grape Varieties Site Desirability (Long)", "Low Pressure Pipe Septic System (DE)",
-    "MIL - Bivouac Areas (DOD)", "MIL - Excavations Crew-Served Weapon Fighting Position (DOD)",
-    "MIL - Excavations for Individual Fighting Position (DOD)", "MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)", "MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)",
-    "MIL - Trafficability Veh. Type 7 dry season (DOD)", "NCCPI - Irrigated National Commodity Crop Productivity Index",
-    "Nitrogen Loss Potential (ND)", "Potential Windthrow Hazard (TN)",
-    "REC - Foot and ATV Trails (AK)", "REC - Playgrounds (AK)", "RSK-risk assessment for manure application (OH)",
-    "SAS - CMECS Substrate Origin", "SAS - CMECS Substrate Subclass/Group/Subgroup",
-    "SAS - Mooring Anchor - Deadweight", "Septic System A/B Soil System (Alternate) (PA)",
-    "Septic System CO-OP RFS III w/Spray Irrigation (PA)", "Septic System Dual Field Trench (conventional) (WV)",
-    "Septic System Elevated Field (alternative) (WV)", "Septic System In Ground Trench (conventional) (PA)",
-    "Septic System In Ground Trench (conventional) (WV)", "Septic System Low Pressure Pipe (alternative) (WV)",
-    "Septic System Mound (alternative) (WV)", "Septic System Peat Based Option2 w/Spray Irrigation (PA)",
-    "Septic System Steep Slope Mound (alternative) (WV)", "SOH - Concentration of Salts- Soil Surface",
-    "SOH - Soil Susceptibility to Compaction", "Soil Habitat for Saprophyte Stage of Coccidioides",
-    "Unlined Retention Systems", "URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)",
-    "URB/REC - Picnic Areas (GA)", "URB/REC - Picnic Areas (MI)",
-    "URB/REC - Picnic Areas (OH)", "Vinifera Wine Grape Site Desirability (Short)",
-    "WLF - Burrowing Mammals & Reptiles (TX)", "WLF - Desert Tortoise (CA)",
-    "WLF - Domestic Grasses & Legumes for Food and Cover (TX)", "WLF - Irrigated Grain & Seed Crops for Food & Cover (TX)",
-    "WMS - Excavated Ponds (Aquifer-fed)", "WMS - Excavated Ponds (Aquifer-fed) (VT)",
-    "WMS - Irrigation, General", "WMS - Irrigation, Micro (above ground)",
-    "WMS - Irrigation, Micro (above ground) (VT)", "WMS - Irrigation, Micro (subsurface drip)",
-    "WMS - Irrigation, Sprinkler (general) (VT)", "WMS - Pond Reservoir Area",
-    "WMS - Pond Reservoir Area (OH)", "WMS - Subsurface Water Management, System Installation"
-  )
 }
 
 .interpretationAggMethod <-  function(method) {

--- a/R/get_SDA_interpretation.R
+++ b/R/get_SDA_interpretation.R
@@ -779,7 +779,7 @@ get_SDA_interpretation <- function(rulename,
   )
 }
 
-.cleanRuleColumnName <- function(x) gsub("[^A-Za-z0-9]", "", x)
+.cleanRuleColumnName <- function(x) gsub("[^A-Za-z0-9]", "", gsub(">", "GT", gsub("<", "LT", gsub("=", "EQ", x, fixed = TRUE), fixed = TRUE), fixed = TRUE))
 
 .interpretation_by_condition <- function(interp, where_clause, dominant = TRUE, sqlite = FALSE) {
   aggfun <- "STRING_AGG(CONCAT(rulename, ' \"', interphrc, '\" (', interphr, ')'), '; ')"

--- a/man/get_SDA_interpretation.Rd
+++ b/man/get_SDA_interpretation.Rd
@@ -12,6 +12,7 @@ get_SDA_interpretation(
   WHERE = NULL,
   query_string = FALSE,
   not_rated_value = NA_real_,
+  wide_reason = FALSE,
   dsn = NULL
 )
 }
@@ -28,7 +29,9 @@ get_SDA_interpretation(
 
 \item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 
-\item{not_rated_value}{used where rating class is "Not Rated". Default: \code{NA_real}}
+\item{not_rated_value}{used where rating class is "Not Rated". Default: \code{NA_real_}}
+
+\item{wide_reason}{Default: \code{FALSE}; if  \code{TRUE} apply post-processing to all columns with prefix \code{"reason_"} to create additional columns for sub-rule ratings.}
 
 \item{dsn}{Path to local SQLite database or a DBIConnection object. If \code{NULL} (default) use Soil Data Access API via \code{SDA_query()}.}
 }
@@ -41,633 +44,651 @@ Get map unit interpretations from Soil Data Access by rule name
 \details{
 \subsection{Rule Names in \code{cointerp} table}{
 \itemize{
-\item AGR-Agronomic Concerns (ND)
-\item AGR-Available Water Capacity (ND)
-\item AGR-Natural Fertility (ND)
-\item AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
-\item AGR-Pesticide and Nutrient Runoff Potential (ND)
-\item AGR-Physical Limitations (ND)
-\item AGR-Rooting Depth (ND)
-\item AGR-Sodicity (ND)
-\item AGR-Subsurface Salinity (ND)
-\item AGR-Surface Crusting (ND)
-\item AGR-Surface Salinity (ND)
-\item AGR-Water Erosion (ND)
-\item AGR-Wind Erosion (ND)
-\item AGR - Air Quality; PM10 (TX)
-\item AGR - Air Quality; PM2_5 (TX)
 \item AGR - Avocado Root Rot Hazard (CA)
-\item AGR - Barley Yield (MT)
 \item AGR - California Revised Storie Index (CA)
-\item AGR - Conventional Tillage (TX)
-\item AGR - Filter Strips (TX)
-\item AGR - Grape non-irrigated (MO)
 \item AGR - Hops Site Suitability (WA)
-\item AGR - Index for alfalfa hay, irrigated (NV)
 \item AGR - Map Unit Cropland Productivity (MN)
-\item AGR - Mulch Till (TX)
-\item AGR - Nitrate Leaching Potential, Irrigated (WA)
-\item AGR - Nitrate Leaching Potential, Nonirrigated (MA)
-\item AGR - Nitrate Leaching Potential, Nonirrigated (MT)
 \item AGR - Nitrate Leaching Potential, Nonirrigated (WA)
 \item AGR - No Till (TX)
-\item AGR - No Till (VT)
-\item AGR - No Till, Tile Drained (TX)
-\item AGR - Oats Yield (MT)
-\item AGR - Orchard Groups (TX)
-\item AGR - Pasture hayland (MO)
-\item AGR - Pesticide Loss Potential-Leaching
-\item AGR - Pesticide Loss Potential-Leaching (NE)
-\item AGR - Pesticide Loss Potential-Soil Surface Runoff
 \item AGR - Pesticide Loss Potential-Soil Surface Runoff (NE)
-\item AGR - Plant Growth Index PGI no Climate Adj. (TX)
-\item AGR - Plant Growth Index PGI with Climate Adj. (TX)
-\item AGR - Plant Growth Index PGI with Climate Adj. MAP,MAAT (TX)
-\item AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
 \item AGR - Ridge Till (TX)
-\item AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
-\item AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
 \item AGR - Selenium Leaching Potential (CO)
-\item AGR - Spring Wheat Yield (MT)
-\item AGR - Water Erosion Potential (TX)
-\item AGR - Water Erosion Potential Wide Ratings Array (TX)
+\item AGR - Water Erosion Potential (NE)
 \item AGR - Wind Erosion Potential (TX)
-\item AGR - Wind Erosion Potential Wide Ratings Array (TX)
-\item AGR - Wine Grape Site Suitability (WA)
 \item AGR - Winter Wheat Yield (MT)
-\item Alaska Exempt Wetland Potential (AK)
+\item AGR-Pesticide and Nutrient Runoff Potential (ND)
+\item AGR-Rooting Depth (ND)
 \item American Wine Grape Varieties Site Desirability (Long)
 \item American Wine Grape Varieties Site Desirability (Medium)
-\item American Wine Grape Varieties Site Desirability (Short)
 \item American Wine Grape Varieties Site Desirability (Very Long)
 \item AWM - Animal Mortality Disposal (Catastrophic) (MO)
-\item AWM - Filter Group (OH)
-\item AWM - Irrigation Disposal of Wastewater
-\item AWM - Irrigation Disposal of Wastewater (DE)
-\item AWM - Irrigation Disposal of Wastewater (MD)
 \item AWM - Irrigation Disposal of Wastewater (OH)
-\item AWM - Irrigation Disposal of Wastewater (VT)
+\item AWM - Irrigation Disposal of Wastewater (VT)s
+\item AWM - Land Application of Municipal Biosolids, summer (OR)
+\item AWM - Manure and Food Processing Waste (MD)
+\item AWM - Manure and Food Processing Waste (OH)
+\item AWM - Overland Flow Process Treatment of Wastewater (VT)
+\item AWM - Rapid Infil Disposal of Wastewater (DE)
+\item AWM - Sensitive Soil Features (MN)
+\item AWM - Sensitive Soil Features (WI)
+\item BLM - Fencing
+\item BLM - Fire Damage Susceptibility
+\item BLM - Mechanical Treatment, Rolling Drum
+\item BLM - Rangeland Drill
+\item BLM - Rangeland Seeding, Colorado Plateau Ecoregion
+\item BLM - Rangeland Seeding, Great Basin Ecoregion
+\item BLM-Reclamation Suitability (MT)
+\item CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
+\item CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
+\item CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
+\item CLR-pastureland limitation (IN)
+\item Commodity Crop Productivity Index (Soybeans) (TN)
+\item CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+\item CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
+\item CPI - Small Grains, IRR - Snake River Plains (ID)
+\item CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
+\item CZSS - Salinization due to Coastal Saltwater Inundation (CT)
+\item DHS - Catastrophic Event, Large Animal Mortality, Burial
+\item DHS - Catastrophic Mortality, Large Animal Disposal, Pit
+\item DHS - Catastrophic Mortality, Large Animal Disposal, Trench
+\item DHS - Potential for Radioactive Bioaccumulation
+\item DHS - Potential for Radioactive Sequestration
+\item DHS - Suitability for Composting Medium and Final Cover
+\item ENG - Construction Materials; Gravel Source
+\item ENG - Construction Materials; Gravel Source (AK)
+\item ENG - Construction Materials; Gravel Source (ID)
+\item ENG - Construction Materials; Gravel Source (OH)
+\item ENG - Construction Materials; Gravel Source (VT)
+\item ENG - Construction Materials; Gravel Source (WA)
+\item ENG - Construction Materials; Roadfill (OH)
+\item ENG - Construction Materials; Sand Source (OR)
+\item ENG - Construction Materials; Sand Source (WA)
+\item ENG - Construction Materials; Topsoil (GA)
+\item ENG - Construction Materials; Topsoil (MD)
+\item ENG - Daily Cover for Landfill
+\item ENG - Daily Cover for Landfill (AK)
+\item ENG - Disposal Field Suitability Class (NJ)
+\item ENG - Dwellings W/O Basements (OH)
+\item ENG - Dwellings with Basements (AK)
+\item ENG - Large Animal Disposal, Pit (CT)
+\item ENG - Lawn, landscape, golf fairway (CT)
+\item ENG - Lined Retention Systems
+\item ENG - Local Roads and Streets (OH)
+\item ENG - On-Site Waste Water Absorption Fields (MO)
+\item ENG - Septic Tank Absorption Fields
+\item ENG - Septic Tank Absorption Fields (MD)
+\item ENG - Septic Tank Absorption Fields (TX)
+\item ENG - Septic Tank, Gravity Disposal (TX)
+\item ENG - Sewage Lagoons
+\item ENG - Small Commercial Buildings (OH)
+\item ENG - Soil Potential Ratings of SSDS (CT)
+\item FOR (USFS) - Road Construction/Maintenance (Natural Surface)
+\item FOR - Compaction Potential (WA)
+\item FOR - Conservation Tree/Shrub Groups (MT)
+\item FOR - Damage by Fire (OH)
+\item FOR - General Harvest Season (VT)
+\item FOR - Hand Planting Suitability
+\item FOR - Hand Planting Suitability, MO13 (DE)
+\item FOR - Hand Planting Suitability, MO13 (MD)
+\item FOR - Log Landing Suitability
+\item FOR - Log Landing Suitability (ME)
+\item FOR - Log Landing Suitability (VT)
+\item FOR - Log Landing Suitability (WA)
+\item FOR - Mechanical Planting Suitability (CT)
+\item FOR - Mechanical Planting Suitability, MO13 (MD)
+\item FOR - Mechanical Site Preparation (Deep)
+\item FOR - Mechanical Site Preparation (Deep) (DE)
+\item FOR - Mechanical Site Preparation (Surface) (DE)
+\item FOR - Mechanical Site Preparation (Surface) (MI)
+\item FOR - Mechanical Site Preparation; Surface (ME)
+\item FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
+\item FOR - Potential Seedling Mortality (PIA)
+\item FOR - Potential Seedling Mortality(ME)
+\item FOR - Puddling Hazard
+\item FOR - Road Suitability (Natural Surface) (ME)
+\item FOR - Road Suitability (Natural Surface) (WA)
+\item FOR - Soil Rutting Hazard (OH)
+\item FOR - Soil Sustainability Forest Biomass Harvesting (CT)
+\item FOR - White Oak Suitability (MO)
+\item FOR-Biomass Harvest (WI)
+\item FOTG - Indiana Corn Yield Calculation (IN)
+\item GRL - Excavations to 24 inches for Plastic Pipelines (TX)
+\item GRL - Fencing, 24 inch Post Depth (MT)
+\item GRL - NV range seeding (Wind C = 100) (NV)
+\item GRL - NV range seeding (Wind C = 40) (NV)
+\item GRL - NV range seeding (Wind C = 60) (NV)
+\item GRL - NV range seeding (Wind C = 80) (NV)
+\item GRL - NV range seeding (Wind C >= 160) (NV)
+\item GRL - Rangeland Planting by Mechanical Seeding (TX)
+\item GRL - Rangeland Root Plowing (TX)
+\item Hybrid Wine Grape Varieties Site Desirability (Long)
+\item Low Pressure Pipe Septic System (DE)
+\item MIL - Bivouac Areas (DOD)
+\item MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
+\item MIL - Excavations for Individual Fighting Position (DOD)
+\item MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 7 dry season (DOD)
+\item NCCPI - Irrigated National Commodity Crop Productivity Index
+\item Nitrogen Loss Potential (ND)
+\item Potential Windthrow Hazard (TN)
+\item REC - Foot and ATV Trails (AK)
+\item REC - Playgrounds (AK)
+\item Reclamation Suitability (ND)
+\item RSK-risk assessment for manure application (OH)
+\item SAS - CMECS Substrate Origin
+\item SAS - CMECS Substrate Subclass/Group/Subgroup
+\item SAS - Mooring Anchor - Deadweight
+\item Septic System A/B Soil System (Alternate) (PA)
+\item Septic System CO-OP RFS III w/Spray Irrigation (PA)
+\item Septic System Dual Field Trench (conventional) (WV)
+\item Septic System Elevated Field (alternative) (WV)
+\item Septic System In Ground Trench (conventional) (PA)
+\item Septic System In Ground Trench (conventional) (WV)
+\item AGR - Filter Strips (TX)
+\item AGR - Hops Site Suitability (ID)
+\item AGR - Mulch Till (TX)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (MT)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (WV)
+\item AGR - No Till (VT)
+\item AGR - Oats Yield (MT)
+\item AGR - Pesticide Loss Potential-Leaching
+\item AGR - Pesticide Loss Potential-Leaching (NE)
+\item AGR - Rutting Hazard =< 10,000 Pounds per Wheel (TX)
+\item AGR - S. Highbush Blueberry Suitability MLRA 153 (SC)
+\item AGR - Wind Erosion Potential (NE)
+\item AGR-Available Water Capacity (ND)
+\item AGR-Physical Limitations (ND)
+\item AGR-Sodicity (ND)
+\item AGR-Surface Crusting (ND)
+\item AGR-Wind Erosion (ND)
+\item AWM - Irrigation Disposal of Wastewater (DE)
 \item AWM - Land App of Municipal Sewage Sludge (DE)
 \item AWM - Land App of Municipal Sewage Sludge (MD)
-\item AWM - Land Application of Dry and Slurry Manure (TX)
 \item AWM - Land Application of Milk (CT)
 \item AWM - Land Application of Municipal Biosolids, spring (OR)
-\item AWM - Land Application of Municipal Biosolids, summer (OR)
-\item AWM - Land Application of Municipal Biosolids, winter (OR)
 \item AWM - Land Application of Municipal Sewage Sludge
 \item AWM - Land Application of Municipal Sewage Sludge (OH)
 \item AWM - Land Application of Municipal Sewage Sludge (VT)
 \item AWM - Large Animal Disposal, Pit (MN)
 \item AWM - Manure and Food Processing Waste
-\item AWM - Manure and Food Processing Waste (DE)
-\item AWM - Manure and Food Processing Waste (MD)
-\item AWM - Manure and Food Processing Waste (OH)
 \item AWM - Manure and Food Processing Waste (VT)
-\item AWM - Manure Stacking - Site Evaluation (TX)
-\item AWM - Overland Flow Process Treatment of Wastewater
-\item AWM - Overland Flow Process Treatment of Wastewater (VT)
-\item AWM - Phosphorus Management (TX)
-\item AWM - Rapid Infil Disposal of Wastewater (DE)
 \item AWM - Rapid Infil Disposal of Wastewater (MD)
-\item AWM - Rapid Infiltration Disposal of Wastewater
 \item AWM - Rapid Infiltration Disposal of Wastewater (VT)
-\item AWM - Sensitive Soil Features (MN)
-\item AWM - Slow Rate Process Treatment of Wastewater
 \item AWM - Slow Rate Process Treatment of Wastewater (VT)
-\item AWM - Vegetated Treatment Area (PIA)
-\item AWM - Waste Field Storage Area (VT)
-\item BLM-Reclamation Suitability (MT)
 \item BLM - Chaining Suitability
-\item BLM - Fencing
-\item BLM - Fire Damage Susceptibility
 \item BLM - Fugitive Dust Resistance
-\item BLM - Mechanical Treatment, Rolling Drum
-\item BLM - Mechanical Treatment, Shredder
-\item BLM - Medusahead Invasion Susceptibility
-\item BLM - Pygmy Rabbit Habitat Potential
-\item BLM - Rangeland Drill
-\item BLM - Rangeland Seeding, Colorado Plateau Ecoregion
-\item BLM - Rangeland Seeding, Great Basin Ecoregion
-\item BLM - Rangeland Tillage
-\item BLM - Site Degradation Susceptibility
-\item BLM - Soil Compaction Resistance
 \item BLM - Soil Restoration Potential
 \item BLM - Yellow Star-thistle Invasion Susceptibility
-\item CA Prime Farmland (CA)
+\item CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
+\item CLR-cropland limitation for corn and soybeans (IN)
+\item Commodity Crop Productivity Index (Corn) (WI)
+\item CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
+\item CPI - Potatoes Productivity Index (AK)
+\item CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
+\item CPI - Small Grains, NIRR - Palouse Prairies (ID)
+\item DHS - Emergency Animal Mortality Disposal by Shallow Burial
+\item DHS - Rubble and Debris Disposal, Large-Scale Event
+\item ENG - Aquifer Assessment - 7081 (MN)
+\item ENG - Construction Materials - Gravel Source (MN)
+\item ENG - Construction Materials; Gravel Source (MI)
+\item ENG - Construction Materials; Gravel Source (OR)
+\item ENG - Construction Materials; Reclamation
+\item ENG - Construction Materials; Reclamation (OH)
+\item ENG - Construction Materials; Sand Source
+\item ENG - Construction Materials; Sand Source (AK)
+\item ENG - Construction Materials; Sand Source (ID)
+\item ENG - Construction Materials; Sand Source (IN)
+\item ENG - Construction Materials; Sand Source (OH)
+\item ENG - Construction Materials; Topsoil
+\item ENG - Construction Materials; Topsoil (WA)
+\item ENG - Ground-based Solar Arrays, Soil-based Anchor Systems
+\item ENG - Local Roads and Streets
+\item ENG - New Ohio Septic Rating (OH)
+\item ENG - Sanitary Landfill (Trench) (OH)
+\item ENG - Septic Tank Absorption Fields (AK)
+\item ENG - Septic Tank Absorption Fields (DE)
+\item ENG - Septic Tank Absorption Fields (NY)
+\item ENG - Sewage Lagoons (OH)
+\item ENG - Shallow Excavations (AK)
+\item ENG - Shallow Excavations (MI)
+\item ENG - Unpaved Local Roads and Streets
+\item FOR - Black Walnut Suitability Index (MO)
+\item FOR - Conservation Tree and Shrub Groups (TX)
+\item FOR - Construction Limitations - Haul Roads/Log Landing (OH)
+\item FOR - Construction Limitations For Haul Roads (MI)
+\item FOR - Hand Planting Suitability (ME)
+\item FOR - Harvest Equipment Operability (MD)
+\item FOR - Harvest Equipment Operability (OH)
+\item FOR - Harvest Equipment Operability (VT)
+\item FOR - Mechanical Planting Suitability
+\item FOR - Mechanical Planting Suitability (ME)
+\item FOR - Mechanical Planting Suitability, MO13 (DE)
+\item FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+\item FOR - Potential Erosion Hazard (Road/Trail) (PIA)
+\item FOR - Potential Seedling Mortality (VT)
+\item FOR - Potential Windthrow Hazard (NY)
+\item FOR - Potential Windthrow Hazard (VT)
+\item FOR - Puddling Potential (WA)
+\item FOR - Road Suitability (Natural Surface)
+\item FOR - Road Suitability (Natural Surface) (OH)
+\item FOR - Road Suitability (Natural Surface) (OR)
+\item FOR - Rutting Hazard by Season
+\item FOR - Shortleaf pine littleleaf disease susceptibility
+\item FOR - Soil Compactibility Risk
+\item FOR - Soil Rutting Hazard (ME)
+\item FOR - Windthrow Hazard
+\item FOR-Construction Limitations for Haul Roads/Log Landings(ME)
+\item FOTG - Indiana Slippage Potential (IN)
+\item Gravity Full Depth Septic System (DE)
+\item GRL - Fencing, Post Depth =<36 inches
+\item GRL - NV range seeding (Wind C = 50) (NV)
+\item GRL - Ranch Access Roads (TX)
+\item GRL - Rangeland Roller Chopping (TX)
+\item Ground Penetrating Radar Penetration
+\item Ground-based Solar Arrays_bedrock(ME)
+\item Ground-based Solar Arrays_bedrock_slope_ballast(ME)
+\item Hybrid Wine Grape Varieties Site Desirability (Short)
+\item ISDH Septic Tank Interpretation (IN)
+\item Land Application of Municipal Sewage Sludge (PA)
+\item MIL - Helicopter Landing Zones (DOD)
+\item MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 5 dry season (DOD)
+\item MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
+\item NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
+\item REC - Camp and Picnic Areas (AK)
+\item REC - Picnic Areas (CT)
+\item REC - Playgrounds (CT)
+\item SAS - CMECS Substrate Subclass
+\item Septic System Drip Irrigation (Alternate) (PA)
+\item Septic System Free Access Sand Filter w/Drip Irrigation (PA)
+\item Septic System In Ground Bed (conventional) (PA)
+\item Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
+\item Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
+\item Septic System Sand Mound Bed or Trench (PA)
+\item Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
+\item SOH - Aggregate Stability (ND)
+\item SOH - Agricultural Organic Soil Subsidence
+\item SOH - Dynamic Soil Properties Response to Biochar
+\item SOH - Organic Matter Depletion
+\item SOIL HEALTH ASSESSMENT (NJ)
+\item URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
+\item URB - Reinforced Concrete Slab (TX)
+\item URB/REC - Camp Areas
+\item URB/REC - Camp Areas (OH)
+\item URB/REC - Off-Road Motorcycle Trails (OH)
+\item URB/REC - Paths and Trails (OH)
+\item URB/REC - Picnic Areas
+\item URB/REC - Playgrounds
+\item URB/REC - Playgrounds (GA)
+\item Vinifera Wine Grape Site Desirability (Short to Medium)
+\item WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
+\item WLF - Upland Coniferous Trees (TX)
+\item WLF - Upland Deciduous Trees (TX)
+\item WLF - Upland Desertic Shrubs & Trees (TX)
+\item WLF - Upland Native Herbaceous Plants (TX)
+\item WLF - Upland Shrubs & Vines (TX)
+\item WLF-Soil Suitability - Karner Blue Butterfly (WI)
+\item WMS - Drainage (IL)
+\item WMS - Drainage - (MI)
+\item WMS - Embankments, Dikes, and Levees
+\item WMS - Embankments, Dikes, and Levees (OH)
+\item WMS - Grassed Waterways - (MI)
+\item AGR - Air Quality; PM10 (TX)
+\item AGR - Air Quality; PM2_5 (TX)
+\item AGR - Aronia Berry Suitability (SD)
+\item AGR - Farmland of Statewide Importance (TX)
+\item AGR - Index for alfalfa hay, irrigated (NV)
+\item AGR - Nitrate Leaching Potential, Nonirrigated (MA)
+\item AGR - Rangeland Grass/Herbaceous Productivity Index (TX)
+\item AGR - Rutting Hazard > 10,000 Pounds per Wheel (TX)
+\item AGR - Water Erosion Potential (TX)
+\item AGR - Wine Grape Site Suitability (WA)
+\item AGR-Natural Fertility (ND)
+\item AGR-Subsurface Salinity (ND)
+\item AWM - Filter Group (OH)
+\item AWM - Irrigation Disposal of Wastewater
+\item AWM - Land Application of Dry and Slurry Manure (TX)
+\item AWM - Land Application of Municipal Biosolids, winter (OR)
+\item AWM - Overland Flow Process Treatment of Wastewater
+\item AWM - Rapid Infiltration Disposal of Wastewater
+\item AWM - Vegetated Treatment Area (PIA)
+\item AWM - Waste Field Storage Area (VT)
+\item BLM - Mechanical Treatment, Shredder
+\item BLM - Medusahead Invasion Susceptibility
+\item BLM - Soil Compaction Resistance
 \item Capping Fill Gravity Septic System (DE)
 \item CLASS RULE - Depth to any bedrock kind (5 classes) (NPS)
-\item CLASS RULE - Depth to lithic bedrock (5 classes) (NPS)
-\item CLASS RULE - Depth to non-lithic bedrock (5 classes) (NPS)
-\item CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
-\item CLASS RULE - Soil Inorganic Carbon kg/m2 to 2m (NPS)
-\item CLASS RULE - Soil Organic Carbon kg/m2 to 2m (NPS)
-\item CLR-cropland limitation for corn and soybeans (IN)
-\item CLR-pastureland limitation (IN)
-\item Commodity Crop Productivity Index (Corn) (WI)
 \item CPI - Alfalfa Hay, IRR - Eastern Idaho Plateaus (ID)
 \item CPI - Alfalfa Hay, IRR - Klamath Valley and Basins (OR)
 \item CPI - Alfalfa Hay, IRR - Snake River Plains (ID)
 \item CPI - Alfalfa Hay, NIRR- Eastern Idaho Plateaus (ID)
+\item CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
+\item CPI - Small Grains Productivity Index (AK)
+\item DHS - Catastrophic Event, Large Animal Mortality, Incinerate
+\item DHS - Emergency Land Disposal of Milk
+\item DHS - Site for Composting Facility - Subsurface
+\item DHS - Suitability for Clay Liner Material
+\item ENG - Cohesive Soil Liner (MN)
+\item ENG - Construction Materials - Sand Source (MN)
+\item ENG - Construction Materials; Gravel Source (CT)
+\item ENG - Construction Materials; Gravel Source (NY)
+\item ENG - Construction Materials; Reclamation (DE)
+\item ENG - Construction Materials; Roadfill
+\item ENG - Construction Materials; Roadfill (AK)
+\item ENG - Construction Materials; Sand Source (NY)
+\item ENG - Construction Materials; Sand Source (VT)
+\item ENG - Construction Materials; Topsoil (AK)
+\item ENG - Construction Materials; Topsoil (DE)
+\item ENG - Construction Materials; Topsoil (MI)
+\item ENG - Construction Materials; Topsoil (OR)
+\item ENG - Conventional On-Site Septic Systems (TN)
+\item ENG - Deep Infiltration Systems
+\item ENG - Disposal Field Gravity (DE)
+\item ENG - Dwellings With Basements (OH)
+\item ENG - Ground-based Solar Arrays, Ballast Anchor Systems
+\item ENG - Large Animal Disposal, Trench (CT)
+\item ENG - Lawn, Landscape, Golf Fairway (MI)
+\item ENG - Lawn, Landscape, Golf Fairway (VT)
+\item ENG - Sanitary Landfill (Area) (OH)
+\item ENG - Sanitary Landfill (Trench)
+\item ENG - Sanitary Landfill (Trench) (AK)
+\item ENG - Septage Application - Surface (MN)
+\item ENG - Septic Tank Absorption Fields - At-Grade (MN)
+\item ENG - Septic Tank Absorption Fields - Mound (MN)
+\item ENG - Septic Tank Leaching Chamber (TX)
+\item ENG - Septic Tank, Subsurface Drip Irrigation (TX)
+\item ENG - Shallow Excavations
+\item ENG - Shallow Infiltration Systems
+\item ENG - Small Commercial Buildings
+\item ENG - Soil Potential of Road Salt Applications (CT)
+\item ENG - Source of Caliche (TX)
+\item ENG - Stormwater Management / Ponds (NY)
+\item ENG - Unlined Retention Systems
+\item Farm and Garden Composting Facility - Surface
+\item FOR - Biomass Harvest (MA)
+\item FOR - Black Walnut Suitability Index (KS)
+\item FOR - Displacement Potential (WA)
+\item FOR - Drought Vulnerable Soils
+\item FOR - General Harvest Season (ME)
+\item FOR - Harvest Equipment Operability
+\item FOR - Mechanical Site Preparation (Deep) (MD)
+\item FOR - Mechanical Site Preparation (Surface)
+\item FOR - Mechanical Site Preparation; Deep (CT)
+\item FOR - Potential Erosion Hazard (Road/Trail)
+\item FOR - Potential Fire Damage Hazard
+\item FOR - Potential Seedling Mortality
+\item FOR - Potential Seedling Mortality (MI)
+\item FOR - Potential Windthrow Hazard (ME)
+\item FOR - Potential Windthrow Hazard (MI)
+\item FOR - Road Suitability (Natural Surface) (ID)
+\item FOR - Rutting Hazard by Month
+\item FOR - Windthrow Hazard (WA)
+\item FOTG - NLI Interp Calculation - (IN)
+\item Fragile Soil Index
+\item GRL - Juniper Encroachment Potential (NM)
+\item GRL - NV range seeding (Wind C = 20) (NV)
+\item GRL - Pasture and Hayland SG (OH)
+\item GRL - Rangeland Prescribed Burning (TX)
+\item GRL - Rangeland Soil Seed Bank Suitability (NM)
+\item GRL-FSG-NP-W (MT)
+\item GRL-SHSI Soil Health Sustainability Index (MT)
+\item Ground-based Solar Arrays_saturationt(ME)
+\item Ground-based Solar Arrays_slope(ME)
+\item Inland Wetlands (CT)
+\item IRR-restrictive features for irrigation (OH)
+\item MIL - Excavations for Vehicle Fighting Position (DOD)
+\item MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 2 dry season (DOD)
+\item MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
+\item MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
+\item MIL - Trafficability Veh. Type 6 dry season (DOD)
+\item Muscadine Wine Grape Site Desirability (Very Long)
+\item NCCPI - NCCPI Cotton Submodel (II)
+\item Permafrost Sensitivity (AK)
+\item Pressure Dose Capping Fill Septic System (DE)
+\item REC - Camp Areas (CT)
+\item REC - Off-Road Motorcycle Trails (CT)
+\item SAS - CMECS Substrate Class
+\item SAS - CMECS Substrate Subclass/Group
+\item SAS - Eelgrass Restoration Suitability
+\item SAS - Land Utilization of Dredged Materials
+\item SAS - Northern Quahog (Hard Clam) Habitat Suitability
+\item Septic System At Grade Shallow Field (alternative) (WV)
+\item Septic System At-Grade Bed (Alternate) (PA)
+\item Septic System CO-OP RFS III w/Drip Irrigation (PA)
+\item Septic System Drip Irrigation (alternative) (WV)
+\item Septic System Free Access Sand Filterw/Spray Irrigation (PA)
+\item Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
+\item Septic System Spray Irrigation (PA)
+\item Septic System Steep Slope Sand Mound (Alternate) (PA)
+\item Shallow Infiltration Systems
+\item SOH - Organic Matter Depletion Potential, Irrigated (CA)
+\item SOH - Soil Surface Sealing
+\item TROP - Plantains Productivity
+\item URB/REC - Camp Areas (GA)
+\item URB/REC - Camp Areas (MI)
+\item URB/REC - Golf Fairways (OH)
+\item URB/REC - Off-Road Motorcycle Trails
+\item URB/REC - Paths and Trails (MI)
+\item URB/REC - Playgrounds (OH)
+\item Vinifera Wine Grape Site Desirability (Long to Medium)
+\item WLF - Chufa for Turkey Forage (LA)
+\item WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
+\item WLF - Freshwater Wetland Plants (TX)
+\item WLF - Irrigated Saline Water Wetland Plants (TX)
+\item WLF - Riparian Herbaceous Plants (TX)
+\item WLF - Riparian Shrubs, Vines, & Trees (TX)
+\item WLF - Saline Water Wetland Plants (TX)
+\item WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
+\item WMS - Constructing Grassed Waterways (TX)
+\item WMS - Constructing Terraces and Diversions (OH)
+\item WMS - Embankments, Dikes, and Levees (VT)
+\item WMS - Irrigation, Sprinkler (close spaced outlet drops)
+\item WMS - Irrigation, Sprinkler (general)
+\item WMS - Pond Reservoir Area (GA)
+\item WMS-Subsurface Water Management, Installation (ND)
+\item WMS-Subsurface Water Management, Outflow Quality (ND)
+\item AGR - Barley Yield (MT)
+\item AGR - Conventional Tillage (TX)
+\item AGR - Grape non-irrigated (MO)
+\item AGR - Industrial Hemp for Fiber and Seed Production
+\item AGR - Nitrate Leaching Potential, Irrigated (WA)
+\item AGR - Pasture hayland (MO)
+\item AGR - Pesticide Loss Potential-Soil Surface Runoff
+\item AGR - Prime Farmland (TX)
+\item AGR - Spring Wheat Yield (MT)
+\item AGR-Agronomic Concerns (ND)
+\item AGR-Pesticide and Nutrient Leaching Potential, NIRR (ND)
+\item AGR-Surface Salinity (ND)
+\item AGR-Water Erosion Potential (ND)
+\item Alaska Exempt Wetland Potential (AK)
+\item American Wine Grape Varieties Site Desirability (Short)
+\item AWM - Irrigation Disposal of Wastewater (MD)
+\item AWM - Manure and Food Processing Waste (DE)
+\item AWM - Manure Stacking - Site Evaluation (TX)
+\item AWM - Phosphorus Management (TX)
+\item AWM - Slow Rate Process Treatment of Wastewater
+\item BLM - Pygmy Rabbit Habitat Potential
+\item BLM - Rangeland Tillage
+\item BLM - Site Degradation Susceptibility
+\item CA Prime Farmland (CA)
+\item CLASS RULE - Depth to root limiting layer (5 classes) (NPS)
+\item Commodity Crop Productivity Index (Corn) (TN)
 \item CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
-\item CPI - Alfalfa Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
-\item CPI - Barley, IRR - Eastern Idaho Plateaus (ID)
 \item CPI - Barley, NIRR - Eastern Idaho Plateaus (ID)
 \item CPI - Grass Hay, IRR - Eastern Idaho Plateaus (ID)
-\item CPI - Grass Hay, IRR - Klamath Valleys and Basins (OR)
-\item CPI - Grass Hay, NIRR - Klamath Valleys and Basins (OR)
 \item CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
-\item CPI - Grass Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
-\item CPI - Potatoes, IRR - Eastern Idaho Plateaus (ID)
 \item CPI - Potatoes, IRR - Snake River Plains (ID)
-\item CPI - Small Grains Productivity Index (AK)
-\item CPI - Small Grains, IRR - Snake River Plains (ID)
-\item CPI - Small Grains, NIRR - Palouse Prairies (ID)
 \item CPI - Small Grains, NIRR - Palouse Prairies (OR)
 \item CPI - Small Grains, NIRR - Palouse Prairies (WA)
 \item CPI - Small Grains, NIRR - Snake River Plains (ID)
-\item CPI - Wheat, IRR - Eastern Idaho Plateaus (ID)
 \item CPI - Wheat, NIRR - Eastern Idaho Plateaus (ID)
 \item CPI - Wild Hay, NIRR - Eastern Idaho Plateaus (ID)
 \item CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (ID)
 \item CPI - Wild Hay, NIRR - Palouse, Northern Rocky Mtns. (WA)
 \item Deep Infiltration Systems
-\item DHS - Catastrophic Event, Large Animal Mortality, Burial
-\item DHS - Catastrophic Event, Large Animal Mortality, Incinerate
-\item DHS - Catastrophic Mortality, Large Animal Disposal, Pit
-\item DHS - Catastrophic Mortality, Large Animal Disposal, Trench
-\item DHS - Emergency Animal Mortality Disposal by Shallow Burial
-\item DHS - Emergency Land Disposal of Milk
-\item DHS - Potential for Radioactive Bioaccumulation
-\item DHS - Potential for Radioactive Sequestration
-\item DHS - Rubble and Debris Disposal, Large-Scale Event
-\item DHS - Site for Composting Facility - Subsurface
 \item DHS - Site for Composting Facility - Surface
-\item DHS - Suitability for Clay Liner Material
-\item DHS - Suitability for Composting Medium and Final Cover
 \item Elevated Sand Mound Septic System (DE)
 \item ENG - Animal Disposal by Composting (Catastrophic) (WV)
 \item ENG - Application of Municipal Sludge (TX)
-\item ENG - Aquifer Assessment - 7081 (MN)
 \item ENG - Closed-Loop Horizontal Geothermal Heat Pump (CT)
-\item ENG - Cohesive Soil Liner (MN)
-\item ENG - Construction Materials - Gravel Source (MN)
-\item ENG - Construction Materials - Sand Source (MN)
-\item ENG - Construction Materials; Gravel Source
-\item ENG - Construction Materials; Gravel Source (AK)
-\item ENG - Construction Materials; Gravel Source (CT)
-\item ENG - Construction Materials; Gravel Source (ID)
 \item ENG - Construction Materials; Gravel Source (IN)
-\item ENG - Construction Materials; Gravel Source (MI)
 \item ENG - Construction Materials; Gravel Source (NE)
-\item ENG - Construction Materials; Gravel Source (NY)
-\item ENG - Construction Materials; Gravel Source (OH)
-\item ENG - Construction Materials; Gravel Source (OR)
-\item ENG - Construction Materials; Gravel Source (VT)
-\item ENG - Construction Materials; Gravel Source (WA)
-\item ENG - Construction Materials; Reclamation
-\item ENG - Construction Materials; Reclamation (DE)
 \item ENG - Construction Materials; Reclamation (MD)
 \item ENG - Construction Materials; Reclamation (MI)
-\item ENG - Construction Materials; Reclamation (OH)
-\item ENG - Construction Materials; Roadfill
-\item ENG - Construction Materials; Roadfill (AK)
 \item ENG - Construction Materials; Roadfill (GA)
-\item ENG - Construction Materials; Roadfill (OH)
-\item ENG - Construction Materials; Sand Source
-\item ENG - Construction Materials; Sand Source (AK)
 \item ENG - Construction Materials; Sand Source (CT)
 \item ENG - Construction Materials; Sand Source (GA)
-\item ENG - Construction Materials; Sand Source (ID)
-\item ENG - Construction Materials; Sand Source (IN)
-\item ENG - Construction Materials; Sand Source (NY)
-\item ENG - Construction Materials; Sand Source (OH)
-\item ENG - Construction Materials; Sand Source (OR)
-\item ENG - Construction Materials; Sand Source (VT)
-\item ENG - Construction Materials; Sand Source (WA)
-\item ENG - Construction Materials; Topsoil
-\item ENG - Construction Materials; Topsoil (AK)
-\item ENG - Construction Materials; Topsoil (DE)
-\item ENG - Construction Materials; Topsoil (GA)
 \item ENG - Construction Materials; Topsoil (ID)
-\item ENG - Construction Materials; Topsoil (MD)
-\item ENG - Construction Materials; Topsoil (MI)
 \item ENG - Construction Materials; Topsoil (OH)
-\item ENG - Construction Materials; Topsoil (OR)
-\item ENG - Construction Materials; Topsoil (WA)
-\item ENG - Daily Cover for Landfill
-\item ENG - Daily Cover for Landfill (AK)
 \item ENG - Daily Cover for Landfill (OH)
 \item ENG - Disposal Field (NJ)
-\item ENG - Disposal Field Gravity (DE)
-\item ENG - Disposal Field Suitability Class (NJ)
 \item ENG - Disposal Field Type Inst (NJ)
 \item ENG - Dwellings W/O Basements
-\item ENG - Dwellings W/O Basements (OH)
 \item ENG - Dwellings With Basements
-\item ENG - Dwellings with Basements (AK)
-\item ENG - Dwellings With Basements (OH)
 \item ENG - Dwellings without Basements (AK)
-\item ENG - Large Animal Disposal, Pit (CT)
-\item ENG - Large Animal Disposal, Trench (CT)
 \item ENG - Lawn and Landscape (OH)
 \item ENG - Lawn, Landscape, Golf Fairway
-\item ENG - Lawn, landscape, golf fairway (CT)
-\item ENG - Lawn, Landscape, Golf Fairway (MI)
-\item ENG - Lawn, Landscape, Golf Fairway (VT)
-\item ENG - Local Roads and Streets
 \item ENG - Local Roads and Streets (AK)
 \item ENG - Local Roads and Streets (GA)
-\item ENG - Local Roads and Streets (OH)
-\item ENG - New Ohio Septic Rating (OH)
-\item ENG - On-Site Waste Water Absorption Fields (MO)
 \item ENG - On-Site Waste Water Lagoons (MO)
-\item ENG - OSHA Soil Types (TX)
 \item ENG - Pier Beam Building Foundations (TX)
 \item ENG - Sanitary Landfill (Area)
 \item ENG - Sanitary Landfill (Area) (AK)
-\item ENG - Sanitary Landfill (Area) (OH)
-\item ENG - Sanitary Landfill (Trench)
-\item ENG - Sanitary Landfill (Trench) (AK)
-\item ENG - Sanitary Landfill (Trench) (OH)
 \item ENG - Septage Application - Incorporation or Injection (MN)
-\item ENG - Septage Application - Surface (MN)
 \item ENG - Septic System; Disinfection, Surface Application (TX)
-\item ENG - Septic Tank Absorption Fields
-\item ENG - Septic Tank Absorption Fields - At-Grade (MN)
-\item ENG - Septic Tank Absorption Fields - Mound (MN)
-\item ENG - Septic Tank Absorption Fields - Trench (MN)
-\item ENG - Septic Tank Absorption Fields (AK)
-\item ENG - Septic Tank Absorption Fields (DE)
 \item ENG - Septic Tank Absorption Fields (FL)
-\item ENG - Septic Tank Absorption Fields (MD)
-\item ENG - Septic Tank Absorption Fields (NY)
 \item ENG - Septic Tank Absorption Fields (OH)
-\item ENG - Septic Tank Absorption Fields (TX)
-\item ENG - Septic Tank Leaching Chamber (TX)
-\item ENG - Septic Tank, Gravity Disposal (TX)
-\item ENG - Septic Tank, Subsurface Drip Irrigation (TX)
-\item ENG - Sewage Lagoons
+\item ENG - Septic Tank Absorption Fields - Trench (MN)
 \item ENG - Sewage Lagoons (AK)
-\item ENG - Sewage Lagoons (OH)
-\item ENG - Shallow Excavations
-\item ENG - Shallow Excavations (AK)
-\item ENG - Shallow Excavations (MI)
 \item ENG - Shallow Excavations (OH)
-\item ENG - Small Commercial Buildings
-\item ENG - Small Commercial Buildings (OH)
-\item ENG - Soil Potential of Road Salt Applications (CT)
-\item ENG - Soil Potential Ratings of SSDS (CT)
-\item ENG - Source of Caliche (TX)
+\item ENG - Soil Suitability for SLAMM Marsh Migration (CT)
 \item ENG - Stormwater Management / Infiltration (NY)
-\item ENG - Stormwater Management / Ponds (NY)
 \item ENG - Stormwater Management / Wetlands (NY)
-\item ENG - Unpaved Local Roads and Streets
-\item Farm and Garden Composting Facility - Surface
-\item FOR-Biomass Harvest (WI)
-\item FOR-Construction Limitations for Haul Roads/Log Landings(ME)
-\item FOR - Biomass Harvest (MA)
-\item FOR - Black Walnut Suitability Index (KS)
-\item FOR - Black Walnut Suitability Index (MO)
-\item FOR - Compaction Potential (WA)
-\item FOR - Construction Limitations - Haul Roads/Log Landing (OH)
-\item FOR - Construction Limitations For Haul Roads (MI)
+\item FOR - Black Walnut Suitability (WI)
+\item FOR - Black Walnut Suitability (WV)
 \item FOR - Construction Limitations for Haul Roads/Log Landings
-\item FOR - Damage by Fire (OH)
 \item FOR - Displacement Hazard
-\item FOR - Displacement Potential (WA)
-\item FOR - General Harvest Season (ME)
-\item FOR - General Harvest Season (VT)
-\item FOR - Hand Planting Suitability
-\item FOR - Hand Planting Suitability (ME)
-\item FOR - Hand Planting Suitability, MO13 (DE)
-\item FOR - Hand Planting Suitability, MO13 (MD)
-\item FOR - Harvest Equipment Operability
 \item FOR - Harvest Equipment Operability (DE)
-\item FOR - Harvest Equipment Operability (MD)
 \item FOR - Harvest Equipment Operability (ME)
 \item FOR - Harvest Equipment Operability (MI)
-\item FOR - Harvest Equipment Operability (OH)
-\item FOR - Harvest Equipment Operability (VT)
-\item FOR - Log Landing Suitability
 \item FOR - Log Landing Suitability (ID)
-\item FOR - Log Landing Suitability (ME)
 \item FOR - Log Landing Suitability (MI)
 \item FOR - Log Landing Suitability (OR)
-\item FOR - Log Landing Suitability (VT)
-\item FOR - Log Landing Suitability (WA)
-\item FOR - Mechanical Planting Suitability
-\item FOR - Mechanical Planting Suitability (CT)
-\item FOR - Mechanical Planting Suitability (ME)
 \item FOR - Mechanical Planting Suitability (OH)
-\item FOR - Mechanical Planting Suitability, MO13 (DE)
-\item FOR - Mechanical Planting Suitability, MO13 (MD)
-\item FOR - Mechanical Site Preparation (Deep)
-\item FOR - Mechanical Site Preparation (Deep) (DE)
-\item FOR - Mechanical Site Preparation (Deep) (MD)
-\item FOR - Mechanical Site Preparation (Surface)
-\item FOR - Mechanical Site Preparation (Surface) (DE)
 \item FOR - Mechanical Site Preparation (Surface) (MD)
-\item FOR - Mechanical Site Preparation (Surface) (MI)
 \item FOR - Mechanical Site Preparation (Surface) (OH)
-\item FOR - Mechanical Site Preparation; Deep (CT)
-\item FOR - Mechanical Site Preparation; Surface (ME)
-\item FOR - Potential Erosion Hazard (Off-Road/Off-Trail)
+\item FOR - Mechanical Site Preparation; Surface (CT)
 \item FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (MI)
 \item FOR - Potential Erosion Hazard (Off-Road/Off-Trail) (OH)
-\item FOR - Potential Erosion Hazard (Road/Trail)
-\item FOR - Potential Erosion Hazard (Road/Trail) (PIA)
-\item FOR - Potential Erosion Hazard, Road/Trail, Spring Thaw (AK)
-\item FOR - Potential Fire Damage Hazard
-\item FOR - Potential Seedling Mortality
 \item FOR - Potential Seedling Mortality (FL)
-\item FOR - Potential Seedling Mortality (MI)
 \item FOR - Potential Seedling Mortality (OH)
-\item FOR - Potential Seedling Mortality (PIA)
-\item FOR - Potential Seedling Mortality (VT)
-\item FOR - Potential Seedling Mortality(ME)
-\item FOR - Potential Windthrow Hazard (ME)
-\item FOR - Potential Windthrow Hazard (MI)
-\item FOR - Potential Windthrow Hazard (NY)
-\item FOR - Potential Windthrow Hazard (VT)
-\item FOR - Puddling Hazard
-\item FOR - Puddling Potential (WA)
-\item FOR - Road Suitability (Natural Surface)
-\item FOR - Road Suitability (Natural Surface) (ID)
-\item FOR - Road Suitability (Natural Surface) (ME)
-\item FOR - Road Suitability (Natural Surface) (OH)
-\item FOR - Road Suitability (Natural Surface) (OR)
 \item FOR - Road Suitability (Natural Surface) (VT)
-\item FOR - Road Suitability (Natural Surface) (WA)
-\item FOR - Rutting Hazard by Month
-\item FOR - Rutting Hazard by Season
-\item FOR - Shortleaf pine littleleaf disease susceptibility
-\item FOR - Soil Compactibility Risk
 \item FOR - Soil Rutting Hazard
-\item FOR - Soil Rutting Hazard (ME)
-\item FOR - Soil Rutting Hazard (OH)
-\item FOR - Soil Sustainability Forest Biomass Harvesting (CT)
-\item FOR - White Oak Suitability (MO)
-\item FOR - Windthrow Hazard
-\item FOR - Windthrow Hazard (WA)
-\item FOR (USFS) - Road Construction/Maintenance (Natural Surface)
-\item FOTG - Indiana Corn Yield Calculation (IN)
-\item FOTG - Indiana Slippage Potential (IN)
 \item FOTG - Indiana Soy Bean Yield Calculation (IN)
 \item FOTG - Indiana Wheat Yield Calculation (IN)
-\item Fragile Soil Index
-\item Gravity Full Depth Septic System (DE)
-\item GRL-FSG-NP-W (MT)
-\item GRL - Excavations to 24 inches for Plastic Pipelines (TX)
-\item GRL - Fencing, 24 inch Post Depth (MT)
+\item FOTG - NLI report Calculation - (IN)
 \item GRL - Fencing, Post Depth =<24 inches
-\item GRL - Fencing, Post Depth =<36 inches
 \item GRL - Fencing, Post Depth Less Than 24 inches (TX)
 \item GRL - Fencing, Post Depth Less Than 36 inches (TX)
-\item GRL - Juniper Encroachment Potential (NM)
 \item GRL - NV range seeding (Wind C = 10) (NV)
-\item GRL - NV range seeding (Wind C = 100) (NV)
-\item GRL - NV range seeding (Wind C = 20) (NV)
 \item GRL - NV range seeding (Wind C = 30) (NV)
-\item GRL - NV range seeding (Wind C = 40) (NV)
-\item GRL - NV range seeding (Wind C = 50) (NV)
-\item GRL - NV range seeding (Wind C = 60) (NV)
-\item GRL - NV range seeding (Wind C = 80) (NV)
-\item GRL - NV range seeding (Wind C >= 160) (NV)
-\item GRL - Pasture and Hayland SG (OH)
-\item GRL - Ranch Access Roads (TX)
 \item GRL - Rangeland Chaining (TX)
 \item GRL - Rangeland Disking (TX)
 \item GRL - Rangeland Dozing/Grubbing (TX)
-\item GRL - Rangeland Planting by Mechanical Seeding (TX)
-\item GRL - Rangeland Prescribed Burning (TX)
-\item GRL - Rangeland Roller Chopping (TX)
-\item GRL - Rangeland Root Plowing (TX)
 \item GRL - Utah Juniper Encroachment Potential
 \item GRL - Western Juniper Encroachment Potential (OR)
-\item Ground-based Solar Arrays, Ballast Anchor Systems
-\item Ground-based Solar Arrays, Soil-penetrating Anchor Systems
-\item Ground Penetrating Radar Penetration
-\item Hybrid Wine Grape Varieties Site Desirability (Long)
+\item Ground-based Solar Arrays_bedrock_slope_anchor(ME)
+\item Ground-based Solar Arrays_saturation_flooding_Frost(ME)
 \item Hybrid Wine Grape Varieties Site Desirability (Medium)
-\item Hybrid Wine Grape Varieties Site Desirability (Short)
-\item Inland Wetlands (CT)
-\item IRR-restrictive features for irrigation (OH)
-\item ISDH Septic Tank Interpretation (IN)
-\item Land Application of Municipal Sewage Sludge (PA)
 \item Lined Retention Systems
-\item Low Pressure Pipe Septic System (DE)
-\item MIL - Bivouac Areas (DOD)
-\item MIL - Excavations Crew-Served Weapon Fighting Position (DOD)
-\item MIL - Excavations for Individual Fighting Position (DOD)
-\item MIL - Excavations for Vehicle Fighting Position (DOD)
-\item MIL - Helicopter Landing Zones (DOD)
-\item MIL - Trafficability Veh. Type 1 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 1 50-passes wet season (DOD)
 \item MIL - Trafficability Veh. Type 1 dry season (DOD)
-\item MIL - Trafficability Veh. Type 2 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 2 50-passes wet season (DOD)
-\item MIL - Trafficability Veh. Type 2 dry season (DOD)
 \item MIL - Trafficability Veh. Type 3 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 3 50-passes wet season (DOD)
 \item MIL - Trafficability Veh. Type 3 dry season (DOD)
-\item MIL - Trafficability Veh. Type 4 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 4 50-passes wet season (DOD)
 \item MIL - Trafficability Veh. Type 4 dry season (DOD)
 \item MIL - Trafficability Veh. Type 5 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 5 50-passes wet season (DOD)
-\item MIL - Trafficability Veh. Type 5 dry season (DOD)
-\item MIL - Trafficability Veh. Type 6 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 6 50-passes wet season (DOD)
-\item MIL - Trafficability Veh. Type 6 dry season (DOD)
-\item MIL - Trafficability Veh. Type 7 1-pass wet season (DOD)
-\item MIL - Trafficability Veh. Type 7 50-passes wet season (DOD)
-\item MIL - Trafficability Veh. Type 7 dry season (DOD)
-\item MT - Conservation Tree/Shrub Groups (MT)
-\item Muscadine Wine Grape Site Desirability (Very Long)
-\item NCCPI - Irrigated National Commodity Crop Productivity Index
-\item NCCPI - National Commodity Crop Productivity Index (Ver 3.0)
 \item NCCPI - NCCPI Corn Submodel (I)
-\item NCCPI - NCCPI Cotton Submodel (II)
 \item NCCPI - NCCPI Small Grains Submodel (II)
 \item NCCPI - NCCPI Soybeans Submodel (I)
-\item Nitrogen Loss Potential (ND)
-\item Permafrost Sensitivity (AK)
-\item Pressure Dose Capping Fill Septic System (DE)
+\item Peony Flowers Site Suitability (AK)
 \item Pressure Dose Full Depth Septic System (DE)
-\item REC - Camp and Picnic Areas (AK)
-\item REC - Camp Areas (CT)
 \item REC - Camp Areas; Primitive (AK)
-\item REC - Foot and ATV Trails (AK)
-\item REC - Off-Road Motorcycle Trails (CT)
 \item REC - Paths and Trails (CT)
-\item REC - Picnic Areas (CT)
-\item REC - Playgrounds (AK)
-\item REC - Playgrounds (CT)
-\item RSK-risk assessment for manure application (OH)
-\item Salinity Risk Index, Discharge Model (ND)
-\item SAS - CMECS Substrate Class
-\item SAS - CMECS Substrate Origin
-\item SAS - CMECS Substrate Subclass
-\item SAS - CMECS Substrate Subclass/Group
-\item SAS - CMECS Substrate Subclass/Group/Subgroup
+\item Salinity Risk Index (ND)
 \item SAS - Eastern Oyster Habitat Restoration Suitability
-\item SAS - Eelgrass Restoration Suitability
-\item SAS - Land Utilization of Dredged Materials
-\item SAS - Mooring Anchor - Deadweight
 \item SAS - Mooring Anchor - Mushroom
-\item SAS - Northern Quahog (Hard Clam) Habitat Suitability
-\item Septic System A/B Soil System (Alternate) (PA)
-\item Septic System At-Grade Bed (Alternate) (PA)
-\item Septic System At Grade Shallow Field (alternative) (WV)
 \item Septic System CO-OP RFS III w/At-Grade Bed (PA)
-\item Septic System CO-OP RFS III w/Drip Irrigation (PA)
-\item Septic System CO-OP RFS III w/Spray Irrigation (PA)
-\item Septic System Drip Irrigation (Alternate) (PA)
-\item Septic System Drip Irrigation (alternative) (WV)
-\item Septic System Dual Field Trench (conventional) (WV)
-\item Septic System Elevated Field (alternative) (WV)
 \item Septic System Free Access Sand Filter w/At-Grade Bed (PA)
-\item Septic System Free Access Sand Filter w/Drip Irrigation (PA)
-\item Septic System Free Access Sand Filterw/Spray Irrigation (PA)
-\item Septic System In Ground Bed (conventional) (PA)
-\item Septic System In Ground Trench (conventional) (PA)
-\item Septic System In Ground Trench (conventional) (WV)
-\item Septic System Low Pressure Pipe (alternative) (WV)
 \item Septic System Modified Subsurface Sand Filter (Alt.) (PA)
-\item Septic System Mound (alternative) (WV)
-\item Septic System Peat Based Option1 (UV & At-Grade Bed)Alt (PA)
-\item Septic System Peat Based Option1 w/At-Grade Bed (Alt.) (PA)
-\item Septic System Peat Based Option2 w/Spray Irrigation (PA)
-\item Septic System Peat Sys Opt3 w/Subsurface Sand Filter (PA)
-\item Septic System Sand Mound Bed or Trench (PA)
 \item Septic System Shallow In Ground Trench (conventional) (WV)
-\item Septic System Shallow Placement Pressure Dosed (Alt.) (PA)
-\item Septic System Spray Irrigation (PA)
-\item Septic System Steep Slope Mound (alternative) (WV)
-\item Septic System Steep Slope Sand Mound (Alternate) (PA)
 \item Septic System Subsurface Sand Filter Bed (conventional) (PA)
 \item Septic System Subsurface Sand Filter Trench (standard) (PA)
-\item Shallow Infiltration Systems
-\item SOH -  Suitability for Aerobic Soil Organisms
-\item SOH - Agricultural Organic Soil Subsidence
-\item SOH - Concentration of Salts- Soil Surface
-\item SOH - Organic Matter Depletion
-\item SOH - Soil Surface Sealing
-\item SOH - Soil Susceptibility to Compaction
-\item Soil Habitat for Saprophyte Stage of Coccidioides
-\item SOIL HEALTH ASSESSMENT (NJ)
-\item Soil Vegetative Groups (CA)
-\item Surface Runoff Class (CA)
-\item Unlined Retention Systems
-\item URB - Commercial Brick Bldg; w/Reinforced Concrete Slab (TX)
-\item URB - Commercial Brick Buildings w/Concrete Slab (TX)
-\item URB - Commercial Metal Bldg; w/Concrete Slab (TX)
-\item URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
-\item URB - Commercial Metal Buildings w/o Concrete Slab (TX)
+\item SOH - Limitations for Aerobic Soil Organisms
 \item URB - Concrete Driveways and Sidewalks (TX)
 \item URB - Dwellings on Concrete Slab (TX)
-\item URB - Dwellings With Basements (TX)
 \item URB - Lawns and Ornamental Plantings (TX)
-\item URB - Reinforced Concrete Slab (TX)
-\item URB - Rural Residential Development on Concrete Slab (TX)
-\item URB - Rural Residential Development w/Basement (TX)
-\item URB - Urban Residential Development on Concrete Slab (TX)
-\item URB - Urban Residential Development w/Basement (TX)
-\item URB/REC - Camp Areas
-\item URB/REC - Camp Areas (GA)
-\item URB/REC - Camp Areas (HI)
-\item URB/REC - Camp Areas (MI)
-\item URB/REC - Camp Areas (OH)
-\item URB/REC - Golf Fairways (OH)
-\item URB/REC - Off-Road Motorcycle Trails
-\item URB/REC - Off-Road Motorcycle Trails (OH)
 \item URB/REC - Paths and Trails
 \item URB/REC - Paths and Trails (GA)
-\item URB/REC - Paths and Trails (MI)
-\item URB/REC - Paths and Trails (OH)
-\item URB/REC - Picnic Areas
+\item URB/REC - Playgrounds (MI)
+\item Vinifera Wine Grape Site Desirability (Long)
+\item WLF - Crawfish Aquaculture (TX)
+\item WLF - Desertic Herbaceous Plants (TX)
+\item WLF - Gopher Tortoise Burrowing Suitability
+\item WLF - Grain & Seed Crops for Food and Cover (TX)
+\item WMS - Constructing Grassed Waterways (OH)
+\item WMS - Irrigation, Surface (graded)
+\item WMS - Subsurface Drains - Installation (VT)
+\item WMS - Subsurface Water Management, System Performance
+\item WMS - Surface Drains (TX)
+\item WMS - Surface Irrigation Intake Family (TX)
+\item Septic System Low Pressure Pipe (alternative) (WV)
+\item Septic System Mound (alternative) (WV)
+\item Septic System Peat Based Option2 w/Spray Irrigation (PA)
+\item Septic System Steep Slope Mound (alternative) (WV)
+\item SOH - Concentration of Salts- Soil Surface
+\item SOH - Soil Susceptibility to Compaction
+\item Soil Habitat for Saprophyte Stage of Coccidioides
+\item Unlined Retention Systems
+\item URB - Commercial Metal Bldg; w/Reinforced Concrete Slab (TX)
 \item URB/REC - Picnic Areas (GA)
 \item URB/REC - Picnic Areas (MI)
 \item URB/REC - Picnic Areas (OH)
-\item URB/REC - Playgrounds
-\item URB/REC - Playgrounds (GA)
-\item URB/REC - Playgrounds (MI)
-\item URB/REC - Playgrounds (OH)
-\item Vinifera Wine Grape Site Desirability (Long to Medium)
-\item Vinifera Wine Grape Site Desirability (Long)
-\item Vinifera Wine Grape Site Desirability (Short to Medium)
 \item Vinifera Wine Grape Site Desirability (Short)
-\item WAQ - Soil Pesticide Absorbed Runoff Potential (TX)
-\item WAQ - Soil Pesticide Leaching Potential (TX)
-\item WAQ - Soil Pesticide Solution Runoff Potential (TX)
-\item WLF-Soil Suitability - Karner Blue Butterfly (WI)
 \item WLF - Burrowing Mammals & Reptiles (TX)
-\item WLF - Chufa for Turkey Forage (LA)
-\item WLF - Crawfish Aquaculture (TX)
 \item WLF - Desert Tortoise (CA)
-\item WLF - Desertic Herbaceous Plants (TX)
 \item WLF - Domestic Grasses & Legumes for Food and Cover (TX)
-\item WLF - Food Plots for Upland Wildlife < 2 Acres (TX)
-\item WLF - Freshwater Wetland Plants (TX)
-\item WLF - Gopher Tortoise Burrowing Suitability
-\item WLF - Grain & Seed Crops for Food and Cover (TX)
-\item WLF - Irr. Domestic Grasses & Legumes for Food & Cover (TX)
-\item WLF - Irrigated Freshwater Wetland Plants (TX)
 \item WLF - Irrigated Grain & Seed Crops for Food & Cover (TX)
-\item WLF - Irrigated Saline Water Wetland Plants (TX)
-\item WLF - Riparian Herbaceous Plants (TX)
-\item WLF - Riparian Shrubs, Vines, & Trees (TX)
-\item WLF - Saline Water Wetland Plants (TX)
-\item WLF - Upland Coniferous Trees (TX)
-\item WLF - Upland Deciduous Trees (TX)
-\item WLF - Upland Desertic Shrubs & Trees (TX)
-\item WLF - Upland Mixed Deciduous & Coniferous Trees (TX)
-\item WLF - Upland Native Herbaceous Plants (TX)
-\item WLF - Upland Shrubs & Vines (TX)
-\item WMS-Subsurface Water Management, Installation (ND)
-\item WMS-Subsurface Water Management, Outflow Quality (ND)
-\item WMS-Subsurface Water Management, Performance (ND)
-\item WMS - Constructing Grassed Waterways (OH)
-\item WMS - Constructing Grassed Waterways (TX)
-\item WMS - Constructing Terraces & Diversions (TX)
-\item WMS - Constructing Terraces and Diversions (OH)
-\item WMS - Drainage - (MI)
-\item WMS - Drainage (IL)
-\item WMS - Drainage (OH)
-\item WMS - Embankments, Dikes, and Levees
-\item WMS - Embankments, Dikes, and Levees (OH)
-\item WMS - Embankments, Dikes, and Levees (VT)
 \item WMS - Excavated Ponds (Aquifer-fed)
-\item WMS - Excavated Ponds (Aquifer-fed) (OH)
 \item WMS - Excavated Ponds (Aquifer-fed) (VT)
-\item WMS - Grape Production with Drip Irrigation (TX)
-\item WMS - Grassed Waterways - (MI)
 \item WMS - Irrigation, General
 \item WMS - Irrigation, Micro (above ground)
 \item WMS - Irrigation, Micro (above ground) (VT)
 \item WMS - Irrigation, Micro (subsurface drip)
-\item WMS - Irrigation, Micro (subsurface drip) (VT)
-\item WMS - Irrigation, Sprinkler (close spaced outlet drops)
-\item WMS - Irrigation, Sprinkler (general)
 \item WMS - Irrigation, Sprinkler (general) (VT)
-\item WMS - Irrigation, Surface (graded)
-\item WMS - Irrigation, Surface (level)
 \item WMS - Pond Reservoir Area
-\item WMS - Pond Reservoir Area (GA)
-\item WMS - Pond Reservoir Area (MI)
 \item WMS - Pond Reservoir Area (OH)
+\item WMS - Subsurface Water Management, System Installation
+\item WMS - Constructing Terraces & Diversions (TX)
+\item WMS - Drainage (OH)
+\item WMS - Excavated Ponds (Aquifer-fed) (OH)
+\item WMS - Grape Production with Drip Irrigation (TX)
+\item WMS - Irrigation, Micro (subsurface drip) (VT)
+\item WMS - Irrigation, Surface (level)
+\item WMS - Pond Reservoir Area (MI)
+\item WMS - Pond Reservoir Area (VT)
 \item WMS - Sprinkler Irrigation (MT)
 \item WMS - Sprinkler Irrigation RDC (IL)
-\item WMS - Subsurface Drains - Installation (VT)
 \item WMS - Subsurface Drains - Performance (VT)
-\item WMS - Subsurface Drains < 3 Feet Deep (TX)
-\item WMS - Subsurface Drains > 3 Feet Deep (TX)
 \item WMS - Subsurface Water Management, Outflow Quality
-\item WMS - Subsurface Water Management, System Installation
-\item WMS - Subsurface Water Management, System Performance
-\item WMS - Surface Drains (TX)
-\item WMS - Surface Irrigation Intake Family (TX)
 \item WMS - Surface Water Management, System
+\item WMS-Subsurface Water Management, Performance (ND)
 }
 }
 }


### PR DESCRIPTION
Adds subrule ratings to "reason" fields calculated for each `mrulename` in a `get_SDA_interpretation()` query. 

This helps get key information about subrules that are exported in cointerp with `ruledepth > 0` 

TODO:
 - [x] consider if there is a truly generic way to flatten these results 1:1 with mukey/component/mrulename... or if that has to be left to the user/unique to the interpretation being queried
    - could pack an optional XML column containing arbitrary complexity about subrules 
 - [x] <strike> `.interpretation_weighted_average()` needs SQLite compatible `STRING_AGG()` switch</strike>(wontfix; the rest of the query is not SQLite compatible either)
 - [x] <strike>order subrule "reasons" alphabetically? or at least consistently</strike> (wontfix; can't use ORDER BY in the T-SQL subquery)
 - [x] some subrule reasons are hard to interpret without subrule name

Will close #303


Note the "reason" field now includes the `interphr` as well as `interphrc` values for rules with ruledepth != 0
``` r
library(soilDB)

x <- get_SDA_interpretation(rulename  = "NCCPI - National Commodity Crop Productivity Index (Ver 3.0)",
                            method     = "Dominant Component",
                            mukeys     = c("242963","242964","242965"))
x
#>    mukey    cokey areasymbol musym
#> 1 242963 23671045      IL019  152A
#> 2 242964 23670915      IL019  134A
#> 3 242965 23671016      IL019  154A
#>                                           muname compname compkind comppct_r
#> 1 Drummer silty clay loam, 0 to 2 percent slopes  Drummer   Series        94
#> 2        Camden silt loam, 0 to 2 percent slopes   Camden   Series        92
#> 3      Flanagan silt loam, 0 to 2 percent slopes Flanagan   Series        95
#>   majcompflag rating_NCCPINationalCommodityCropProductivityIndexVer30
#> 1         Yes                                                   0.826
#> 2         Yes                                                   0.917
#> 3         Yes                                                   0.899
#>   class_NCCPINationalCommodityCropProductivityIndexVer30
#> 1                             High inherent productivity
#> 2                             High inherent productivity
#> 3                             High inherent productivity
#>                                                                                                                                                                                                           reason_NCCPINationalCommodityCropProductivityIndexVer30
#> 1 Impacted soil "No limitation" (0); NCCPI - NCCPI Cotton Submodel (II) "Cotton" (0.001); NCCPI - NCCPI Small Grains Submodel (II) "Small grains" (0.687); NCCPI - NCCPI Soybeans Submodel (I) "Soybeans" (0.752); NCCPI - NCCPI Corn Submodel (I) "Corn" (0.826)
#> 2 NCCPI - NCCPI Cotton Submodel (II) "Cotton" (0.001); NCCPI - NCCPI Soybeans Submodel (I) "Soybeans" (0.777); NCCPI - NCCPI Small Grains Submodel (II) "Small grains" (0.791); NCCPI - NCCPI Corn Submodel (I) "Corn" (0.917); Impacted soil "No limitation" (0)
#> 3  Impacted soil "No limitation" (0); NCCPI - NCCPI Cotton Submodel (II) "Cotton" (0.001); NCCPI - NCCPI Small Grains Submodel (II) "Small grains" (0.734); NCCPI - NCCPI Soybeans Submodel (I) "Soybeans" (0.76); NCCPI - NCCPI Corn Submodel (I) "Corn" (0.899)
```
