### PR TITLE
`createSSURGO()` updates

### DIFF
--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -1,29 +1,50 @@
 #' Get SSURGO ZIP files from Web Soil Survey 'Download Soils Data'
 #'
-#' Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard SSURGO format; optionally including the corresponding SSURGO Template Database with `include_template=TRUE`.
+#' Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard
+#' SSURGO format; optionally including the corresponding SSURGO Template Database with
+#' `include_template=TRUE`.
 #'
-#' To specify the Soil Survey Areas you would like to obtain data you use a `WHERE` clause for query of `sacatalog` table such as `areasymbol = 'CA067'`, `"areasymbol IN ('CA628', 'CA067')"` or  `areasymbol LIKE 'CT%'`.
+#' To specify the Soil Survey Areas you would like to obtain data you use a `WHERE` clause for query
+#' of `sacatalog` table such as `areasymbol = 'CA067'`, `"areasymbol IN ('CA628', 'CA067')"` or
+#' `areasymbol LIKE 'CT%'`.
 #'
-#' @param WHERE A SQL `WHERE` clause expression used to filter records in `sacatalog` table. Alternately `WHERE` can be any spatial object supported by `SDA_spatialQuery()` for defining the target extent.
-#' @param areasymbols Character vector of soil survey area symbols e.g. `c("CA067", "CA077")`. Used in lieu of `WHERE` argument.
-#' @param destdir Directory to download ZIP files into. Default `tempdir()`.
-#' @param exdir Directory to extract ZIP archives into. May be a directory that does not yet exist. Each ZIP file will extract to a folder labeled with `areasymbol` in this directory. Default: `destdir`
-#' @param include_template Include the (possibly state-specific) MS Access template database? Default: `FALSE`
-#' @param db Either `"SSURGO"` (default; detailed soil map) or `"STATSGO"` (general soil map).
-#' @param extract Logical. Extract ZIP files to `exdir`? Default: `TRUE`
-#' @param remove_zip Logical. Remove ZIP files after extracting? Default: `FALSE` 
-#' @param overwrite Logical. Overwrite by re-extracting if directory already exists? Default: `FALSE`
-#' @param quiet Logical. Passed to `curl::curl_download()`.
-#' @details
-#' When `db="STATSGO"` the `WHERE` argument is not supported. Allowed `areasymbols` include `"US"` and two-letter state codes e.g. `"WY"` for the Wyoming general soils map.
+#' @param WHERE _character_. A SQL `WHERE` clause expression used to filter records in `sacatalog` table.
+#'   Alternately `WHERE` can be any spatial object supported by `SDA_spatialQuery()` for defining
+#'   the target extent.
+#' @param areasymbols _character_. Character vector of soil survey area symbols e.g. `c("CA067", "CA077")`. Used
+#'   in lieu of `WHERE` argument.
+#' @param destdir _character_. Directory to download ZIP files into. Default `tempdir()`.
+#' @param exdir _character_. Directory to extract ZIP archives into. May be a directory that does not yet exist.
+#'   Each ZIP file will extract to a folder labeled with `areasymbol` in this directory. Default:
+#'   `destdir`
+#' @param include_template _logical_. Include the (possibly state-specific) MS Access template database?
+#'   Default: `FALSE`
+#' @param db _character_. Either `"SSURGO"` (default; detailed soil map) or `"STATSGO"` (general soil map).
+#' @param extract _logical_. Extract ZIP files to `exdir`? Default: `TRUE`
+#' @param remove_zip _logical_. Remove ZIP files after extracting? Default: `FALSE`
+#' @param overwrite _logical_. Overwrite by re-extracting if directory already exists? Default:
+#'   `FALSE`
+#' @param quiet _logical_. Passed to `curl::curl_download()`.
+#' 
+#' @details When `db="STATSGO"` the `WHERE` argument is not supported. Allowed `areasymbols` include
+#' `"US"` and two-letter state codes e.g. `"WY"` for the Wyoming general soils map.
 #'
 #' @export
 #'
