### PR TITLE
soilDB v2.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.7.11
+Version: 2.8.0
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov"),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 
@@ -12,7 +12,7 @@ Description: A collection of functions for reading soil data from U.S. Departmen
 License: GPL (>= 3)
 LazyLoad: yes
 Depends: R (>= 3.5.0)
-Imports: grDevices, graphics, stats, utils, methods, aqp, data.table, DBI, curl
+Imports: grDevices, graphics, stats, utils, methods, aqp (>= 2.0.2), data.table, DBI, curl
 Suggests: jsonlite, xml2, httr, rvest, odbc, RSQLite, sf, wk, terra, raster, knitr, rmarkdown, testthat
 Repository: CRAN
 URL: https://ncss-tech.github.io/soilDB/, https://ncss-tech.github.io/AQP/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
-# soilDB 2.7.11 (development)
+# soilDB 2.8.0 (development)
+
+ - Minimum {aqp} version set to v2.0.2. This is due to changes in the namespace related to `aqp::col2Munsell()`, to "encourage" users to update to the more efficient routines provided in {aqp} 2+ (if they haven't already), and prepare for future updates in the 2.x series.
  - Fix bugs in `get_SDA_interpretation()` when `dsn` refers to a local SQLite source
 and in concatenation of reason string when `wide_reason=TRUE`
- - `createSSURGO()` now creates indices for foreign keys and other columns important data analysis, dramatically improving the performance of standard soilDB queries on SQLite sources.
- - `createSSURGO()` now works properly on STATSGO datasets for individual states or CONUS. Previously tabular data would be transferred but spatial data were not.
+ - `createSSURGO()` updates:
+   - *Breaking change*: Now uses the standard SSURGO layer names for spatial data (e.g. `"mupolygon"` rather than `"soilmu_a"`).
+   - Creates indices for foreign keys and other columns important for data analysis, dramatically improving the performance of standard queries on SQLite sources.
+   - Now works properly on STATSGO data sets for individual states or CONUS. Previously tabular data would be transferred but spatial data were not.
  - `downloadSSURGO()` gains `db` argument which gives ability to download STATSGO by state or all of US from Web Soil Survey. Thanks to Meghan Krueger for suggestion.
- - `get_SDA_property()`: weighted average/dominant component numeric methods now returns `mukey` in first column position; for parity with other `get_SDA*` methods recently updated/already doing this, making it easier to use these columns for raster attribute tables via `terra::set.levels()`
+ - `get_SDA_property()`: weighted average/dominant component numeric methods now return `mukey` in first column position; for parity with other `get_SDA*` methods recently updated/already doing this, making it easier to use these columns for raster attribute tables via `terra::set.levels()`
 
 # soilDB 2.7.10 (2023-11-16)
 


### PR DESCRIPTION
Draft PR for upcoming 2.8.x release. Plan is to get this out before 22 December (when CRAN goes on winter holiday)

 - Sets minimum aqp version v2.0.2 RE: #318, #325