### PR TITLE
SDA_spatialQuery: Add `addFields` argument

### DIFF
--- a/R/SDA-spatial.R
+++ b/R/SDA-spatial.R
@@ -310,9 +310,7 @@ SDA_spatialQuery <- function(geom,
   return_terra <- FALSE
 
   # raster support
-  if (inherits(geom, 'RasterLayer') |
-      inherits(geom, 'RasterBrick') |
-      inherits(geom, 'RasterStack')) {
+  if (inherits(geom, c('RasterLayer', 'RasterBrick', 'RasterStack'))) {
     if (!requireNamespace('terra'))
       stop("packages terra is required", call. = FALSE)
     geom <- terra::rast(geom)

--- a/R/SDA-spatial.R
+++ b/R/SDA-spatial.R
@@ -67,30 +67,16 @@ processSDA_WKT <- function(d, g='geom', crs = 4326, p4s = NULL, as_sf = TRUE) {
   geom_sql <- sprintf(switch(method,
                              intersection = "%s.STIntersection(geometry::STGeomFromText('%%s', 4326)) AS geom",
                              overlap = "%s AS geom"), db_column)
-  include_nationalmusym <- (id_column == "mukey" && db_table != "sapolygon")
-  
   res <- sprintf(
-      "WITH geom_data (geom, %s%s) AS (
-          SELECT %s, %s.%s %s
+      "WITH geom_data (geom, %s) AS (
+          SELECT %s, %s
           FROM %s 
-          %s
           WHERE %s.STIntersects(geometry::STGeomFromText('%%s', 4326)) = 1 %s
-        ) SELECT geom.STAsText() AS geom, %s%s%s
+        ) SELECT geom.STAsText() AS geom, %s%s
         FROM geom_data",
-      id_column, 
-      ifelse(include_nationalmusym, ", nationalmusym", ""),
-      geom_sql, db_table, id_column,
-      ifelse(include_nationalmusym, ", mapunit.nationalmusym", ""),
-      db_table, 
-      ifelse(include_nationalmusym, 
-             sprintf("INNER JOIN mapunit ON mapunit.mukey = %s.mukey",
-                     db_table), ""),
-      db_column, clip_sql, id_column,
-      ifelse(geomAcres, area_ac_sql, ""),
-      ifelse(include_nationalmusym, ", nationalmusym", "")
-      
+      id_column, geom_sql, id_column, db_table, db_column, clip_sql, id_column,
+      ifelse(geomAcres, area_ac_sql, "")
     )
-  
   
   # handle non-polygon results
   if (db == "SSURGO" && what %in% c("mupoint", "muline", "featpoint", "featline")) {
@@ -324,8 +310,8 @@ SDA_spatialQuery <- function(geom,
   return_terra <- FALSE
 
   # raster support
-  if (inherits(geom, 'RasterLayer') ||
-      inherits(geom, 'RasterBrick') ||
+  if (inherits(geom, 'RasterLayer') |
+      inherits(geom, 'RasterBrick') |
       inherits(geom, 'RasterStack')) {
     if (!requireNamespace('terra'))
       stop("packages terra is required", call. = FALSE)

--- a/man/SDA_spatialQuery.Rd
+++ b/man/SDA_spatialQuery.Rd
@@ -12,6 +12,7 @@ SDA_spatialQuery(
   db = c("SSURGO", "STATSGO", "SAPOLYGON"),
   byFeature = FALSE,
   idcol = "gid",
+  addFields = NULL,
   query_string = FALSE,
   as_Spatial = getOption("soilDB.return_Spatial", default = FALSE)
 )
@@ -30,6 +31,8 @@ SDA_spatialQuery(
 \item{byFeature}{Iterate over features, returning a combined data.frame where each feature is uniquely identified by value in \code{idcol}. Default \code{FALSE}.}
 
 \item{idcol}{Unique IDs used for individual features when \code{byFeature = TRUE}; Default \code{"gid"}}
+
+\item{addFields}{character; Amend result with a query to \code{mapunit} table for additional information? Default: \code{NULL}. A character vector can be used to specify columns from the \code{legend}, \code{mapunit}, and \code{muaggatt} tables (for \code{mupolygon}, \code{mupoint}, \code{muline} and \code{mukey}), \code{legend} table for areasymbol and sapolygon, and \code{featdesc} for \code{featpoint} and \code{featline}.  Mapunit and mapunit aggregate attribute tables are ignored for soil survey area polygon results.}
 
 \item{query_string}{Default: \code{FALSE}; if \code{TRUE} return a character string containing query that would be sent to SDA via \code{SDA_query}}
 


### PR DESCRIPTION
- Adds a new argument to `SDA_spatialQuery()` analogous to `fetchSDA_spatial(add.fields)` for adding additional columns to the tabular or spatial results of a spatial query
- Reverts and supersedes #402; which becomes just a specific case of the general solution here

New `addFields` is:
  - More extensible (supports many more tables and columns) 
  - Backward-compatible (does not introduce issues for folks who already have some custom join workflow)

For example, can now do:
<details>

``` r
library(soilDB)

bsf <- c(
    xmin = -102.04,
    ymin = 36.99,
    xmax = -101.929,
    ymax = 37.138
  ) |>
  sf::st_bbox(crs = "OGC:CRS84") |>
  sf::st_as_sfc() |>
  sf::st_as_sf()

SDA_spatialQuery(bsf,
                 what = "areasymbol",
                 addFields = "tabularversion")
#>   areasymbol tabularversion
#> 1      KS129             21
#> 2      OK139             22
#> 3      OK025             20

SDA_spatialQuery(bsf,
                 what = "areasymbol",
                 addFields = c("areaname", "areaacres"))
#>   areasymbol                  areaname areaacres
#> 1      KS129     Morton County, Kansas    467923
#> 2      OK139    Texas County, Oklahoma   1310918
#> 3      OK025 Cimarron County, Oklahoma   1178586

SDA_spatialQuery(bsf, what = "mukey")
#>      mukey
#> 1   382055
#> 2   382058
#> 3   384902
#> 4   384904
#> 5   384906
#> 6   384920
#> 7   384928
#> 8  1382580
#> 9  1382581
#> 10 1382582
#> 11 1382583
#> 12 1382584
#> 13 1382586
#> 14 1382587
#> 15 1382588
#> 16 1382590
#> 17 1382591
#> 18 1382592
#> 19 1382593
#> 20 1382595
#> 21 1382596
#> 22 1382597
#> 23 1382599
#> 24 1382600
#> 25 1382601
#> 26 1382602
#> 27 1382603
#> 28 1382605
#> 29 1382606
#> 30 1382607
#> 31 1382608
#> 32 1382615
#> 33 1382616
#> 34 1451973
#> 35 1542313
#> 36 2509190
#> 37 2668838
#> 38 2785208
#>                                                                     muname
#> 1                           Dalhart fine sandy loam, 0 to 1 percent slopes
#> 2                           Dalhart loamy fine sand, 0 to 3 percent slopes
#> 3                           Dalhart fine sandy loam, 0 to 1 percent slopes
#> 4                           Dalhart loamy fine sand, 0 to 3 percent slopes
#> 5                            Perico-Ulysses complex, 1 to 3 percent slopes
#> 6                          Rickmore fine sandy loam, 0 to 1 percent slopes
#> 7                               Eva loamy fine sand, 0 to 3 percent slopes
#> 8                                Atchison clay loam, 3 to 6 percent slopes
#> 9                          Atchison fine sandy loam, 1 to 3 percent slopes
#> 10                                    Atchison loam, 1 to 3 percent slopes
#> 11                                    Atchison loam, 6 to 9 percent slopes
#> 12                   Atchison-Rock outcrop complex, 6 to 20 percent slopes
#> 13                                      Belfon loam, 0 to 1 percent slopes
#> 14                           Bigbow fine sandy loam, 0 to 1 percent slopes
#> 15                           Bigbow loamy fine sand, 0 to 3 percent slopes
#> 16                          Dalhart fine sandy loam, 0 to 1 percent slopes
#> 17                          Dalhart fine sandy loam, 1 to 3 percent slopes
#> 18                          Dalhart loamy fine sand, 0 to 3 percent slopes
#> 19                          Dalhart loamy fine sand, 3 to 5 percent slopes
#> 20                              Eva loamy fine sand, 0 to 3 percent slopes
#> 21                              Eva loamy fine sand, 3 to 8 percent slopes
#> 22                              Eva-Optima complex, 5 to 15 percent slopes
#> 23                          Glenberg fine sandy loam, occasionally flooded
#> 24                                Glenberg fine sandy loam, rarely flooded
#> 25 Happyditch loamy fine sand, 0 to 2 percent slopes, occasionally flooded
#> 26            Happyditch loamy sand, 0 to 2 percent slopes, rarely flooded
#> 27              Happyditch sand, 0 to 2 percent slopes, frequently flooded
#> 28                           Optima loamy fine sand, 1 to 5 percent slopes
#> 29                               Optima loamy sand, 5 to 20 percent slopes
#> 30                           Otero fine sandy loam, 7 to 15 percent slopes
#> 31                              Richfield silt loam, 0 to 1 percent slopes
#> 32                         Wagonbed silty clay loam, 0 to 1 percent slopes
#> 33                         Wagonbed silty clay loam, 1 to 3 percent slopes
#> 34                          Vorhees fine sandy loam, 1 to 3 percent slopes
#> 35             Dalhart-Eva complex loamy fine sands, 3 to 8 percent slopes
#> 36                          Satanta fine sandy loam, 0 to 1 percent slopes
#> 37                                Ulysses silt loam, 0 to 1 percent slopes
#> 38                              Eva loamy fine sand, 3 to 8 percent slopes

SDA_spatialQuery(bsf,
                 what = "mupolygon",
                 addFields = c("nationalmusym", "farmlndcl"))
#> Simple feature collection with 140 features and 4 fields
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -102.0845 ymin: 36.93656 xmax: -101.556 ymax: 37.24493
#> Geodetic CRS:  WGS 84
#> First 10 features:
#>     mukey nationalmusym          farmlndcl     area_ac
#> 1  382055         2rgf1 Not prime farmland   56.005717
#> 2  382058         2rgf3 Not prime farmland 2528.331879
#> 3  384902         2rgf1 Not prime farmland   28.871235
#> 4  384902         2rgf1 Not prime farmland   15.998875
#> 5  384904         2rgf3 Not prime farmland 3329.136579
#> 6  384906          dxjb Not prime farmland  119.126836
#> 7  384920          dxjs Not prime farmland   23.910188
#> 8  384920          dxjs Not prime farmland    9.893309
#> 9  384928         2rgdw Not prime farmland   85.706215
#> 10 384928         2rgdw Not prime farmland   52.676845
#>                              geom
#> 1  POLYGON ((-102.0348 36.9931...
#> 2  POLYGON ((-102.0831 36.9439...
#> 3  POLYGON ((-102.0029 36.9932...
#> 4  POLYGON ((-101.9286 36.9916...
#> 5  POLYGON ((-102.0282 36.9639...
#> 6  POLYGON ((-101.9373 36.9935...
#> 7  POLYGON ((-101.9453 36.9934...
#> 8  POLYGON ((-101.9333 36.9935...
#> 9  POLYGON ((-101.9442 36.9908...
#> 10 POLYGON ((-101.9824 36.9933...

SDA_spatialQuery(bsf,
                 what = "mupolygon",
                 db = "SSURGO")
#> Simple feature collection with 140 features and 2 fields
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -102.0845 ymin: 36.93656 xmax: -101.556 ymax: 37.24493
#> Geodetic CRS:  WGS 84
#> First 10 features:
#>      mukey    area_ac                           geom
#> 1  1382606  687.49728 POLYGON ((-102.0057 37.0344...
#> 2  1382608  315.23731 POLYGON ((-102.0232 37.1152...
#> 3  1382593   41.30710 POLYGON ((-102.0391 37.0400...
#> 4  1382602  101.49347 POLYGON ((-101.9766 37.0761...
#> 5  1382597 4848.83856 POLYGON ((-101.9738 37.0716...
#> 6  1382582  492.97907 POLYGON ((-101.9917 37.1193...
#> 7  1382580   16.17867 POLYGON ((-101.956 37.10971...
#> 8  1382583   17.97865 POLYGON ((-101.9296 37.1131...
#> 9  1382599   43.84678 POLYGON ((-101.9387 37.1012...
#> 10 1382601  233.22672 POLYGON ((-102.023 37.07766...

SDA_spatialQuery(bsf,
                 what = "mupolygon",
                 db = "STATSGO",
                 addFields = "mapunit.muname")
#> Simple feature collection with 6 features and 3 fields
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -102.4119 ymin: 36.69976 xmax: -100.5935 ymax: 37.97419
#> Geodetic CRS:  WGS 84
#>    mukey                                     muname   area_ac
#> 1 659689              Vona-Valent-Dune land (s1368)  27570.66
#> 2 662881 Ulysses-Otero-Lincoln-Colby-Canlon (s2581) 136482.17
#> 3 662902                        Vona-Valent (s2602)  60402.63
#> 4 662905                  Ulysses-Richfield (s2605) 949128.40
#> 5 671219         Satanta-Darrouzett-Dalhart (s6178) 462241.41
#> 6 671220                       Vona-Dalhart (s6179)  73839.14
#>                             geom
#> 1 POLYGON ((-101.9697 37.0398...
#> 2 POLYGON ((-101.23 37.50713,...
#> 3 POLYGON ((-101.5626 37.2003...
#> 4 POLYGON ((-101.9965 37.9468...
#> 5 POLYGON ((-101.2874 37.1812...
#> 6 POLYGON ((-101.9701 37.0104...

SDA_spatialQuery(bsf, what = "featpoint", addFields = c("featpoint.areasymbol", "featpoint.featsym", "featdesc"))
#> Simple feature collection with 604 features and 4 fields
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: -101.9723 ymin: 36.99019 xmax: -101.9697 ymax: 36.99026
#> Geodetic CRS:  WGS 84
#> First 10 features:
#>    featkey areasymbol featsym
#> 1   288267      OK139     BLO
#> 2   288267      OK139     BLO
#> 3   288267      OK139     BLO
#> 4   288267      OK139     BLO
#> 5   288267      OK139     BLO
#> 6   288267      OK139     BLO
#> 7   288267      OK139     BLO
#> 8   288267      OK139     BLO
#> 9   288267      OK139     BLO
#> 10  288267      OK139     BLO
#>                                                                                                                                                                                                                                                                                                                                                                                              featdesc
#> 1  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 2  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 3  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 4  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 5  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 6  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 7  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 8  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 9  A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#> 10 A saucer-, cup-, or trough-shaped depression formed by wind erosion on a pre-existing dune or other sand deposit, especially in an area of shifting sand or loose soil or where protective vegetation is disturbed or destroyed. The adjoining accumulation of sand derived from the depression, where recognizable, is commonly included. Blowouts are commonly small. Typically 0.25 to 3 acres.
#>                          geom
#> 1  POINT (-101.9697 36.99026)
#> 2  POINT (-101.9723 36.99019)
#> 3  POINT (-101.9697 36.99026)
#> 4  POINT (-101.9723 36.99019)
#> 5  POINT (-101.9697 36.99026)
#> 6  POINT (-101.9723 36.99019)
#> 7  POINT (-101.9697 36.99026)
#> 8  POINT (-101.9723 36.99019)
#> 9  POINT (-101.9697 36.99026)
#> 10 POINT (-101.9723 36.99019)

SDA_spatialQuery(bsf, what = "sapolygon", addFields = "areaname")
#> Simple feature collection with 3 features and 3 fields
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -103.0025 ymin: 36.49939 xmax: -100.9455 ymax: 37.38931
#> Geodetic CRS:  WGS 84
#>   areasymbol                  areaname   area_ac                           geom
#> 1      KS129     Morton County, Kansas  466981.9 POLYGON ((-102.0392 37.3893...
#> 2      OK025 Cimarron County, Oklahoma 1178240.9 POLYGON ((-102.7492 37.0003...
#> 3      OK139    Texas County, Oklahoma 1310814.4 POLYGON ((-100.9457 36.9984...
```

</details>

