### PR TITLE
alignment of WCS results with authoritative grid topology

### DIFF
--- a/R/ISSR800.R
+++ b/R/ISSR800.R
@@ -36,6 +36,10 @@
 #' @export
 ISSR800.wcs <- function(aoi, var, res = 800, quiet = FALSE) {
   
+  if (!requireNamespace("terra")) {
+    stop("package 'terra' is required", call. = FALSE)
+  }
+  
   # sanity check: aoi specification
   if (!inherits(aoi, c('list', 'Spatial', 'sf', 'sfc', 'bbox', 'RasterLayer', 'SpatRaster', 'SpatVector'))) { 
     stop('invalid `aoi` specification', call. = FALSE)

--- a/R/ISSR800.R
+++ b/R/ISSR800.R
@@ -53,8 +53,13 @@ ISSR800.wcs <- function(aoi, var, res = 800, quiet = FALSE) {
   # get variable specs
   var.spec <- .ISSR800.spec[[var]]
   
+  # authoritative CONUS = grid
+  .crs <- 'EPSG:5070'
+  .grid <- terra::rast(nrows = 3621, ncols = 5770, crs = .crs, 
+                       extent = terra::ext(-2357200, 2258800, 276400, 3173200))
+  
   # compute BBOX / IMG geometry in native CRS
-  wcs.geom <- .prepare_AEA_AOI(aoi, res = res, native_crs = 'EPSG:5070')
+  wcs.geom <- .prepare_AEA_AOI(aoi, res = res, native_crs = .crs)
   
   ## TODO: investigate why this is so
   # sanity check: a 1x1 pixel request to WCS results in a corrupt GeoTiff 
@@ -190,6 +195,9 @@ ISSR800.wcs <- function(aoi, var, res = 800, quiet = FALSE) {
     # register categories in new order
     levels(r) <- rat[cat.idx, col.names]
   }
+  
+  # align to authoritative grid
+  terra::ext(r) <- terra::align(terra::ext(r), .grid)
   
   input_class <- attr(wcs.geom, '.input_class')
   

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -63,17 +63,21 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   db <- match.arg(tolower(db[1]), choices = c('gnatsgo', 'gssurgo', 'rss', 'statsgo', 'pr_ssurgo', 'hi_ssurgo'))
   
   # lookup native CRS
-  if(db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
+  if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
     # CONUS
     .crs <- 'EPSG:5070'
     .grid <- terra::rast(nrows = 96754, ncols = 153999, crs = .crs, 
                          extent = terra::ext(-2356155, 2263815, 270015, 3172635))
-  } else if(db == 'pr_ssurgo') {
+  } else if (db == 'pr_ssurgo') {
     # PR
     .crs <- 'EPSG:32161'
-  } else if(db == 'hi_ssurgo') {
+    .grid <- terra::rast(nrows = 9608, ncols = 2229, crs = .crs, 
+                         extent = terra::ext(208815.704, 275685.704, 39904.225, 328144.225))
+  } else if (db == 'hi_ssurgo') {
     # HI
     .crs <- 'EPSG:6628'
+    .grid <- terra::rast(nrows = 17193, ncols = 12440, crs = .crs, 
+                         extent = terra::ext(8585.137, 381785.137, 56991.645, 572781.645))
   }
 
   # sanity check: aoi specification

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -66,6 +66,8 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   if(db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
     # CONUS
     .crs <- 'EPSG:5070'
+    .grid <- terra::rast(nrows = 96754, ncols = 153999, crs = .crs, 
+                         extent = terra::ext(-2356155, 2263815, 270015, 3172635))
   } else if(db == 'pr_ssurgo') {
     # PR
     .crs <- 'EPSG:32161'
@@ -224,6 +226,11 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   attr(r, 'layer name') <- var.spec$desc
 
   input_class <- attr(wcs.geom, '.input_class')
+  
+  if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
+    # TODO: HI, PR, ISSR800
+    terra::ext(r) <- terra::align(terra::ext(r), .grid)
+  }
   
   if ((!is.null(input_class) && input_class == "raster") ||
       getOption('soilDB.return_Spatial', default = FALSE)) {

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -75,13 +75,13 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   } else if (db == 'pr_ssurgo') {
     # PR
     .crs <- 'EPSG:32161'
-    .grid <- terra::rast(nrows = 9608, ncols = 2229, crs = .crs, 
-                         extent = terra::ext(208815.704, 275685.704, 39904.225, 328144.225))
+    .grid <- terra::rast(nrows = 2229, ncols = 9608, crs = .crs, 
+                         extent = terra::ext(39905, 328145, 208815, 275685))
   } else if (db == 'hi_ssurgo') {
     # HI
     .crs <- 'EPSG:6628'
-    .grid <- terra::rast(nrows = 17193, ncols = 12440, crs = .crs, 
-                         extent = terra::ext(8585.137, 381785.137, 56991.645, 572781.645))
+    .grid <- terra::rast(nrows = 12441, ncols = 17193, crs = .crs, 
+                         extent = terra::ext(56992, 572782, 8585, 381815))
   }
 
   # sanity check: aoi specification
@@ -246,7 +246,7 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
 
   input_class <- attr(wcs.geom, '.input_class')
   
-  if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
+  if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo', 'hi_ssurgo', 'pr_ssurgo')) {
     terra::ext(r) <- terra::align(terra::ext(r), .grid)
   }
   

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -236,7 +236,6 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   input_class <- attr(wcs.geom, '.input_class')
   
   if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
-    # TODO: HI, PR, ISSR800
     terra::ext(r) <- terra::align(terra::ext(r), .grid)
   }
   

--- a/R/mukey-WCS.R
+++ b/R/mukey-WCS.R
@@ -62,6 +62,10 @@ mukey.wcs <- function(aoi, db = c('gNATSGO', 'gSSURGO', 'RSS', 'STATSGO', 'PR_SS
   # sanity check: db name
   db <- match.arg(tolower(db[1]), choices = c('gnatsgo', 'gssurgo', 'rss', 'statsgo', 'pr_ssurgo', 'hi_ssurgo'))
   
+  if (!requireNamespace("terra")) {
+    stop("package 'terra' is required", call. = FALSE)
+  }
+  
   # lookup native CRS
   if (db %in% c('gnatsgo', 'gssurgo', 'rss', 'statsgo')) {
     # CONUS


### PR DESCRIPTION
As a proof of concept I use `terra::align()` to adjust results based on known dimensions and extent of the complete CONUS/EPSG:5070 30m data sources.

- [x] add grid topology metadata for gNATSGO Hawaii, Puerto Rico, and ISSR800