-#' @details Pipe-delimited TXT files are found in _/tabular/_ folder extracted from a SSURGO ZIP. The files are named for tables in the SSURGO schema. There is no header / the files do not have column names. See the _Soil Data Access Tables and Columns Report_: \url{https://sdmdataaccess.nrcs.usda.gov/documents/TablesAndColumnsReport.pdf} for details on tables, column names and metadata including the default sequence of columns used in TXT files. The function returns a `try-error` if the `WHERE`/`areasymbols` arguments result in
+#' @details Pipe-delimited TXT files are found in _/tabular/_ folder extracted from a SSURGO ZIP.
+#'   The files are named for tables in the SSURGO schema. There is no header / the files do not have
+#'   column names. See the _Soil Data Access Tables and Columns Report_:
+#'   \url{https://sdmdataaccess.nrcs.usda.gov/documents/TablesAndColumnsReport.pdf} for details on
+#'   tables, column names and metadata including the default sequence of columns used in TXT files.
+#'   The function returns a `try-error` if the `WHERE`/`areasymbols` arguments result in
 #'
-#' Several ESRI shapefiles are found in the _/spatial/_ folder extracted from a SSURGO ZIP. These have prefix `soilmu_` (mapunit), `soilsa_` (survey area), `soilsf_` (special features). There will also be a TXT file with prefix `soilsf_` describing any special features. Shapefile names then have an `a_` (polygon), `l_` (line), `p_` (point) followed by the soil survey area symbol.
+#'   Several ESRI shapefiles are found in the _/spatial/_ folder extracted from a SSURGO ZIP. These
+#'   have prefix `soilmu_` (mapunit), `soilsa_` (survey area), `soilsf_` (special features). There
+#'   will also be a TXT file with prefix `soilsf_` describing any special features. Shapefile names
+#'   then have an `a_` (polygon), `l_` (line), `p_` (point) followed by the soil survey area symbol.
 #'
