### PR TITLE
createSSURGO: add support for creating DuckDB and other DBI-compatible databases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: GPL (>= 3)
 LazyLoad: yes
 Depends: R (>= 3.5.0)
 Imports: grDevices, graphics, stats, utils, methods, aqp (>= 2.0.2), data.table, DBI, curl
-Suggests: jsonlite, xml2, httr, rvest, odbc, RSQLite, sf, wk, terra, raster, knitr, rmarkdown, testthat
+Suggests: jsonlite, xml2, httr, rvest, odbc, RSQLite, duckdb, sf, wk, terra, raster, knitr, rmarkdown, testthat
 Repository: CRAN
 URL: https://ncss-tech.github.io/soilDB/, https://ncss-tech.github.io/AQP/
 BugReports: https://github.com/ncss-tech/soilDB/issues

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -12,6 +12,7 @@ createSSURGO(
   overwrite = FALSE,
   header = FALSE,
   quiet = TRUE,
+  duckdb = FALSE,
   ...
 )
 }
@@ -29,6 +30,8 @@ createSSURGO(
 \item{header}{Logical. Passed to \code{read.delim()} for reading pipe-delimited (\code{|}) text files containing tabular data.}
 
 \item{quiet}{Logical. Suppress messages and other output from database read/write operations?}
+
+\item{duckdb}{Logical. Create DuckDB rather than SQLite database? Default: \code{FALSE}.}
 
 \item{...}{Additional arguments passed to \code{write_sf()} for writing spatial layers.}
 }

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -2,24 +2,26 @@
 % Please edit documentation in R/createSSURGO.R
 \name{createSSURGO}
 \alias{createSSURGO}
