### PR TITLE
fetchSCAN: return all above-ground sensors

### DIFF
--- a/R/fetchSCAN.R
+++ b/R/fetchSCAN.R
@@ -235,14 +235,11 @@ fetchSCAN <- function(site.code = NULL, year = NULL, report = 'SCAN', timeseries
     return(NULL)
   }
 
-  ## https://github.com/ncss-tech/soilDB/issues/14
-  ## there may be multiple above-ground sensors (takes the first)
+  ## there may be multiple above-ground sensors 
   if (length(d.cols) > 1 && code %in% c('TAVG', 'TMIN', 'TMAX', 'PRCP', 'PREC',
                                       'SNWD', 'WTEQ', 'WDIRV', 'WSPDV', 'LRADT')) {
     message(paste0('multiple sensors per site [site ', d$Site[1], '] ',
                    paste0(names(d)[d.cols], collapse = ',')))
-    # use only the first sensor
-    d.cols <- d.cols[1]
   }
 
   # coerce all values to double (avoids data.table warnings)


### PR DESCRIPTION
Closes #14 

**Before:**
``` r
library(soilDB)

fetchSCAN(site.code = 482, year = 2014)$WTEQ$sensor.id |> 
  unique()
#> multiple sensors per site [site 482] PREC.I,PREC.I-2
#> multiple sensors per site [site 482] WTEQ.I,WTEQ.I-2
#> 2921 records (0.19 Mb transferred)
#> [1] WTEQ.I
#> Levels: WTEQ.I
```

**After:**
``` r
library(soilDB)

fetchSCAN(site.code = 482, year = 2014)$WTEQ$sensor.id |> 
  unique()
#> multiple sensors per site [site 482] PREC.I,PREC.I-2
#> multiple sensors per site [site 482] WTEQ.I,WTEQ.I-2
#> 3652 records (0.2 Mb transferred)
#> [1] WTEQ.I   WTEQ.I-2
#> Levels: WTEQ.I WTEQ.I-2
```




