### PR TITLE
`createSSURGO()` updates

### DIFF
--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -391,9 +391,12 @@ createSSURGO <- function(filename = NULL,
       
       d <- try(lapply(seq_along(f.txt.grp[[x]]), function(i) {
           # message(f.txt.grp[[x]][i])
-          y <- try(read.delim(f.txt.grp[[x]][i], sep = "|", stringsAsFactors = FALSE, header = header), silent = quiet)
+          y <- try(read.delim(f.txt.grp[[x]][i], sep = "|", stringsAsFactors = FALSE, header = header), silent = TRUE)
           
           if (inherits(y, 'try-error')) {
+            if (!quiet) {
+              message("File ", f.txt.grp[[x]][i], " contains no data")
+            }
             return(NULL)
           } else if (length(y) == 1) {
             if (grepl("soil_metadata", f.txt.grp[[x]][i])) {
@@ -401,14 +404,18 @@ createSSURGO <- function(filename = NULL,
                 areasymbol = toupper(gsub(".*soil_metadata_(.*)\\.txt", "\\1", f.txt.grp[[x]][i])),
                 content = paste(y[[1]], collapse = "\n")
               )
-            }
-            else {
+            } else {
               y <- data.frame(content = y)
             }
           } else {
             if (!is.null(mstab) && !header) { # preserve headers if present 
               colnames(y) <- newnames
             }
+          }
+          
+          if (is.na(mstab_lut[x])) {
+            # readme, version
+            return(NULL)
           }
           
           # remove deeper rules from cointerp for smaller DB size

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -204,10 +204,14 @@ createSSURGO <- function(filename = NULL,
   
   if (missing(conn) || is.null(conn)) {
     # delete existing file if overwrite=TRUE
-    if (isTRUE(overwrite) && file.exists(filename)) {
-      file.remove(filename)
+    if (file.exists(filename)) {
+      if (isTRUE(overwrite)) {
+        file.remove(filename)
+      } else {
+        stop("File '", filename,"' exists and overwrite = FALSE", call. = FALSE)
+      }
     }
-  } 
+  }
   
   # DuckDB has special spatial format, so it gets custom handling for
   IS_DUCKDB <- inherits(conn, "duckdb_connection")
@@ -416,7 +420,7 @@ createSSURGO <- function(filename = NULL,
           }
           
           try({
-            if (i == 1) {
+            if (i == 1 && overwrite) {
               DBI::dbWriteTable(conn, mstab_lut[x], y, overwrite = TRUE)
             } else {
               DBI::dbWriteTable(conn, mstab_lut[x], y, append = TRUE)


### PR DESCRIPTION
Cleanup overwrite logic to close #400; now throws an error when `filename` exists and `overwrite=FALSE`

Also, corrects some other situations:
 -  Using `filename` and `conn` with SQLite driver with .sqlite rather than .gpkg output
 -  Better handling of missing export files, with better messages when `quiet=FALSE`
 -  Skip executing commands that rely on a table being present (empty SSURGO export files currently can leaves gaps in the database)

``` r
library(soilDB)
library(RSQLite)

base_dir <- "D:/workspace/scratch"
.exdir1 <- file.path(base_dir, "ssurgo", "ssurgo1")
.exdir2 <- file.path(base_dir, "ssurgo", "ssurgo2")

# # download a single SSA
# downloadSSURGO(areasymbols = "ca113", destdir = .exdir1, include_template = FALSE, extract = TRUE, remove_zip = TRUE, db = "SSURGO")
# 
# # download another SSA in a different directory
# downloadSSURGO(areasymbols = "ca654", destdir = .exdir2, include_template = FALSE, extract = TRUE, remove_zip = TRUE, db = "SSURGO")

# init DB file, delete if already existing
.dbfile1 <- file.path(base_dir, "ssurgo1.sqlite")
unlink(.dbfile1)

# init SQLite DB with CA113
createSSURGO(filename = .dbfile1, exdir = .exdir1, include_spatial = FALSE, overwrite = TRUE, quiet = FALSE)
#> Loading required namespace: sf

# append existing SQLite DB with CA654
createSSURGO(filename = .dbfile1, exdir = .exdir2, include_spatial = FALSE, overwrite = FALSE, quiet = TRUE)
#> Error: File 'D:/workspace/scratch/ssurgo1.sqlite' exists and overwrite = FALSE

soilDB::SDA_query("SELECT DISTINCT areasymbol FROM legend ;", .dbfile1)
#>   areasymbol
#> 1      CA113

# init DB file, delete if already existing
.dbfile2 <- file.path(base_dir, "ssurgo2.sqlite")
unlink(.dbfile2)

# init SQLite DB with CA113 and CA654
createSSURGO(filename = .dbfile2, exdir = dirname(.exdir1), include_spatial = FALSE, overwrite = TRUE, quiet = TRUE)

soilDB::SDA_query("SELECT DISTINCT areasymbol FROM legend ;", .dbfile2)
#>   areasymbol
#> 1      CA113
#> 2      CA654
```