-\title{Create a SQLite database or GeoPackage from one or more SSURGO Exports}
+\title{Create a database from SSURGO Exports}
 \usage{
 createSSURGO(
   filename,
   exdir,
+  conn = DBI::dbConnect(DBI::dbDriver("SQLite"), filename, loadable.extensions = TRUE),
   pattern = NULL,
   include_spatial = TRUE,
   overwrite = FALSE,
   header = FALSE,
   quiet = TRUE,
-  duckdb = FALSE,
   ...
 )
 }
 \arguments{
-\item{filename}{Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'})}
+\item{filename}{Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'}). Only used when \code{con} is not specified by the user.}
 
-\item{exdir}{Path containing containing SSURGO spatial (.shp) and tabular (.txt) files.}
+\item{exdir}{Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files, downloaded and extracted by \code{downloadSSURGO()} or similar.}
+
+\item{conn}{A \emph{DBIConnection} object. Default is a \code{SQLiteConnection} used for writing .sqlite or .gpkg files. Alternate options are any DBI connection types. When \code{include_spatial=TRUE}, the sf package is used to write spatial data to the database.}
 
 \item{pattern}{Character. Optional regular expression to use to filter subdirectories of \code{exdir}. Default: \code{NULL} will search all subdirectories for SSURGO export files.}
 
@@ -31,19 +33,27 @@ createSSURGO(
 
 \item{quiet}{Logical. Suppress messages and other output from database read/write operations?}
 
-\item{duckdb}{Logical. Create DuckDB rather than SQLite database? Default: \code{FALSE}.}
-
 \item{...}{Additional arguments passed to \code{write_sf()} for writing spatial layers.}
 }
 \value{
 Character. Vector of layer/table names in \code{filename}.
 }
 \description{
-Create a SQLite database or GeoPackage from one or more SSURGO Exports
+The following database types are tested and fully supported:
+\itemize{
+\item SQLite or Geopackage
+\item DuckDB
+\item Postgres or PostGIS
+}
+
+In theory any other DBI-compatible data source can be used for output. See \code{conn} argument. If you encounter issues using specific DBI connection types, please report in the soilDB issue tracker.
 }
 \examples{
 \dontrun{
  downloadSSURGO("areasymbol IN ('CA067', 'CA077', 'CA632')", destdir = "SSURGO_test")
  createSSURGO("test.gpkg", "SSURGO_test")
 }
+}
+\seealso{
+\code{\link[=downloadSSURGO]{downloadSSURGO()}}
 }

--- a/man/downloadSSURGO.Rd
+++ b/man/downloadSSURGO.Rd
@@ -53,3 +53,6 @@ Pipe-delimited TXT files are found in \emph{/tabular/} folder extracted from a S
 
 Several ESRI shapefiles are found in the \emph{/spatial/} folder extracted from a SSURGO ZIP. These have prefix \code{soilmu_} (mapunit), \code{soilsa_} (survey area), \code{soilsf_} (special features). There will also be a TXT file with prefix \code{soilsf_} describing any special features. Shapefile names then have an \code{a_} (polygon), \code{l_} (line), \code{p_} (point) followed by the soil survey area symbol.
 }
+\seealso{
+\code{\link[=createSSURGO]{createSSURGO()}}
+}

--- a/misc/postgis-ssurgo.Rmd
+++ b/misc/postgis-ssurgo.Rmd
@@ -1,0 +1,91 @@
+---
+title: "`createSSURGO()` + PostGIS"
+output: md_document
+---
+
+## Setup PostGIS Docker Container
+
+First, install [Docker](https://docs.docker.com/engine/install/).
+
+Then, pull the `postgis` image you want. 
+
+Here, we get the latest version using tag `"latest"`:
+
+```sh
+docker pull postgis/postgis:latest    
+```
+
+Then run an instance of the image. 
+
+```sh
+docker run --name steep-piano -e POSTGRES_PASSWORD=mypassword -d -p 5432:5432 postgis/postgis
+```
+
+Give it a name (e.g. `steep-piano`). The default username is `postgres`. Set a password (e.g. `"mypassword"`) and port to forward (e.g. `5432`) from your docker container to your public host network address.
+
+In the simplest case you are just running `postgis` for local testing, so the host address will simply be `localhost`.
+
+You can then make a connection to the PostGIS instance running in the Docker container. 
+
+To make sure everything is working open up the `psql` SQL prompt: 
+
+```sh
+psql -h localhost -p 5432 -U postgres
+```
+
+Then use command `\l` to list databases then `\q` to quit.
+
+# Connecting with R
+
+Create a database connection to your local PostGIS instance. To do this we use DBI and RPostgres packages.
+
+```{r}
+library(soilDB)
+library(RPostgres)
+
+con <- DBI::dbConnect(DBI::dbDriver("Postgres"), 
+                      host = "localhost",
+                      port = 5432L,
+                      user = "postgres",
+                      password = "password")
+```
+
+Download some SSURGO data, if needed, and extract the files/folder structure to `"SSURGO_test"` subfolder of current working directory.
+
+```{r, eval = FALSE}
+if (!dir.exists("SSURGO_test"))
+  downloadSSURGO(areasymbols = c("CA067", "CA077", "CA632"),
+                 destdir = "SSURGO_test")
+```
+
+Pass the `con` argument to `createSSURGO()` to override the default SQLite connection that is created to `filename`. When `con` is not the default SQLite connection, the `filename` argument can take any value (including `NULL`).
+
+```{r, eval = FALSE}
+createSSURGO(exdir = "SSURGO_test", 
+             con = con)
+```
+
+Once the tables have been written to the database, you can write queries involving spatial and tabular data.
+Perhaps the easiest way to do this is to use `sf::st_read()`. 
+
+The `st_read()` function can take a DBIConnection as a data source, and takes a `query` argument. It will return an `sf` data frame if the result table contains a geometry column. Otherwise, it will return a data.frame (with a warning).
+
+```{r}
+res <- sf::st_read(con, query = "SELECT 
+                                  ST_Centroid(geometry) AS centroid, 
+                                  ST_Area(geometry) AS polygon_area,
+                                  muaggatt.*
+                                 FROM mupolygon 
+                                 LEFT JOIN muaggatt ON muaggatt.mukey = CAST(mupolygon.mukey AS integer)
+                                 LIMIT 2")
+
+res
+
+plot(res["musym"], pch = "+")
+```
+
+Close the connection when you are done.
+
+```{r}
+DBI::dbDisconnect(con)
+```


### PR DESCRIPTION
For a few months I have been exploring the idea of making SSURGO DuckDB databases. 

To further support incorporating this into my workflows, this PR configures `createSSURGO()` to optionally use [{duckdb}](https://duckdb.org/docs/api/r.html) instead of {sf}+{RSQLite}. To toggle on this behavior use `createSSURGO(..., duckdb=TRUE)`.

In the future I would like to develop benchmarks and examples for large database processing--i.e. all of SSURGO in DuckDB vs. Spatialite or Geopackage.