### PR TITLE
Deprecate NASIS column name aliases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,17 @@
-# soilDB 2.8.6 (development)
+# soilDB 2.8.7 (2025-01-10)
+ - Several aliases of NASIS physical column names have been deprecated and will be removed in the next minor release (2.9.x). See https://ncss-tech.github.io/AQP/soilDB/bulletins/2025.01-1-soilDB-NASIS-column-aliases.html for details (#369)
+ - `createSSURGO()` updates
+   - Improvements for more efficient writing of tabular data
+   - Added `maxruledepth`, `dissolve_field`, `include_tabular` arguments; updated `overwrite` and `filename` logic
+   - Allow `include_spatial` and `include_tabular` arguments to be a character vector of table names to include
+   - Create composite `"soil_metadata"` table with one row per Soil Survey Area
+   
+# soilDB 2.8.6 (2024-12-16)
  - `fetchNASIS()` and `get_site_data_from_NASIS_db()` now return Ecological Site State and Community Phase information (ecostatename, ecostateid, commphasename, commphaseid columns) from Site Observation table
- - `createStaticNASIS()` removed workaround for {odbc}/nanoodbc VARCHAR(MAX) columns; now can directly use `DBI::dbReadTable()` for all tables via NASIS ODBC connection
- - `fetchNASIS()` changed default behavior to `mixColors = FALSE` which returns dominant condition for each moisture state rather than mixing LAB color coordinates
+ - `createStaticNASIS()` bug fixes
+   - Removed workaround for {odbc}/nanoodbc VARCHAR(MAX) columns; now can directly use `DBI::dbReadTable()` for all tables via NASIS ODBC connection
+   - Fixed error when `output_path=NULL`
+ - `fetchNASIS()` changed default behavior to `mixColors=FALSE` which returns dominant condition for each moisture state rather than mixing LAB color coordinates
    - `get_colors_from_NASIS_db()` deprecate `mixColors` argument, add `method` argument with options "dominant", "mixed", and "none". New aggregation method `"none"` returns long format representation of color data from phcolor table with no aggregation applied. 
 
 # soilDB 2.8.5 (2024-11-04)

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -10,7 +10,7 @@ soilDB.env <- new.env(hash = TRUE)
   options(soilDB.verbose = FALSE,
           soilDB.timeout = 300,
           soilDB.ssl_verifyhost = 0,
-          soilDB.alias_warnings = TRUE)
+          soilDB.warn.aliases = TRUE)
   
   # set default local nasis authentication
   options(soilDB.NASIS.credentials = "DSN=nasis_local;UID=NasisSqlRO;PWD=nasisRe@d0n1y")