-#' @return Character. Paths to downloaded ZIP files (invisibly). May not exist if `remove_zip = TRUE`.
+#' @return _character_. Paths to downloaded ZIP files (invisibly). May not exist if `remove_zip =
+#'   TRUE`.
 #' @seealso [createSSURGO()]
 downloadSSURGO <- function(WHERE = NULL, 
                            areasymbols = NULL,
@@ -119,17 +140,31 @@ downloadSSURGO <- function(WHERE = NULL,
 #'  - DuckDB
 #'  - Postgres or PostGIS
 #'
-#' In theory any other DBI-compatible data source can be used for output. See `conn` argument. If you encounter issues using specific DBI connection types, please report in the soilDB issue tracker.
+#' In theory any other DBI-compatible data source can be used for output. See `conn` argument. If
+#' you encounter issues using specific DBI connection types, please report in the soilDB issue
+#' tracker.
 #'
-#' @param filename Output file name (e.g. `'db.sqlite'` or `'db.gpkg'`). Only used when `con` is not specified by the user.
-#' @param exdir Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files, downloaded and extracted by `downloadSSURGO()` or similar.
-#' @param conn A _DBIConnection_ object. Default is a `SQLiteConnection` used for writing .sqlite or .gpkg files. Alternate options are any DBI connection types. When `include_spatial=TRUE`, the sf package is used to write spatial data to the database.
-#' @param pattern Character. Optional regular expression to use to filter subdirectories of `exdir`. Default: `NULL` will search all subdirectories for SSURGO export files.
-#' @param include_spatial Logical. Include spatial data layers in database? Default: `TRUE`. 
-#' @param maxruledepth Integer. Maximum rule depth for `"cointerp"` table. Default `0` includes only shallowest ratings for smaller database size.
-#' @param overwrite Logical. Overwrite existing layers? Default `FALSE` will append to existing tables/layers.
-#' @param header Logical. Passed to `read.delim()` for reading pipe-delimited (`|`) text files containing tabular data.
-#' @param quiet Logical. Suppress messages and other output from database read/write operations?
+#' @param filename _character_. Output file name (e.g. `'db.sqlite'` or `'db.gpkg'`). Only used when `con` is not
+#'   specified by the user.
+#' @param exdir  _character_. Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files,
+#'   downloaded and extracted by `downloadSSURGO()` or similar.
+#' @param conn A _DBIConnection_ object. Default is a `SQLiteConnection` used for writing .sqlite or
+#'   .gpkg files. Alternate options are any DBI connection types. When `include_spatial=TRUE`, the
+#'   sf package is used to write spatial data to the database.
+#' @param pattern  _character_. Optional regular expression to use to filter subdirectories of `exdir`.
+#'   Default: `NULL` will search all subdirectories for SSURGO export files.
+#' @param include_spatial _logical_. Include spatial data layers in database? Default: `TRUE`.
+#' @param dissolve_field _character_. Dissolve geometries to create MULTIPOLYGON features? Column name
+#'   specified is the grouping variable. Default: `NULL` does no aggregation, giving 1 `POLYGON`
+#'   feature per delineation. `"mukey"` aggregates all related delineations within a soil survey
+#'   area.
+#' @param maxruledepth _integer_. Maximum rule depth for `"cointerp"` table. Default `0` includes only
+#'   shallowest ratings for smaller database size.
+#' @param overwrite _logical_. Overwrite existing layers? Default `FALSE` will append to existing
+#'   tables/layers.
+#' @param header _logical_. Passed to `read.delim()` for reading pipe-delimited (`|`) text files
+#'   containing tabular data.
+#' @param quiet _logical_. Suppress messages and other output from database read/write operations?
 #' @param ... Additional arguments passed to `write_sf()` for writing spatial layers.
 #'
 #' @return Character. Vector of layer/table names in `filename`.

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -126,6 +126,7 @@ downloadSSURGO <- function(WHERE = NULL,
 #' @param conn A _DBIConnection_ object. Default is a `SQLiteConnection` used for writing .sqlite or .gpkg files. Alternate options are any DBI connection types. When `include_spatial=TRUE`, the sf package is used to write spatial data to the database.
 #' @param pattern Character. Optional regular expression to use to filter subdirectories of `exdir`. Default: `NULL` will search all subdirectories for SSURGO export files.
 #' @param include_spatial Logical. Include spatial data layers in database? Default: `TRUE`. 
+#' @param maxruledepth Integer. Maximum rule depth for `"cointerp"` table. Default `0` includes only shallowest ratings for smaller database size.
 #' @param overwrite Logical. Overwrite existing layers? Default `FALSE` will append to existing tables/layers.
 #' @param header Logical. Passed to `read.delim()` for reading pipe-delimited (`|`) text files containing tabular data.
 #' @param quiet Logical. Suppress messages and other output from database read/write operations?
@@ -144,6 +145,7 @@ createSSURGO <- function(filename,
                          conn = NULL, 
                          pattern = NULL,
                          include_spatial = TRUE,
+                         maxruledepth = 0,
                          overwrite = FALSE,
                          header = FALSE,
                          quiet = TRUE,
@@ -301,6 +303,12 @@ createSSURGO <- function(filename,
           if (!is.null(mstab) && !header) { # preserve headers if present 
             colnames(y) <- newnames
           }
+        }
+        
+        # remove deeper rules from cointerp for smaller DB size
+        # most people only use depth==0 (default)
+        if (mstab_lut[x] == "cointerp" && !is.null(maxruledepth)) {
+          y <- y[y$ruledepth <= maxruledepth, ]
         }
         
         try({

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -140,7 +140,7 @@ downloadSSURGO <- function(WHERE = NULL,
 #'  downloadSSURGO("areasymbol IN ('CA067', 'CA077', 'CA632')", destdir = "SSURGO_test")
 #'  createSSURGO("test.gpkg", "SSURGO_test")
 #' }
-createSSURGO <- function(filename,
+createSSURGO <- function(filename = NULL,
                          exdir,
                          conn = NULL, 
                          pattern = NULL,
@@ -243,11 +243,7 @@ createSSURGO <- function(filename,
     
     # if user did not specify their own connection, close on exit
     on.exit(DBI::dbDisconnect(conn))
-  } else {
-    if (isTRUE(overwrite)) {
-      message("`filename` argument is ignored when `conn` is specified")
-    }
-  }
+  } 
   
   # create and add combined tabular datasets
   f.txt <- f[grepl(".*\\.txt$", f)]

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -191,6 +191,13 @@ createSSURGO <- function(filename = NULL,
     stop("`filename` should be a path to a .gpkg or .sqlite file to create or append to, or a DBIConnection should be provided via `conn`.")
   }
   
+  if (missing(conn) || is.null(conn)) {
+    # delete existing file if overwrite=TRUE
+    if (isTRUE(overwrite) && file.exists(filename)) {
+      file.remove(filename)
+    }
+  }
+  
   # DuckDB has special spatial format, so it gets custom handling for
   IS_DUCKDB <- inherits(conn, "duckdb_connection")
   
@@ -293,10 +300,6 @@ createSSURGO <- function(filename = NULL,
   }
   
   if (missing(conn) || is.null(conn)) {
-    # delete existing file if overwrite=TRUE
-    if (isTRUE(overwrite) && file.exists(filename)) {
-      file.remove(filename)
-    }
     
     if (!requireNamespace("RSQLite")) {
       stop("package 'RSQLite' is required (when `conn` is not specified)", call. = FALSE)

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -10,6 +10,7 @@ createSSURGO(
   conn = NULL,
   pattern = NULL,
   include_spatial = TRUE,
+  maxruledepth = 0,
   overwrite = FALSE,
   header = FALSE,
   quiet = TRUE,
@@ -26,6 +27,8 @@ createSSURGO(
 \item{pattern}{Character. Optional regular expression to use to filter subdirectories of \code{exdir}. Default: \code{NULL} will search all subdirectories for SSURGO export files.}
 
 \item{include_spatial}{Logical. Include spatial data layers in database? Default: \code{TRUE}.}
+
+\item{maxruledepth}{Integer. Maximum rule depth for \code{"cointerp"} table. Default \code{0} includes only shallowest ratings for smaller database size.}
 
 \item{overwrite}{Logical. Overwrite existing layers? Default \code{FALSE} will append to existing tables/layers.}
 

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -39,7 +39,9 @@ containing table names, only that set are written to file. e.g. \code{include_sp
 
 \item{include_tabular}{\emph{logical} or \emph{character}. Include tabular data layers in database?
 Default: \code{TRUE} inserts all tabular tables. If \code{include_tabular} is a \emph{character} vector
-containing table names, only that set are written to file. e.g. \code{include_tabular=c("mapunit", "muaggatt")} writes only the \code{mapunit} and \code{muaggatt} tables.}
+containing table names, only that set are written to file. e.g. \code{include_tabular=c("mapunit", "muaggatt")} writes only the \code{mapunit} and \code{muaggatt} tables. Note that special feature
+descriptions are stored in table \code{"featdesc"} and metadata for each soil survey area are stored
+in \code{"soil_metadata"} tables.}
 
 \item{dissolve_field}{\emph{character}. Dissolve geometries to create MULTIPOLYGON features? Column
 name

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -10,6 +10,7 @@ createSSURGO(
   conn = NULL,
   pattern = NULL,
   include_spatial = TRUE,
+  dissolve_field = NULL,
   maxruledepth = 0,
   overwrite = FALSE,
   header = FALSE,
@@ -18,23 +19,36 @@ createSSURGO(
 )
 }
 \arguments{
-\item{filename}{Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'}). Only used when \code{con} is not specified by the user.}
+\item{filename}{\emph{character}. Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'}). Only used when \code{con} is not
+specified by the user.}
 
-\item{exdir}{Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files, downloaded and extracted by \code{downloadSSURGO()} or similar.}
+\item{exdir}{\emph{character}. Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files,
+downloaded and extracted by \code{downloadSSURGO()} or similar.}
 
-\item{conn}{A \emph{DBIConnection} object. Default is a \code{SQLiteConnection} used for writing .sqlite or .gpkg files. Alternate options are any DBI connection types. When \code{include_spatial=TRUE}, the sf package is used to write spatial data to the database.}
+\item{conn}{A \emph{DBIConnection} object. Default is a \code{SQLiteConnection} used for writing .sqlite or
+.gpkg files. Alternate options are any DBI connection types. When \code{include_spatial=TRUE}, the
+sf package is used to write spatial data to the database.}
 
-\item{pattern}{Character. Optional regular expression to use to filter subdirectories of \code{exdir}. Default: \code{NULL} will search all subdirectories for SSURGO export files.}
+\item{pattern}{\emph{character}. Optional regular expression to use to filter subdirectories of \code{exdir}.
+Default: \code{NULL} will search all subdirectories for SSURGO export files.}
 
-\item{include_spatial}{Logical. Include spatial data layers in database? Default: \code{TRUE}.}
+\item{include_spatial}{\emph{logical}. Include spatial data layers in database? Default: \code{TRUE}.}
 
-\item{maxruledepth}{Integer. Maximum rule depth for \code{"cointerp"} table. Default \code{0} includes only shallowest ratings for smaller database size.}
+\item{dissolve_field}{\emph{character}. Dissolve geometries to create MULTIPOLYGON features? Column name
+specified is the grouping variable. Default: \code{NULL} does no aggregation, giving 1 \code{POLYGON}
+feature per delineation. \code{"mukey"} aggregates all related delineations within a soil survey
+area.}
 
-\item{overwrite}{Logical. Overwrite existing layers? Default \code{FALSE} will append to existing tables/layers.}
+\item{maxruledepth}{\emph{integer}. Maximum rule depth for \code{"cointerp"} table. Default \code{0} includes only
+shallowest ratings for smaller database size.}
 
-\item{header}{Logical. Passed to \code{read.delim()} for reading pipe-delimited (\code{|}) text files containing tabular data.}
+\item{overwrite}{\emph{logical}. Overwrite existing layers? Default \code{FALSE} will append to existing
+tables/layers.}
 
-\item{quiet}{Logical. Suppress messages and other output from database read/write operations?}
+\item{header}{\emph{logical}. Passed to \code{read.delim()} for reading pipe-delimited (\code{|}) text files
+containing tabular data.}
+
+\item{quiet}{\emph{logical}. Suppress messages and other output from database read/write operations?}
 
 \item{...}{Additional arguments passed to \code{write_sf()} for writing spatial layers.}
 }
@@ -48,8 +62,11 @@ The following database types are tested and fully supported:
 \item DuckDB
 \item Postgres or PostGIS
 }
-
-In theory any other DBI-compatible data source can be used for output. See \code{conn} argument. If you encounter issues using specific DBI connection types, please report in the soilDB issue tracker.
+}
+\details{
+In theory any other DBI-compatible data source can be used for output. See \code{conn} argument. If
+you encounter issues using specific DBI connection types, please report in the soilDB issue
+tracker.
 }
 \examples{
 \dontrun{

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -5,7 +5,7 @@
 \title{Create a database from SSURGO Exports}
 \usage{
 createSSURGO(
-  filename,
+  filename = NULL,
   exdir,
   conn = NULL,
   pattern = NULL,

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -10,6 +10,7 @@ createSSURGO(
   conn = NULL,
   pattern = NULL,
   include_spatial = TRUE,
+  include_tabular = TRUE,
   dissolve_field = NULL,
   maxruledepth = 0,
   overwrite = FALSE,
@@ -32,9 +33,16 @@ sf package is used to write spatial data to the database.}
 \item{pattern}{\emph{character}. Optional regular expression to use to filter subdirectories of \code{exdir}.
 Default: \code{NULL} will search all subdirectories for SSURGO export files.}
 
-\item{include_spatial}{\emph{logical}. Include spatial data layers in database? Default: \code{TRUE}.}
+\item{include_spatial}{\emph{logical} or \emph{character}. Include spatial data layers in database?
+Default: \code{TRUE} inserts all spatial tables. If \code{include_spatial} is a \emph{character} vector
+containing table names, only that set are written to file. e.g. \code{include_spatial=c("mupolygon", "featpoint")} writes only the mapunit polygons and special feature points.}
 
-\item{dissolve_field}{\emph{character}. Dissolve geometries to create MULTIPOLYGON features? Column name
+\item{include_tabular}{\emph{logical} or \emph{character}. Include tabular data layers in database?
+Default: \code{TRUE} inserts all tabular tables. If \code{include_tabular} is a \emph{character} vector
+containing table names, only that set are written to file. e.g. \code{include_tabular=c("mapunit", "muaggatt")} writes only the \code{mapunit} and \code{muaggatt} tables.}
+
+\item{dissolve_field}{\emph{character}. Dissolve geometries to create MULTIPOLYGON features? Column
+name
 specified is the grouping variable. Default: \code{NULL} does no aggregation, giving 1 \code{POLYGON}
 feature per delineation. \code{"mukey"} aggregates all related delineations within a soil survey
 area.}

--- a/man/downloadSSURGO.Rd
+++ b/man/downloadSSURGO.Rd
@@ -18,40 +18,60 @@ downloadSSURGO(
 )
 }
 \arguments{
-\item{WHERE}{A SQL \code{WHERE} clause expression used to filter records in \code{sacatalog} table. Alternately \code{WHERE} can be any spatial object supported by \code{SDA_spatialQuery()} for defining the target extent.}
+\item{WHERE}{\emph{character}. A SQL \code{WHERE} clause expression used to filter records in \code{sacatalog} table.
+Alternately \code{WHERE} can be any spatial object supported by \code{SDA_spatialQuery()} for defining
+the target extent.}
 
-\item{areasymbols}{Character vector of soil survey area symbols e.g. \code{c("CA067", "CA077")}. Used in lieu of \code{WHERE} argument.}
+\item{areasymbols}{\emph{character}. Character vector of soil survey area symbols e.g. \code{c("CA067", "CA077")}. Used
+in lieu of \code{WHERE} argument.}
 
-\item{destdir}{Directory to download ZIP files into. Default \code{tempdir()}.}
+\item{destdir}{\emph{character}. Directory to download ZIP files into. Default \code{tempdir()}.}
 
-\item{exdir}{Directory to extract ZIP archives into. May be a directory that does not yet exist. Each ZIP file will extract to a folder labeled with \code{areasymbol} in this directory. Default: \code{destdir}}
+\item{exdir}{\emph{character}. Directory to extract ZIP archives into. May be a directory that does not yet exist.
+Each ZIP file will extract to a folder labeled with \code{areasymbol} in this directory. Default:
+\code{destdir}}
 
-\item{include_template}{Include the (possibly state-specific) MS Access template database? Default: \code{FALSE}}
+\item{include_template}{\emph{logical}. Include the (possibly state-specific) MS Access template database?
+Default: \code{FALSE}}
 
-\item{db}{Either \code{"SSURGO"} (default; detailed soil map) or \code{"STATSGO"} (general soil map).}
+\item{db}{\emph{character}. Either \code{"SSURGO"} (default; detailed soil map) or \code{"STATSGO"} (general soil map).}
 
-\item{extract}{Logical. Extract ZIP files to \code{exdir}? Default: \code{TRUE}}
+\item{extract}{\emph{logical}. Extract ZIP files to \code{exdir}? Default: \code{TRUE}}
 
-\item{remove_zip}{Logical. Remove ZIP files after extracting? Default: \code{FALSE}}
+\item{remove_zip}{\emph{logical}. Remove ZIP files after extracting? Default: \code{FALSE}}
 
-\item{overwrite}{Logical. Overwrite by re-extracting if directory already exists? Default: \code{FALSE}}
+\item{overwrite}{\emph{logical}. Overwrite by re-extracting if directory already exists? Default:
+\code{FALSE}}
 
-\item{quiet}{Logical. Passed to \code{curl::curl_download()}.}
+\item{quiet}{\emph{logical}. Passed to \code{curl::curl_download()}.}
 }
 \value{
-Character. Paths to downloaded ZIP files (invisibly). May not exist if \code{remove_zip = TRUE}.
+\emph{character}. Paths to downloaded ZIP files (invisibly). May not exist if \code{remove_zip = TRUE}.
 }
 \description{
-Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard SSURGO format; optionally including the corresponding SSURGO Template Database with \code{include_template=TRUE}.
+Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard
+SSURGO format; optionally including the corresponding SSURGO Template Database with
+\code{include_template=TRUE}.
 }
 \details{
-To specify the Soil Survey Areas you would like to obtain data you use a \code{WHERE} clause for query of \code{sacatalog} table such as \code{areasymbol = 'CA067'}, \code{"areasymbol IN ('CA628', 'CA067')"} or  \verb{areasymbol LIKE 'CT\%'}.
+To specify the Soil Survey Areas you would like to obtain data you use a \code{WHERE} clause for query
+of \code{sacatalog} table such as \code{areasymbol = 'CA067'}, \code{"areasymbol IN ('CA628', 'CA067')"} or
+\verb{areasymbol LIKE 'CT\%'}.
 
-When \code{db="STATSGO"} the \code{WHERE} argument is not supported. Allowed \code{areasymbols} include \code{"US"} and two-letter state codes e.g. \code{"WY"} for the Wyoming general soils map.
+When \code{db="STATSGO"} the \code{WHERE} argument is not supported. Allowed \code{areasymbols} include
+\code{"US"} and two-letter state codes e.g. \code{"WY"} for the Wyoming general soils map.
 
-Pipe-delimited TXT files are found in \emph{/tabular/} folder extracted from a SSURGO ZIP. The files are named for tables in the SSURGO schema. There is no header / the files do not have column names. See the \emph{Soil Data Access Tables and Columns Report}: \url{https://sdmdataaccess.nrcs.usda.gov/documents/TablesAndColumnsReport.pdf} for details on tables, column names and metadata including the default sequence of columns used in TXT files. The function returns a \code{try-error} if the \code{WHERE}/\code{areasymbols} arguments result in
+Pipe-delimited TXT files are found in \emph{/tabular/} folder extracted from a SSURGO ZIP.
+The files are named for tables in the SSURGO schema. There is no header / the files do not have
+column names. See the \emph{Soil Data Access Tables and Columns Report}:
+\url{https://sdmdataaccess.nrcs.usda.gov/documents/TablesAndColumnsReport.pdf} for details on
+tables, column names and metadata including the default sequence of columns used in TXT files.
+The function returns a \code{try-error} if the \code{WHERE}/\code{areasymbols} arguments result in
 
-Several ESRI shapefiles are found in the \emph{/spatial/} folder extracted from a SSURGO ZIP. These have prefix \code{soilmu_} (mapunit), \code{soilsa_} (survey area), \code{soilsf_} (special features). There will also be a TXT file with prefix \code{soilsf_} describing any special features. Shapefile names then have an \code{a_} (polygon), \code{l_} (line), \code{p_} (point) followed by the soil survey area symbol.
+Several ESRI shapefiles are found in the \emph{/spatial/} folder extracted from a SSURGO ZIP. These
+have prefix \code{soilmu_} (mapunit), \code{soilsa_} (survey area), \code{soilsf_} (special features). There
+will also be a TXT file with prefix \code{soilsf_} describing any special features. Shapefile names
+then have an \code{a_} (polygon), \code{l_} (line), \code{p_} (point) followed by the soil survey area symbol.
 }
 \seealso{
 \code{\link[=createSSURGO]{createSSURGO()}}


### PR DESCRIPTION
`createSSURGO()` updates
 - Add incremental write of tabular data by table and soil survey area. Much more memory efficient, especially with larger sets of SSAs where tables start to get large.
 - Add `maxruledepth` argument, and set default to `0` (reduces number of cointerp rows by 75% for published SSURGO with depth 0 or 1). Generally WSS exports only have max ruledepth 1, but custom NASIS exports can go "deeper"
 - Update behavior of `filename` argument when `conn` _DBIConnection_ is specified.
 - Add `dissolve_field` argument
 - Improve `overwrite` logic
 - Add `include_tabular` argument
 - Allow `include_spatial` and `include_tabular` to be a _character_ vector of table names (TRUE is all tables, FALSE is no tables)
 - Make composite `"soil_metadata"` table, one row per soil survey area