### PR TITLE
`fetchSOLUS`: Add mpspline based interpolation methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: GPL (>= 3)
 LazyLoad: yes
 Depends: R (>= 3.5.0)
 Imports: grDevices, graphics, stats, utils, methods, aqp (>= 2.0.2), data.table, DBI, curl
-Suggests: jsonlite, xml2, httr, rvest, odbc, RSQLite, sf, wk, terra, raster, knitr, rmarkdown, testthat
+Suggests: jsonlite, xml2, httr, rvest, odbc, RSQLite, sf, wk, terra, raster, mpspline2, knitr, rmarkdown, testthat
 Repository: CRAN
 URL: https://github.com/ncss-tech/soilDB/, https://ncss-tech.github.io/soilDB/, https://ncss-tech.github.io/AQP/
 BugReports: https://github.com/ncss-tech/soilDB/issues

--- a/man/fetchSOLUS.Rd
+++ b/man/fetchSOLUS.Rd
@@ -49,11 +49,16 @@ other than \code{"step"}).}
 
 \item{method}{character. Used to determine depth interpolation method for \emph{SoilProfileCollection}
 output. Default: \code{"linear"}. Options include any \code{method} allowed for \code{approxfun()} or
-\code{splinefun()} plus \code{"step"} and \code{"slice"}. \code{"step"} uses the prediction depths as the top and
-bottom of each interval to create a piecewise continuous profile to maximum of 200 cm depth
-(for 150 cm upper prediction depth). \code{"slice"} returns a discontinuous profile with 1 cm thick
-slices at the predicted depths. Both \code{"step"} and \code{"slice"} return a number of layers equal to
-length of \code{depth_slices}, and all other methods return data in interpolated 1cm slices.}
+\code{splinefun()} plus \code{"step"}, \code{"slice"} and several mass-preserving spline methods. \code{"step"}
+uses the prediction depths as the top and bottom of each interval to create a piecewise
+continuous profile. \code{"slice"} returns a discontinuous profile with 1 cm thick
+slices at the predicted depths. To use mass-preserving (equal area) splines via
+\code{mpspline2::mpspline()} use \code{"mpspline_est_icm"}, \code{"mpspline_est_1cm"}, or
+\code{"mpspline_est_dcm"}. Methods \code{"step"}, \code{"slice"}, \code{"mpspline_est_icm"}, and
+\code{"mpspline_est_dcm"} return a number of layers equal to length of \code{depth_slices}, and all other
+methods return values for interpolated 1 cm slices.}
+
+\item{max_depth}{integer. Maximum depth to interpolate 150 cm slice data to. Default: \code{151}}
 
 \item{max_depth}{integer. Maximum depth to interpolate 150 cm slice data to. Default: \code{151}.
 Interpolation deeper than 151 cm is not possible for methods other than \code{"step"} and will


### PR DESCRIPTION
I was going through and deleting old branches and saw this one which I never merged.

This PR would add `mpspline2` to suggests, and add several variants of equal-area spline depth interpolation `method` options for  SoilProfileCollection conversion in `fetchSOLUS()`

At the time I considered that the approaches I developed for depth interpolation data should probably be generalized to a function in aqp that was data source agnostic. aqp already brings in mpspline2, and the general functionality would be more useful there, which is probably why I did not pursue this PR further. Opening a draft PR to remind myself to look back at this.