@@ -83,19 +83,20 @@ get_soilDB_env <- function() {
 .soilDB_warn_deprecated_aliases <- function(aliases, FUN = deparse(sys.calls()[[sys.nframe() - 1]][[1]])) {
   if (.soilDB_warn_deprecated(FUN) && length(aliases) > 0) {
     message("------------------------------------------")
-    message("NOTE: `", FUN, "()` column aliases will be removed in the next soilDB release.")
+    message("NOTE: `", FUN, "()` column aliases will be removed in the next minor soilDB release (2.9.x).")
     message("Please replace use of the following column names with NASIS physical column name:")
     sapply(seq(aliases), function(i) message("\t - ", aliases[i], " => ", names(aliases)[i]))
-    message("Set `options(soilDB.alias_warnings=FALSE)` to prevent this message from displaying in future sessions.")
+    message("Set `options(soilDB.warn.aliases=FALSE)` to prevent this message from displaying in future sessions.")
+    message("See <https://ncss-tech.github.io/AQP/soilDB/bulletins/2025.01-1-soilDB-NASIS-column-aliases.html> for details.")
     message("------------------------------------------")
   }
 }
 
 .soilDB_warn_deprecated <- function(x) {
-  if (isFALSE(getOption("soilDB.alias_warnings", default = TRUE)) || x %in% soilDB.env$soilDB.alias_warnings_fnlist) {
+  if (isFALSE(getOption("soilDB.warn.aliases", default = TRUE)) || x %in% soilDB.env$soilDB.warn.aliases_fnlist) {
     return(FALSE)
   } else {
-    soilDB.env$soilDB.alias_warnings_fnlist <- c(unique(soilDB.env$soilDB.alias_warnings_fnlist), x)
+    soilDB.env$soilDB.warn.aliases_fnlist <- c(unique(soilDB.env$soilDB.warn.aliases_fnlist), x)
     return(TRUE)
   }
 }

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -9,7 +9,8 @@ soilDB.env <- new.env(hash = TRUE)
   # function verbosity
   options(soilDB.verbose = FALSE,
           soilDB.timeout = 300,
-          soilDB.ssl_verifyhost = 0)
+          soilDB.ssl_verifyhost = 0,
+          soilDB.alias_warnings = TRUE)
   
   # set default local nasis authentication
   options(soilDB.NASIS.credentials = "DSN=nasis_local;UID=NasisSqlRO;PWD=nasisRe@d0n1y")
@@ -77,4 +78,24 @@ get_soilDB_env <- function() {
   res <- FUN(tf, ...)
   unlink(tf)
   res
+}
+
+.soilDB_warn_deprecated_aliases <- function(aliases, FUN = deparse(sys.calls()[[sys.nframe() - 1]][[1]])) {
+  if (.soilDB_warn_deprecated(FUN) && length(aliases) > 0) {
+    message("------------------------------------------")
+    message("NOTE: `", FUN, "()` column aliases will be removed in the next soilDB release.")
+    message("Please replace use of the following column names with NASIS physical column name:")
+    sapply(seq(aliases), function(i) message("\t - ", aliases[i], " => ", names(aliases)[i]))
+    message("Set `options(soilDB.alias_warnings=FALSE)` to prevent this message from displaying in future sessions.")
+    message("------------------------------------------")
+  }
+}
+
+.soilDB_warn_deprecated <- function(x) {
+  if (isFALSE(getOption("soilDB.alias_warnings", default = TRUE)) || x %in% soilDB.env$soilDB.alias_warnings_fnlist) {
+    return(FALSE)
+  } else {
+    soilDB.env$soilDB.alias_warnings_fnlist <- c(unique(soilDB.env$soilDB.alias_warnings_fnlist), x)
+    return(TRUE)
+  }
 }

--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -65,7 +65,7 @@
   missing.lower.depth.idx <- which(!is.na(hz_data$hzdept) & is.na(hz_data$hzdepb))
 
   # keep track of affected pedon IDs (if none, this will have zero length)
-  assign('missing.bottom.depths', value = unique(hz_data$pedon_id[missing.lower.depth.idx]), envir = get_soilDB_env())
+  assign('missing.bottom.depths', value = unique(hz_data$upedonid[missing.lower.depth.idx]), envir = get_soilDB_env())
 
   if (length(missing.lower.depth.idx) > 0) {
     message(paste0('replacing missing lower horizon depths with top depth + 1cm ... [', length(missing.lower.depth.idx), ' horizons]'))
@@ -78,7 +78,7 @@
   top.eq.bottom.idx <- which(hz_data$hzdept == hz_data$hzdepb)
 
   # keep track of affected pedon IDs (if none, this will have zero length)
-  assign('top.bottom.equal', value = unique(hz_data$pedon_id[	top.eq.bottom.idx]), envir = get_soilDB_env())
+  assign('top.bottom.equal', value = unique(hz_data$upedonid[top.eq.bottom.idx]), envir = get_soilDB_env())
 
   if (length(top.eq.bottom.idx) > 0) {
     message(paste0('top/bottom depths equal, adding 1cm to bottom depth ... [', length(top.eq.bottom.idx), ' horizons]'))
@@ -105,8 +105,8 @@
     good.ids <- as.character(h.test$peiid[which(h.test$valid)])
     bad.ids <- as.character(h.test$peiid[which(!h.test$valid)])
     bad.horizons <- hz_data[hz_data$peiid %in% h.test$peiid[which(!h.test$valid)], 
-                            c("peiid", "phiid", "pedon_id", "hzname", "hzdept", "hzdepb")]
-    bad.pedon.ids <- site_data$pedon_id[which(site_data$peiid %in% bad.ids)]
+                            c("peiid", "phiid", "upedonid", "hzname", "hzdept", "hzdepb")]
+    bad.pedon.ids <- site_data$upedonid[which(site_data$peiid %in% bad.ids)]
     
     # handle fill=TRUE
     if(length(filled.ids) > 0) {
@@ -131,8 +131,8 @@
   # upgrade to SoilProfilecollection
   depths(hz_data) <- peiid ~ hzdept + hzdepb
 
-  # move pedon_id into @site
-  site(hz_data) <- ~ pedon_id
+  # move upedonid into @site
+  site(hz_data) <- ~ upedonid
 
   ## copy pre-computed colors into a convenience field for plotting
   # moist colors
@@ -164,8 +164,8 @@
   horizons(hz_data) <- extended_data$art_summary
 
   # add site data to object
-  # remove 'pedon_id' column from site_data
-  site_data$pedon_id <- NULL
+  # remove 'upedonid' column from site_data
+  site_data$upedonid <- NULL
   
   # TODO: duplicating surface fine gravel column with old name for backward compatibility
   site_data$surface_fgravel <- site_data$surface_fine_gravel

--- a/R/fetchNASIS_pedons.R
+++ b/R/fetchNASIS_pedons.R
@@ -166,6 +166,7 @@
   # add site data to object
   # remove 'upedonid' column from site_data
   site_data$upedonid <- NULL
+  site_data$pedon_id <- NULL
   
   # TODO: duplicating surface fine gravel column with old name for backward compatibility
   site_data$surface_fgravel <- site_data$surface_fine_gravel

--- a/R/fetchVegdata.R
+++ b/R/fetchVegdata.R
@@ -60,7 +60,7 @@ fetchVegdata <- function(SS = TRUE, include_pedon = TRUE, stringsAsFactors = NUL
   
   # add peiid information to vegplot
   if (is.character(include_pedon) && include_pedon == "assocuserpedonid") {
-    match.idx <- match(vegplot$pedon_id, site$pedon_id)  # TODO: remove alias for assocuserpedonid
+    match.idx <- match(vegplot$assocuserpedonid, site$upedonid)
     vegplot$peiid <- site$peiid[match.idx]
   } else if (isTRUE(include_pedon)) {
     # any pedon linked to the same site is included (may cause duplication)

--- a/R/getHzErrorsNASIS.R
+++ b/R/getHzErrorsNASIS.R
@@ -7,7 +7,7 @@
 #' @param dsn Optional: path to local SQLite database containing NASIS
 #' table structure; default: NULL
 #' @return A data.frame containing problematic records with columns:
-#' 'peiid','pedon_id','hzdept','hzdepb','hzname'
+#' 'peiid','upedonid','hzdept','hzdepb','hzname'
 #' @export 
 getHzErrorsNASIS <- function(strict = TRUE, SS = TRUE, dsn = NULL) {
 
@@ -17,17 +17,17 @@ getHzErrorsNASIS <- function(strict = TRUE, SS = TRUE, dsn = NULL) {
   
 	# get data
 	site_data <- get_site_data_from_NASIS_db(SS = SS, dsn = dsn)
-	site_data$pedon_id <- NULL
+	site_data$upedonid <- NULL
 	hz_data <- get_hz_data_from_NASIS_db(SS = SS, dsn = dsn)
 
 	if (nrow(site_data) == 0) {
 	  message("No Site records in NASIS database")
-  	return(data.frame(pedon_id = character(0), valid = logical(0)))
+  	return(data.frame(upedonid = character(0), valid = logical(0)))
 	}
 
 	if (nrow(hz_data) == 0) {
 	  message("No Pedon Horizon records in NASIS database")
-	  return(data.frame(pedon_id = character(0), valid = logical(0)))
+	  return(data.frame(upedonid = character(0), valid = logical(0)))
 	}
 
 	# combine pieces
@@ -36,10 +36,10 @@ getHzErrorsNASIS <- function(strict = TRUE, SS = TRUE, dsn = NULL) {
 	f.test <- aqp::checkHzDepthLogic(f, hzdepths = c('hzdept', 'hzdepb'), idname = 'peiid', fast = TRUE)
 
 	# find bad ones
-	bad.pedon.ids <- as.character(f.test$pedon_id[which(f.test$valid == FALSE)])
+	bad.pedon.ids <- as.character(f.test$upedonid[which(f.test$valid == FALSE)])
 
 	# now describe the problems
-	b <- f[which(f$pedon_id %in% bad.pedon.ids), c('peiid', 'pedon_id','hzdept','hzdepb','hzname')]
+	b <- f[which(f$pedon_id %in% bad.pedon.ids), c('peiid', 'upedonid','hzdept','hzdepb','hzname')]
 
 	return(b)
 

--- a/R/get_component_data_from_NASIS_db.R
+++ b/R/get_component_data_from_NASIS_db.R
@@ -589,7 +589,7 @@ get_comonth_from_NASIS_db <- function(SS = TRUE,
 #' @rdname get_component_data_from_NASIS_db
 get_copedon_from_NASIS_db <- function(SS = TRUE, dsn = NULL) {
 
-  q <- "SELECT coiidref as coiid, peiidref as peiid, upedonid as pedon_id, rvindicator as representative
+  q <- "SELECT coiidref as coiid, peiidref as peiid, upedonid, rvindicator as representative
 
   FROM copedon_View_1 copedon
 
@@ -610,7 +610,7 @@ get_copedon_from_NASIS_db <- function(SS = TRUE, dsn = NULL) {
   d <- dbQueryNASIS(channel, q)
 
   # missing pedon ID suggests records not in the selected set or local database
-  if(nrow(d) > 0 & any(is.na(d$pedon_id))) {
+  if(nrow(d) > 0 & any(is.na(d$upedonid))) {
     message('some linked pedons not in selected set or local database')
   }
 

--- a/R/get_component_data_from_NASIS_db.R
+++ b/R/get_component_data_from_NASIS_db.R
@@ -589,7 +589,9 @@ get_comonth_from_NASIS_db <- function(SS = TRUE,
 #' @rdname get_component_data_from_NASIS_db
 get_copedon_from_NASIS_db <- function(SS = TRUE, dsn = NULL) {
 
-  q <- "SELECT coiidref as coiid, peiidref as peiid, upedonid, rvindicator as representative
+  .soilDB_warn_deprecated_aliases(c("upedonid" = "pedon_id", "rvindicator" = "representative"))
+  
+  q <- "SELECT coiidref as coiid, peiidref as peiid, upedonid as pedon_id, upedonid, rvindicator as representative, rvindicator
 
   FROM copedon_View_1 copedon
 

--- a/R/get_ecosite_history_from_NASIS_db.R
+++ b/R/get_ecosite_history_from_NASIS_db.R
@@ -17,7 +17,7 @@ get_ecosite_history_from_NASIS_db <- function(best = TRUE, SS = TRUE, es_classif
   
   # ecological site
   q.ecosite <- "SELECT siteiidref AS siteiid, ecositeid, ecositenm, ecositecorrdate, seh.recwlupdated,
-                       classifier As es_classifier, classifier AS [siteecositehistory.classifier]
+                       classifier AS [siteecositehistory.classifier]
   FROM siteecositehistory_View_1 AS seh
   LEFT OUTER JOIN ecologicalsite AS es ON es.ecositeiid=seh.ecositeiidref
   ORDER BY siteiid;"

--- a/R/get_ecosite_history_from_NASIS_db.R
+++ b/R/get_ecosite_history_from_NASIS_db.R
@@ -13,11 +13,13 @@
 #' @export
 get_ecosite_history_from_NASIS_db <- function(best = TRUE, SS = TRUE, es_classifier = NULL, dsn = NULL) {
   
+  .soilDB_warn_deprecated_aliases(c("siteecositehistory.classifier" = "es_classifier"))
+  
   .SD <- NULL
   
   # ecological site
   q.ecosite <- "SELECT siteiidref AS siteiid, ecositeid, ecositenm, ecositecorrdate, seh.recwlupdated,
-                       classifier AS [siteecositehistory.classifier]
+                       classifier AS es_classifier, classifier AS [siteecositehistory.classifier]
   FROM siteecositehistory_View_1 AS seh
   LEFT OUTER JOIN ecologicalsite AS es ON es.ecositeiid=seh.ecositeiidref
   ORDER BY siteiid;"

--- a/R/get_hz_data_from_NASIS_db.R
+++ b/R/get_hz_data_from_NASIS_db.R
@@ -33,15 +33,12 @@ get_hz_data_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
   
-  q <- sprintf("SELECT peiid, phiid, upedonid as pedon_id,
-  hzname, dspcomplayerid as genhz, hzdept, hzdepb,
-  bounddistinct, boundtopo,
-  claytotest AS clay, CASE WHEN silttotest IS NULL THEN 100 - (claytotest + sandtotest) ELSE silttotest END AS silt,
-  sandtotest AS sand, fragvoltot, texture, texcl, lieutex, phfield, effclass, phs.labsampnum, rupresblkdry, rupresblkmst, rupresblkcem, stickiness, plasticity, ksatpedon
-
-  FROM
-
-  pedon_View_1 p
+  q <- sprintf("SELECT peiid, phiid, upedonid,
+    hzname, dspcomplayerid, hzdept, hzdepb,
+    bounddistinct, boundtopo, claytotest, silttotest, sandtotest, 
+    fragvoltot, texture, texcl, lieutex, phfield, effclass, phs.labsampnum, 
+    rupresblkdry, rupresblkmst, rupresblkcem, stickiness, plasticity, ksatpedon
+  FROM pedon_View_1 p
   %s JOIN phorizon_View_1 ph ON ph.peiidref = p.peiid
   LEFT OUTER JOIN phsample_View_1 phs ON phs.phiidref = ph.phiid
   LEFT OUTER JOIN

--- a/R/get_hz_data_from_NASIS_db.R
+++ b/R/get_hz_data_from_NASIS_db.R
@@ -33,9 +33,14 @@ get_hz_data_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
   
-  q <- sprintf("SELECT peiid, phiid, upedonid,
+  .soilDB_warn_deprecated_aliases(c("upedonid" = "pedon_id", "claytotest" = "clay", "silttotest" = "silt", "sandtotest" = "sand"))
+  
+  q <- sprintf("SELECT peiid, phiid, upedonid AS pedon_id, upedonid,
     hzname, dspcomplayerid, hzdept, hzdepb,
     bounddistinct, boundtopo, claytotest, silttotest, sandtotest, 
+    claytotest AS clay,
+    CASE WHEN silttotest IS NULL THEN 100 - (claytotest + sandtotest) ELSE silttotest END AS silt,
+    sandtotest AS sand,
     fragvoltot, texture, texcl, lieutex, phfield, effclass, phs.labsampnum, 
     rupresblkdry, rupresblkmst, rupresblkcem, stickiness, plasticity, ksatpedon
   FROM pedon_View_1 p

--- a/R/get_hz_data_from_pedon_db.R
+++ b/R/get_hz_data_from_pedon_db.R
@@ -26,7 +26,7 @@ get_hz_data_from_pedon_db <- function(dsn) {
   if(!requireNamespace('odbc'))
     stop('please install the `odbc` package', call.=FALSE)
   
-	q <- "SELECT pedon.peiid, phorizon.phiid, pedon.upedonid as pedon_id, phorizon.hzname, phorizon.hzdept, phorizon.hzdepb,
+	q <- "SELECT pedon.peiid, phorizon.phiid, pedon.upedonid, phorizon.hzname, phorizon.hzdept, phorizon.hzdepb,
   phorizon.claytotest AS clay, IIF(IsNULL(phorizon.silttotest), (100 - (phorizon.sandtotest + phorizon.claytotest)), phorizon.silttotest) AS silt, phorizon.sandtotest AS sand, texture, phfield, phnaf, eff.choice AS effervescence, l.labsampnum, IIF(IsNULL(f.total_frags_pct), 0, f.total_frags_pct) AS total_frags_pct, fragvoltot
 	FROM (
 	(
@@ -50,7 +50,7 @@ get_hz_data_from_pedon_db <- function(dsn) {
 	# test for duplicate horizons: due to bugs in our queries that lead to >1 row/hz
 	hz.tab <- table(d$phiid)
 	dupe.hz <- which(hz.tab > 1)
-	dupe.hz.pedon.ids <- d$pedon_id[d$phiid %in% names(hz.tab[dupe.hz])]
+	dupe.hz.pedon.ids <- d$upedonid[d$phiid %in% names(hz.tab[dupe.hz])]
 	
 	if(length(dupe.hz) > 0) {
 		message(paste('notice: duplicate horizons in query results, matching pedons:\n', paste(unique(dupe.hz.pedon.ids), collapse=','), sep=''))

--- a/R/get_hz_data_from_pedon_db.R
+++ b/R/get_hz_data_from_pedon_db.R
@@ -26,7 +26,7 @@ get_hz_data_from_pedon_db <- function(dsn) {
   if(!requireNamespace('odbc'))
     stop('please install the `odbc` package', call.=FALSE)
   
-	q <- "SELECT pedon.peiid, phorizon.phiid, pedon.upedonid, phorizon.hzname, phorizon.hzdept, phorizon.hzdepb,
+	q <- "SELECT pedon.peiid, phorizon.phiid, pedon.upedonid AS pedon_id, pedon.upedonid, phorizon.hzname, phorizon.hzdept, phorizon.hzdepb,
   phorizon.claytotest AS clay, IIF(IsNULL(phorizon.silttotest), (100 - (phorizon.sandtotest + phorizon.claytotest)), phorizon.silttotest) AS silt, phorizon.sandtotest AS sand, texture, phfield, phnaf, eff.choice AS effervescence, l.labsampnum, IIF(IsNULL(f.total_frags_pct), 0, f.total_frags_pct) AS total_frags_pct, fragvoltot
 	FROM (
 	(

--- a/R/get_site_data_from_NASIS_db.R
+++ b/R/get_site_data_from_NASIS_db.R
@@ -41,6 +41,19 @@ get_site_data_from_NASIS_db <- function(SS = TRUE,
                                         nullFragsAreZero = TRUE,
                                         stringsAsFactors = NULL,
                                         dsn = NULL) {
+  
+  .soilDB_warn_deprecated_aliases(
+    c(
+      "upedonid" = "pedon_id",
+      "longstddecimaldegrees" = "x_std",
+      "latstddecimaldegrees" = "y_std",
+      "descname" = "describer",
+      "elev" = "elev_field",
+      "slope" = "slope_field",
+      "aspect" = "aspect_field"
+    )
+  )
+  
   .SD <- NULL
   
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
@@ -49,11 +62,12 @@ get_site_data_from_NASIS_db <- function(SS = TRUE,
   }
   
 	q <- paste0("SELECT siteiid, siteobsiid, usiteid, 
-  	", ifelse(include_pedon, "peiid, upedonid, ", ""), "
+  	", ifelse(include_pedon, "peiid, CAST(upedonid AS varchar(60)) as pedon_id, upedonid, ", ""), "
   	obsdate, utmzone, utmeasting, utmnorthing, horizdatnm,
   	longstddecimaldegrees, latstddecimaldegrees, gpspositionalerror, 
-    ", ifelse(include_pedon, "descname, pedonpurpose, pedontype, pedlabsampnum, labdatadescflag, 
+    ", ifelse(include_pedon, "descname AS describer, descname, pedonpurpose, pedontype, pedlabsampnum, labdatadescflag, 
     tsectstopnum, tsectinterval, utransectid, tsectkind, tsectselmeth, erocl,", ""), "
+    elev as elev_field, slope as slope_field, aspect as aspect_field,
     elev, slope, aspect, 
     ecostatename, ecostateid, commphasename, commphaseid, plantassocnm, 
     siteobs_View_1.earthcovkind1, siteobs_View_1.earthcovkind2, 

--- a/R/get_site_data_from_NASIS_db.R
+++ b/R/get_site_data_from_NASIS_db.R
@@ -48,12 +48,13 @@ get_site_data_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
   
-	q <- paste0("SELECT siteiid, siteobsiid, CAST(usiteid AS varchar(60)) as site_id, 
-  	", ifelse(include_pedon, "peiid, CAST(upedonid AS varchar(60)) as pedon_id, ", ""), "
-  	obsdate as obs_date, utmzone, utmeasting, utmnorthing, horizdatnm, 
-    longstddecimaldegrees as x_std, latstddecimaldegrees as y_std, longstddecimaldegrees, latstddecimaldegrees, gpspositionalerror, 
-    ", ifelse(include_pedon, "descname as describer, pedonpurpose, pedontype, pedlabsampnum, labdatadescflag, tsectstopnum, tsectinterval, utransectid, tsectkind, tsectselmeth, erocl,", ""), "
-    elev as elev_field, slope as slope_field, aspect as aspect_field, 
+	q <- paste0("SELECT siteiid, siteobsiid, usiteid, 
+  	", ifelse(include_pedon, "peiid, upedonid, ", ""), "
+  	obsdate, utmzone, utmeasting, utmnorthing, horizdatnm,
+  	longstddecimaldegrees, latstddecimaldegrees, gpspositionalerror, 
+    ", ifelse(include_pedon, "descname, pedonpurpose, pedontype, pedlabsampnum, labdatadescflag, 
+    tsectstopnum, tsectinterval, utransectid, tsectkind, tsectselmeth, erocl,", ""), "
+    elev, slope, aspect, 
     ecostatename, ecostateid, commphasename, commphaseid, plantassocnm, 
     siteobs_View_1.earthcovkind1, siteobs_View_1.earthcovkind2, 
     bedrckdepth, bedrckkind, bedrckhardness, pmgroupname, 
@@ -209,7 +210,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	# 	message('multiple horizontal datums present, consider using WGS84 coordinates (x_std, y_std)')
 
 	# are there any duplicate pedon IDs?
-	t.pedon_id <- table(d2$pedon_id)
+	t.pedon_id <- table(d2$upedonid)
 	not.unique.pedon_id <- t.pedon_id > 1
 	if (any(not.unique.pedon_id))
 	  assign('dup.pedon.ids', value = names(t.pedon_id[which(not.unique.pedon_id)]), envir = get_soilDB_env())
@@ -217,7 +218,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	# warn about sites without a matching pedon (records missing peiid)
 	missing.pedon <- which(is.na(d2$peiid))
 	if (length(missing.pedon) > 0)
-	  assign('sites.missing.pedons', value = unique(d2$site_id[missing.pedon]), envir = get_soilDB_env())
+	  assign('sites.missing.pedons', value = unique(d2$usiteid[missing.pedon]), envir = get_soilDB_env())
 
   ## set factor levels, when it makes sense
 	# most of these are done via uncode()

--- a/R/get_text_notes_from_NASIS_db.R
+++ b/R/get_text_notes_from_NASIS_db.R
@@ -40,7 +40,7 @@ get_text_notes_from_NASIS_db <- function(SS=TRUE, fixLineEndings=TRUE, dsn = NUL
 	q.sitetext <- "SELECT recdate, recauthor, sitetextkind, textcat, textsubcat, siteiidref AS siteiid, sitetextiid, CAST(textentry as text) AS textentry FROM sitetext_View_1;"
 
 	# siteobstext
-	q.siteobstext <- "SELECT recdate, recauthor, siteobstextkind, textcat, textsubcat, siteiidref AS site_id, siteobstextiid, CAST(textentry as text) AS textentry FROM (
+	q.siteobstext <- "SELECT recdate, recauthor, siteobstextkind, textcat, textsubcat, siteiidref AS siteiid, siteobstextiid, CAST(textentry as text) AS textentry FROM (
 siteobs_View_1 LEFT OUTER JOIN
 siteobstext_View_1 ON siteobs_View_1.siteobsiid = siteobstext_View_1.siteobsiidref);"
 
@@ -48,7 +48,7 @@ siteobstext_View_1 ON siteobs_View_1.siteobsiid = siteobstext_View_1.siteobsiidr
 	q.phtext <- "SELECT recdate, recauthor, phorizontextkind, textcat, textsubcat, phiidref AS phiid, phtextiid, CAST(textentry as text) AS textentry FROM phtext_View_1;"
 
 	# photo links
-	q.photos <- "SELECT recdate, recauthor, siteobstextkind, textcat, textsubcat, siteiidref AS site_id, siteobstextiid, CAST(textentry as text) AS textentry FROM (siteobs_View_1 LEFT OUTER JOIN siteobstext_View_1 ON siteobs_View_1.siteobsiid = siteobstext_View_1.siteobsiidref) WHERE siteobstext_View_1.textcat LIKE 'Photo%' ORDER BY siteobstext_View_1.siteobstextkind;"
+	q.photos <- "SELECT recdate, recauthor, siteobstextkind, textcat, textsubcat, siteiidref AS siteiid, siteobstextiid, CAST(textentry as text) AS textentry FROM (siteobs_View_1 LEFT OUTER JOIN siteobstext_View_1 ON siteobs_View_1.siteobsiid = siteobstext_View_1.siteobsiidref) WHERE siteobstext_View_1.textcat LIKE 'Photo%' ORDER BY siteobstext_View_1.siteobstextkind;"
 
 	# toggle selected set vs. local DB
 	if (SS == FALSE) {

--- a/R/get_text_notes_from_NASIS_db.R
+++ b/R/get_text_notes_from_NASIS_db.R
@@ -32,7 +32,9 @@
 #'
 #' @export get_text_notes_from_NASIS_db
 get_text_notes_from_NASIS_db <- function(SS=TRUE, fixLineEndings=TRUE, dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("siteiid" = "site_id"))
+  
 	# petext
 	q.petext <- "SELECT recdate, recauthor, pedontextkind, textcat, textsubcat, peiidref AS peiid, petextiid, CAST(textentry as text) AS textentry FROM petext_View_1;"
 

--- a/R/get_veg_data_from_NASIS_db.R
+++ b/R/get_veg_data_from_NASIS_db.R
@@ -29,7 +29,9 @@
 #' 
 #' @export get_veg_data_from_NASIS_db
 get_veg_data_from_NASIS_db <- function(SS=TRUE, dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("vegtransplantsummiid" = "vstpiid"))
+  
   # existing veg
   # NOTE: left join of siteobs:vegplot ensures that all site/siteobs are in this result, 
   #       records will be NA filled when no vegplot available
@@ -46,7 +48,7 @@ get_veg_data_from_NASIS_db <- function(SS=TRUE, dsn = NULL) {
   }
   
   # veg transect
-  q.vegtransect <- "SELECT siteiid, vegplotiid, vegplotid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose, assocuserpedonid, vegtransectid, vegtransplantsummiid, transectlength, plantsym, plantsciname, plantnatvernm
+  q.vegtransect <- "SELECT siteiid, vegplotiid, vegplotid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose, assocuserpedonid, vegtransectid, vegtransplantsummiid AS vtpsiid, vegtransplantsummiid, transectlength, plantsym, plantsciname, plantnatvernm
   
     FROM site_View_1 AS s
     INNER JOIN siteobs ON siteobs.siteiidref=s.siteiid

--- a/R/get_veg_data_from_NASIS_db.R
+++ b/R/get_veg_data_from_NASIS_db.R
@@ -46,7 +46,7 @@ get_veg_data_from_NASIS_db <- function(SS=TRUE, dsn = NULL) {
   }
   
   # veg transect
-  q.vegtransect <- "SELECT siteiid, vegplotiid, vegplotid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose, assocuserpedonid, vegtransectid, vegtransplantsummiid vtpsiid, transectlength, plantsym, plantsciname, plantnatvernm
+  q.vegtransect <- "SELECT siteiid, vegplotiid, vegplotid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose, assocuserpedonid, vegtransectid, vegtransplantsummiid, transectlength, plantsym, plantsciname, plantnatvernm
   
     FROM site_View_1 AS s
     INNER JOIN siteobs ON siteobs.siteiidref=s.siteiid

--- a/R/get_vegplot_data_from_NASIS_db.R
+++ b/R/get_vegplot_data_from_NASIS_db.R
@@ -267,7 +267,7 @@ get_vegplot_transect_from_NASIS_db <-  function(SS = TRUE,
   }
 
   # veg transect data - many transects to one vegplot
-  q.vegtransect <- "SELECT siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiidref, vegtransectiid,
+  q.vegtransect <- "SELECT siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiid, vegtransectiid,
     usiteid AS site_id, usiteid, assocuserpedonid AS pedon_id, assocuserpedonid, 
     vegplotid AS vegplot_id, vegplotid, vegplotname, vegtransectid as vegtransect_id, vegtransectid, 
     obsdate, primarydatacollector, datacollectionpurpose, transectstartlatitude, 
@@ -463,7 +463,7 @@ get_vegplot_tree_si_summary_from_NASIS_db <-  function(SS = TRUE,
   }
 
   # plot tree site index summary data
-  q.pltsis <- "SELECT siteiid, siteobsiid, vegplotiid, pltsis.seqnum, plantiidref, plantsym, plantsciname, plantnatvernm, plantnativity, siteindexbase, speciestreecount, siteindexplotave, speciesdbhaverage, treeageave, treecanopyhttopave, plottreesiteindsumiid
+  q.pltsis <- "SELECT siteiid, siteobsiid, vegplotiid, pltsis.seqnum, plantiid, plantsym, plantsciname, plantnatvernm, plantnativity, siteindexbase, speciestreecount, siteindexplotave, speciesdbhaverage, treeageave, treecanopyhttopave, plottreesiteindsumiid
 
   FROM
   site_View_1 AS s
@@ -534,7 +534,7 @@ get_vegplot_tree_si_details_from_NASIS_db <- function(SS = TRUE,
                                                       dsn = NULL) {
 
   # plot tree site index detail data
-  q.pltsid <- "SELECT  siteiid, siteobsiid, vegplotiid, plottreesiteindsumiidref, pltsid.seqnum, plantsym, plantsciname, plantnatvernm, treenumber, crownclass, reproductionsource, treediameterbreastheight, tenyeargrowthradius, growthringcount, growthringcountheight, growthringcountage, treeage, treecanopyhtbottom, treecanopyhttop, plottreesiteinddetailsiid
+  q.pltsid <- "SELECT  siteiid, siteobsiid, vegplotiid, plottreesiteindsumiid, pltsid.seqnum, plantsym, plantsciname, plantnatvernm, treenumber, crownclass, reproductionsource, treediameterbreastheight, tenyeargrowthradius, growthringcount, growthringcountheight, growthringcountage, treeage, treecanopyhtbottom, treecanopyhttop, plottreesiteinddetailsiid
 
   FROM
   site_View_1 AS s

--- a/R/get_vegplot_data_from_NASIS_db.R
+++ b/R/get_vegplot_data_from_NASIS_db.R
@@ -5,14 +5,16 @@
 get_vegplot_from_NASIS_db <- function(SS = TRUE,
                                       stringsAsFactors = NULL,
                                       dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("usiteid" = "site_id", "assocuserpedonid" = "pedon_id", "vegplotid" = "vegplot_id"))
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
-  q.vegplot <- "SELECT siteiid, so.siteobsiid, usiteid, assocuserpedonid, 
-    v.vegplotid, vegplotiid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose,
+  q.vegplot <- "SELECT siteiid, so.siteobsiid, usiteid AS site_id, usiteid, assocuserpedonid as pedon_id, assocuserpedonid, 
+    v.vegplotid AS vegplot_id, v.vegplotid, vegplotiid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose,
     vegdataorigin, vegplotsize, soilprofileindicator, soil232idlegacy, ahorizondepth, alkalinesalineindicator,
     alkalineaffected, salinityclass, restrictivelayerdepthlegacy, legacysoilcompname, legacysoilphase, 
     legacylocalsoilphase, legacysoilsurftext, legacysurftextmod, legacyterminlieu, erosionclasslegacy, 
@@ -84,14 +86,16 @@ get_vegplot_from_NASIS_db <- function(SS = TRUE,
 get_vegplot_location_from_NASIS_db <- function(SS = TRUE,
                                                stringsAsFactors = NULL,
                                                dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("usiteid" = "site_id", "vegplotid" = "vegplot_id"))
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
   # query the coordinate, plss description, and site characteristics data for these records from the site table
-  q.plotlocation <- "SELECT s.siteiid, so.siteobsiid, s.usiteid, v.vegplotid, vegplotiid, so.obsdate, v.datacollectionpurpose, latdegrees, latminutes, latseconds, latdir, longdegrees, longminutes, longseconds, longdir, horizdatnm, plsssection, plsstownship, plssrange, plssmeridian, utmzone, utmnorthing, utmeasting, latstddecimaldegrees, longstddecimaldegrees, geocoordsource, elev, slope, aspect, CAST(plsssdetails as text) AS plsssdetails, CAST(locdesc as text) AS locdesc
+  q.plotlocation <- "SELECT s.siteiid, so.siteobsiid, s.usiteid AS site_id, s.usiteid, v.vegplotid AS vegplot_id, v.vegplotid, vegplotiid, so.obsdate, v.datacollectionpurpose, latdegrees, latminutes, latseconds, latdir, longdegrees, longminutes, longseconds, longdir, horizdatnm, plsssection, plsstownship, plssrange, plssmeridian, utmzone, utmnorthing, utmeasting, latstddecimaldegrees, longstddecimaldegrees, geocoordsource, elev, slope, aspect, CAST(plsssdetails as text) AS plsssdetails, CAST(locdesc as text) AS locdesc
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid
@@ -151,13 +155,15 @@ get_vegplot_location_from_NASIS_db <- function(SS = TRUE,
 get_vegplot_trhi_from_NASIS_db <- function(SS = TRUE,
                                            stringsAsFactors = NULL,
                                            dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("usiteid" = "site_id", "assocuserpedonid" = "pedon_id", "vegplotid" = "vegplot_id"))
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
-  q.vegplotrhi <- "SELECT siteiid, so.siteobsiid, p.peiid, usiteid, assocuserpedonid, v.vegplotid, vegplotiid, vegplotname, obsdate, rhiannualprod, rhibareground, rhicompactionlayer, rhifuncstructgroups, rhierosionresistance, rhigullies, rhirills, rhipedastalsterracettes, rhiinfilrunoff, rhilitteramount, rhilittermovement, rhiplantmortality, rhireprodcapability, rhiinvasiveplants, rhisoilsurfdegradation, rhiwaterflowpatterns, rhiwindscourareas, rhisoilsitestabsumm, rhibioticintegritysumm, rhihydrofunctionsumm
+  q.vegplotrhi <- "SELECT siteiid, so.siteobsiid, p.peiid, usiteid AS site_id, usiteid, assocuserpedonid AS pedon_id, assocuserpedonid, v.vegplotid AS vegplot_id, v.vegplotid, vegplotiid, vegplotname, obsdate, rhiannualprod, rhibareground, rhicompactionlayer, rhifuncstructgroups, rhierosionresistance, rhigullies, rhirills, rhipedastalsterracettes, rhiinfilrunoff, rhilitteramount, rhilittermovement, rhiplantmortality, rhireprodcapability, rhiinvasiveplants, rhisoilsurfdegradation, rhiwaterflowpatterns, rhiwindscourareas, rhisoilsitestabsumm, rhibioticintegritysumm, rhihydrofunctionsumm
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid
@@ -197,7 +203,7 @@ get_vegplot_trhi_from_NASIS_db <- function(SS = TRUE,
 get_vegplot_species_from_NASIS_db <-  function(SS = TRUE,
                                                stringsAsFactors = NULL,
                                                dsn = NULL) {
-
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)
@@ -252,14 +258,34 @@ get_vegplot_species_from_NASIS_db <-  function(SS = TRUE,
 get_vegplot_transect_from_NASIS_db <-  function(SS = TRUE,
                                                 stringsAsFactors = NULL,
                                                 dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("usiteid" = "site_id", "assocuserpedonid" = "pedon_id", "vegplotid" = "vegplot_id", "vegtransectid" = "vegtransect_id"))
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
   # veg transect data - many transects to one vegplot
-  q.vegtransect <- "SELECT  siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiidref, vegtransectiid, usiteid, assocuserpedonid, vegplotid, vegplotname, vegtransectid, obsdate, primarydatacollector, datacollectionpurpose, transectstartlatitude, transectstartlongitude, transectendlatitude, transectendlongitude, transectazimuth, transectlength, transectstartelevation, transectendelevation, dblsampquadratssampled, dblsampquadratsclipped, nestedfreqquadratssampled, freqquadratssampled, dwrquadratssampled, daubenmirequadratssampled, quadratsizedomlegacy, quadratsizeseclegacy, quadratshapedomlegacy, quadratshapeseclegacy, beltwidth, dblsampannualprod, totharvestannualprod, wtunitannualprod, dwrannualprod, comparativeyieldprod, comparativeyieldranktotal, comparativeyieldrankave, comparativerefclipwtave, abovegroundbiomasstotal, standingherbbiomass, transectbasalcovpct, basalcovpcttotal, basalgapsizemin, canopygapsizemin, gapsmeasuredbetween, canopygaplengthtotal, canopygappcttotal, basalgaplengthtotal, basalgappcttotal, vt.understoryreprodabundance, vt.woodyunderstoryabundance, vt.herbundertoryabundance, vt.lichensunderstoryabundance, cancovpcttotaltrans, cancovtotalclasstrans, cancovassessmethod, vt.crowncanclosurepct, vt.crowncancloseassessmethod, vt.crowncompfactorlpp, vt.crowncomplppavedbh, overstorycancovpcttrans, overstorycancovclasstrans, groundcovassessmethod, groundcovquadratssampled, groundcovpointssampled, groundsurfcovassessmethod, groundsurfcovquadratsamp, groundsurfcovpointssamp, lpiobsinterval, totalpointssampledcount, topcanopyhtave, topcanopyhtstddev, totalnumplantsbelt, totalnumspeciesbelt, totalplantdensitybelt
+  q.vegtransect <- "SELECT siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiidref, vegtransectiid,
+    usiteid AS site_id, usiteid, assocuserpedonid AS pedon_id, assocuserpedonid, 
+    vegplotid AS vegplot_id, vegplotid, vegplotname, vegtransectid as vegtransect_id, vegtransectid, 
+    obsdate, primarydatacollector, datacollectionpurpose, transectstartlatitude, 
+    transectstartlongitude, transectendlatitude, transectendlongitude, transectazimuth, transectlength,
+    transectstartelevation, transectendelevation, dblsampquadratssampled, dblsampquadratsclipped, 
+    nestedfreqquadratssampled, freqquadratssampled, dwrquadratssampled, daubenmirequadratssampled,
+    quadratsizedomlegacy, quadratsizeseclegacy, quadratshapedomlegacy, quadratshapeseclegacy, 
+    beltwidth, dblsampannualprod, totharvestannualprod, wtunitannualprod, dwrannualprod, comparativeyieldprod,
+    comparativeyieldranktotal, comparativeyieldrankave, comparativerefclipwtave, abovegroundbiomasstotal,
+    standingherbbiomass, transectbasalcovpct, basalcovpcttotal, basalgapsizemin, canopygapsizemin, 
+    gapsmeasuredbetween, canopygaplengthtotal, canopygappcttotal, basalgaplengthtotal, basalgappcttotal, 
+    vt.understoryreprodabundance, vt.woodyunderstoryabundance, vt.herbundertoryabundance, 
+    vt.lichensunderstoryabundance, cancovpcttotaltrans, cancovtotalclasstrans, cancovassessmethod,
+    vt.crowncanclosurepct, vt.crowncancloseassessmethod, vt.crowncompfactorlpp, vt.crowncomplppavedbh, 
+    overstorycancovpcttrans, overstorycancovclasstrans, groundcovassessmethod, groundcovquadratssampled, 
+    groundcovpointssampled, groundsurfcovassessmethod, groundsurfcovquadratsamp, groundsurfcovpointssamp, 
+    lpiobsinterval, totalpointssampledcount, topcanopyhtave, topcanopyhtstddev, totalnumplantsbelt,
+    totalnumspeciesbelt, totalplantdensitybelt
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid
@@ -308,7 +334,7 @@ get_vegplot_transpecies_from_NASIS_db <-  function(SS = TRUE,
 
   # veg transect species data - many species to one veg transect
   q.vtps <- "SELECT siteiid, siteobsiid, vegplotiid, vegtransectiidref as vegtransectiid, vegplotid, vegplotname,
-    obsdate, vegtransplantsummiid, vtps.seqnum, plantsym, plantsciname,
+    obsdate, vegtransplantsummiid AS vstpiid, vegtransplantsummiid, vtps.seqnum, plantsym, plantsciname,
     plantnatvernm, plantnativity, planttypegroup,
     plantheightcllowerlimit, plantheightclupperlimit, sociabilityclass,
     specieslivecanhtbotave, specieslivecanhttopave, overstorydbhmin,

--- a/R/get_vegplot_data_from_NASIS_db.R
+++ b/R/get_vegplot_data_from_NASIS_db.R
@@ -11,8 +11,8 @@ get_vegplot_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
-  q.vegplot <- "SELECT siteiid, so.siteobsiid, usiteid as site_id, assocuserpedonid as pedon_id, 
-    v.vegplotid as vegplot_id, vegplotiid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose,
+  q.vegplot <- "SELECT siteiid, so.siteobsiid, usiteid, assocuserpedonid, 
+    v.vegplotid, vegplotiid, vegplotname, obsdate, primarydatacollector, datacollectionpurpose,
     vegdataorigin, vegplotsize, soilprofileindicator, soil232idlegacy, ahorizondepth, alkalinesalineindicator,
     alkalineaffected, salinityclass, restrictivelayerdepthlegacy, legacysoilcompname, legacysoilphase, 
     legacylocalsoilphase, legacysoilsurftext, legacysurftextmod, legacyterminlieu, erosionclasslegacy, 
@@ -91,7 +91,7 @@ get_vegplot_location_from_NASIS_db <- function(SS = TRUE,
   }
 
   # query the coordinate, plss description, and site characteristics data for these records from the site table
-  q.plotlocation <- "SELECT s.siteiid, so.siteobsiid, s.usiteid as site_id, v.vegplotid as vegplot_id, vegplotiid, so.obsdate, v.datacollectionpurpose, latdegrees, latminutes, latseconds, latdir, longdegrees, longminutes, longseconds, longdir, horizdatnm, plsssection, plsstownship, plssrange, plssmeridian, utmzone, utmnorthing, utmeasting, latstddecimaldegrees, longstddecimaldegrees, geocoordsource, elev, slope, aspect, CAST(plsssdetails as text) AS plsssdetails, CAST(locdesc as text) AS locdesc
+  q.plotlocation <- "SELECT s.siteiid, so.siteobsiid, s.usiteid, v.vegplotid, vegplotiid, so.obsdate, v.datacollectionpurpose, latdegrees, latminutes, latseconds, latdir, longdegrees, longminutes, longseconds, longdir, horizdatnm, plsssection, plsstownship, plssrange, plssmeridian, utmzone, utmnorthing, utmeasting, latstddecimaldegrees, longstddecimaldegrees, geocoordsource, elev, slope, aspect, CAST(plsssdetails as text) AS plsssdetails, CAST(locdesc as text) AS locdesc
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid
@@ -125,12 +125,12 @@ get_vegplot_location_from_NASIS_db <- function(SS = TRUE,
   load(system.file("data/state_FIPS_codes.rda", package = "soilDB"))
 
   # add ESIS_id
-  fips <- substr(d$site_id, 3, 5)
-  fips_state <- substr(d$site_id, 1, 2)
+  fips <- substr(d$usiteid, 3, 5)
+  fips_state <- substr(d$usiteid, 1, 2)
   idx <- match(fips_state, state_FIPS_codes$state_alpha)
   fips_state_num <- state_FIPS_codes$state_fips[idx]
-  year <- substr(d$site_id, 8, 9)
-  sitenum <- substr(d$site_id, 10, 12)
+  year <- substr(d$usiteid, 8, 9)
+  sitenum <- substr(d$usiteid, 10, 12)
   d$ESIS_id <- paste(sitenum, year, fips_state_num, fips, sep = '')
 
   # clean PLSS TRS data
@@ -157,7 +157,7 @@ get_vegplot_trhi_from_NASIS_db <- function(SS = TRUE,
     NASISDomainsAsFactor(stringsAsFactors)
   }
 
-  q.vegplotrhi <- "SELECT siteiid, so.siteobsiid, p.peiid, usiteid as site_id, assocuserpedonid as pedon_id, v.vegplotid as vegplot_id, vegplotiid, vegplotname, obsdate, rhiannualprod, rhibareground, rhicompactionlayer, rhifuncstructgroups, rhierosionresistance, rhigullies, rhirills, rhipedastalsterracettes, rhiinfilrunoff, rhilitteramount, rhilittermovement, rhiplantmortality, rhireprodcapability, rhiinvasiveplants, rhisoilsurfdegradation, rhiwaterflowpatterns, rhiwindscourareas, rhisoilsitestabsumm, rhibioticintegritysumm, rhihydrofunctionsumm
+  q.vegplotrhi <- "SELECT siteiid, so.siteobsiid, p.peiid, usiteid, assocuserpedonid, v.vegplotid, vegplotiid, vegplotname, obsdate, rhiannualprod, rhibareground, rhicompactionlayer, rhifuncstructgroups, rhierosionresistance, rhigullies, rhirills, rhipedastalsterracettes, rhiinfilrunoff, rhilitteramount, rhilittermovement, rhiplantmortality, rhireprodcapability, rhiinvasiveplants, rhisoilsurfdegradation, rhiwaterflowpatterns, rhiwindscourareas, rhisoilsitestabsumm, rhibioticintegritysumm, rhihydrofunctionsumm
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid
@@ -259,7 +259,7 @@ get_vegplot_transect_from_NASIS_db <-  function(SS = TRUE,
   }
 
   # veg transect data - many transects to one vegplot
-  q.vegtransect <- "SELECT  siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiidref, vegtransectiid, usiteid as site_id, assocuserpedonid as pedon_id, vegplotid as vegplot_id, vegplotname, vegtransectid as vegtransect_id, obsdate, primarydatacollector, datacollectionpurpose, transectstartlatitude, transectstartlongitude, transectendlatitude, transectendlongitude, transectazimuth, transectlength, transectstartelevation, transectendelevation, dblsampquadratssampled, dblsampquadratsclipped, nestedfreqquadratssampled, freqquadratssampled, dwrquadratssampled, daubenmirequadratssampled, quadratsizedomlegacy, quadratsizeseclegacy, quadratshapedomlegacy, quadratshapeseclegacy, beltwidth, dblsampannualprod, totharvestannualprod, wtunitannualprod, dwrannualprod, comparativeyieldprod, comparativeyieldranktotal, comparativeyieldrankave, comparativerefclipwtave, abovegroundbiomasstotal, standingherbbiomass, transectbasalcovpct, basalcovpcttotal, basalgapsizemin, canopygapsizemin, gapsmeasuredbetween, canopygaplengthtotal, canopygappcttotal, basalgaplengthtotal, basalgappcttotal, vt.understoryreprodabundance, vt.woodyunderstoryabundance, vt.herbundertoryabundance, vt.lichensunderstoryabundance, cancovpcttotaltrans, cancovtotalclasstrans, cancovassessmethod, vt.crowncanclosurepct, vt.crowncancloseassessmethod, vt.crowncompfactorlpp, vt.crowncomplppavedbh, overstorycancovpcttrans, overstorycancovclasstrans, groundcovassessmethod, groundcovquadratssampled, groundcovpointssampled, groundsurfcovassessmethod, groundsurfcovquadratsamp, groundsurfcovpointssamp, lpiobsinterval, totalpointssampledcount, topcanopyhtave, topcanopyhtstddev, totalnumplantsbelt, totalnumspeciesbelt, totalplantdensitybelt
+  q.vegtransect <- "SELECT  siteiid, siteobsiid, vegplotiid, p.peiid, vegplotiidref, vegtransectiid, usiteid, assocuserpedonid, vegplotid, vegplotname, vegtransectid, obsdate, primarydatacollector, datacollectionpurpose, transectstartlatitude, transectstartlongitude, transectendlatitude, transectendlongitude, transectazimuth, transectlength, transectstartelevation, transectendelevation, dblsampquadratssampled, dblsampquadratsclipped, nestedfreqquadratssampled, freqquadratssampled, dwrquadratssampled, daubenmirequadratssampled, quadratsizedomlegacy, quadratsizeseclegacy, quadratshapedomlegacy, quadratshapeseclegacy, beltwidth, dblsampannualprod, totharvestannualprod, wtunitannualprod, dwrannualprod, comparativeyieldprod, comparativeyieldranktotal, comparativeyieldrankave, comparativerefclipwtave, abovegroundbiomasstotal, standingherbbiomass, transectbasalcovpct, basalcovpcttotal, basalgapsizemin, canopygapsizemin, gapsmeasuredbetween, canopygaplengthtotal, canopygappcttotal, basalgaplengthtotal, basalgappcttotal, vt.understoryreprodabundance, vt.woodyunderstoryabundance, vt.herbundertoryabundance, vt.lichensunderstoryabundance, cancovpcttotaltrans, cancovtotalclasstrans, cancovassessmethod, vt.crowncanclosurepct, vt.crowncancloseassessmethod, vt.crowncompfactorlpp, vt.crowncomplppavedbh, overstorycancovpcttrans, overstorycancovclasstrans, groundcovassessmethod, groundcovquadratssampled, groundcovpointssampled, groundsurfcovassessmethod, groundsurfcovquadratsamp, groundsurfcovpointssamp, lpiobsinterval, totalpointssampledcount, topcanopyhtave, topcanopyhtstddev, totalnumplantsbelt, totalnumspeciesbelt, totalplantdensitybelt
   FROM
   site_View_1 AS s
   INNER JOIN siteobs_View_1 AS so ON so.siteiidref=s.siteiid

--- a/R/get_vegplot_data_from_NASIS_db.R
+++ b/R/get_vegplot_data_from_NASIS_db.R
@@ -307,8 +307,8 @@ get_vegplot_transpecies_from_NASIS_db <-  function(SS = TRUE,
   }
 
   # veg transect species data - many species to one veg transect
-  q.vtps <- "SELECT siteiid, siteobsiid, vegplotiid, vegtransectiidref as vegtransect_id, vegplotid, vegplotname,
-    obsdate, vegtransplantsummiid as vtpsiid, vtps.seqnum, plantsym, plantsciname,
+  q.vtps <- "SELECT siteiid, siteobsiid, vegplotiid, vegtransectiidref as vegtransectiid, vegplotid, vegplotname,
+    obsdate, vegtransplantsummiid, vtps.seqnum, plantsym, plantsciname,
     plantnatvernm, plantnativity, planttypegroup,
     plantheightcllowerlimit, plantheightclupperlimit, sociabilityclass,
     specieslivecanhtbotave, specieslivecanhttopave, overstorydbhmin,

--- a/R/get_vegplot_data_from_NASIS_db.R
+++ b/R/get_vegplot_data_from_NASIS_db.R
@@ -326,7 +326,9 @@ get_vegplot_transect_from_NASIS_db <-  function(SS = TRUE,
 get_vegplot_transpecies_from_NASIS_db <-  function(SS = TRUE,
                                                    stringsAsFactors = NULL,
                                                    dsn = NULL) {
-
+  
+  .soilDB_warn_deprecated_aliases(c("vegtransplantsummiid" = "vstpiid"))
+  
   if (!missing(stringsAsFactors) && is.logical(stringsAsFactors)) {
     .Deprecated(msg = sprintf("stringsAsFactors argument is deprecated.\nSetting package option with `NASISDomainsAsFactor(%s)`", stringsAsFactors))
     NASISDomainsAsFactor(stringsAsFactors)

--- a/R/soilDB-package.R
+++ b/R/soilDB-package.R
@@ -62,7 +62,7 @@
 #'   plot(gopheridge, name='', print.id=FALSE, plot.order=order(gopheridge$bedrckdepth))
 #'
 #'   # plot first 10 profiles
-#'   plot(gopheridge[1:10, ], name='hzname', color='soil_color', label='pedon_id', id.style='side')
+#'   plot(gopheridge[1:10, ], name='hzname', color='soil_color', label='upedonid', id.style='side')
 #'
 #'   # add rock fragment data to plot:
 #'   addVolumeFraction(gopheridge[1:10, ], colname='total_frags_pct')
@@ -73,7 +73,7 @@
 #'   ## loafercreek
 #'   data("loafercreek")
 #'   # plot first 10 profiles
-#'   plot(loafercreek[1:10, ], name='hzname', color='soil_color', label='pedon_id', id.style='side')
+#'   plot(loafercreek[1:10, ], name='hzname', color='soil_color', label='upedonid', id.style='side')
 #'
 #'   # add rock fragment data to plot:
 #'   addVolumeFraction(loafercreek[1:10, ], colname='total_frags_pct')

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,7 +106,7 @@
 .pickBestEcosite <- function(d, es_classifier = NULL) {
 
   if (!is.null(es_classifier)) {
-    d <- d[which(d$es_classifier %in% es_classifier),]
+    d <- d[which(d$siteecositehistory.classifier %in% es_classifier), ]
   }
   
 	# add a method field


### PR DESCRIPTION
This PR introduces soft deprecation of aliases to address NASIS portion of https://github.com/ncss-tech/soilDB/issues/242; it supersedes #368 which is a branch that will only be used for testing that various soilDB usages in the wild are working _without_ aliases.

The development and next CRAN release will have warning messages and duplicate columns. In order to ensure that a particular script is compatible with the future removal of aliases, be sure it runs with an install from the "remove-aliases" branch:

```r
remotes::install_github("ncss-tech/soilDB@remove-aliases", dependencies=FALSE)
```

For the deprecation of column aliases, a warning message will be issued the first time an affected function is called in a session. e.g.

```
f <- get_vegplot_from_NASIS_db()
#> ------------------------------------------
#> NOTE: `get_vegplot_from_NASIS_db()` column aliases will be removed in the next soilDB release.
#> Please replace use of the following column names with NASIS physical column name:
#> 	 - site_id => usiteid
#> 	 - pedon_id => assocuserpedonid
#> 	 - vegplot_id => vegplotid
#> Set `options(soilDB.warn.aliases=FALSE)` to prevent this message from displaying in future sessions.
#> ------------------------------------------
```

Subsequent calls to functions in the same session will not display the message. Higher level functions like `fetchNASIS()` and `fetchVegdata()` will dump quite a few of these--one for each lower-level function that has aliases currently in use, which is kindof annoying but should make the fact that things are changing fairly obvious to users.

The message gives instructions on result column names that need to be changed. For now the old aliases and the new physical column names will be duplicated in the result, so nothing will "break" and users can switch to the suggested names without disruptions other than the messages.

To prevent the alias warning messages from displaying in future sessions, there is an option that can be set,
`options(soilDB.warn.aliases=FALSE)`, which we may want to use in some cases to limit the more verbose output that will show up in tutorials or training materials. I suggest setting this option in an invisible code block so the user does not turn off the messages in their own session, but the messages are omitted from the knitted output.

<strike>I will create a webpage on the ncss-tech.github.io repository with some additional information about the justification and overall scope of this change, with links to NASIS metadata, etc. to add to the message.</strike> See https://ncss-tech.github.io/AQP/soilDB/bulletins/2025.01-1-soilDB-NASIS-column-aliases.html