### PR TITLE
fix: SDA_spatialQuery: addFields with `geomIntersection=TRUE` and feat* tables

### DIFF
--- a/R/SDA-spatial.R
+++ b/R/SDA-spatial.R
@@ -519,7 +519,7 @@ SDA_spatialQuery <- function(geom,
       addFields <- addFields[!addFields == "lkey"]
       lecol <- toString(unique(c(key, addFields)))
       q <- paste0(q, "\nINNER JOIN legend ON legend.areasymbol = geom_data.areasymbol")
-      q <- gsub("([^o]) AS geom", paste0("\\1 AS geom, ", lecol), q)
+      q <- gsub("(\\) SELECT geom_data.*) AS geom", paste0("\\1 AS geom, ", lecol), q)
     } else if (grepl("feat", what)) {
       key <- character(0)
       if (include_key) {
@@ -528,11 +528,8 @@ SDA_spatialQuery <- function(geom,
       addFields <- trimws(addFields)
       addFields <- addFields[!addFields == "featkey"]
       mucol <- toString(unique(c(key, addFields)))
-      q <- paste(q, sprintf("INNER JOIN %s ON %s.featkey = geom_data.featkey
-                     INNER JOIN featdesc ON featdesc.featkey = geom_data.featkey",
-                            what, what))
-      q <- gsub("([^o]) AS geom", paste0("\\1 AS geom, ", mucol), q)
-      
+      q <- paste(q, sprintf("INNER JOIN featdesc ON geom_data.featkey = featdesc.featkey", what))
+      q <- gsub("(\\) SELECT geom_data.*) AS geom", paste0("\\1 AS geom, ", mucol), q)
     } else {
       key <- character(0)
       if (include_key) {
@@ -544,7 +541,7 @@ SDA_spatialQuery <- function(geom,
       q <- paste(q, "INNER JOIN mapunit ON mapunit.mukey = geom_data.mukey
            INNER JOIN muaggatt ON muaggatt.mukey = mapunit.mukey
            INNER JOIN legend ON legend.lkey = mapunit.lkey ")
-      q <- gsub("([^o]) AS geom", paste0("\\1 AS geom, ", mucol), q)
+      q <- gsub("(\\) SELECT geom_data.*) AS geom", paste0("\\1 AS geom, ", mucol), q)
     }
   }
   gsub(", FROM", " FROM", gsub("NULL AS geom[, ]*", "", q))

--- a/tests/testthat/test-SDA_query.R
+++ b/tests/testthat/test-SDA_query.R
@@ -127,10 +127,11 @@ test_that("SDA_spatialQuery() simple spatial query, tabular results", {
 
 test_that("SDA_spatialQuery() simple spatial query, spatial results", {
   
+  
   skip_if_not_installed("httr")
   
   skip_if_offline()
-
+  
   skip_on_cran()
   
   skip_if_not_installed("sf")
@@ -143,10 +144,14 @@ test_that("SDA_spatialQuery() simple spatial query, spatial results", {
   # testing known values
   expect_true(inherits(res, 'sf'))
   expect_equivalent(nrow(res), 1)
-
-
+  
   # test with db = "STATSGO"
-  res <- suppressWarnings(SDA_spatialQuery(p, what = 'geom', db = "STATSGO"))
+  res <- suppressWarnings(SDA_spatialQuery(
+    p,
+    what = 'geom',
+    addFields = "mapunit.muname",
+    db = "STATSGO"
+  ))
   
   skip_if(inherits(res, 'try-error'))
   
@@ -154,15 +159,78 @@ test_that("SDA_spatialQuery() simple spatial query, spatial results", {
   expect_true(inherits(res, 'sf'))
   expect_equivalent(nrow(res), 1)
   
-  # test with what = "sapolygon" 
-  res <- suppressWarnings(SDA_spatialQuery(p, what = "sapolygon"))
+  # test with what = "sapolygon"
+  res <- suppressWarnings(SDA_spatialQuery(p, what = "sapolygon", addFields = "legend.areaname"))
   
   skip_if(inherits(res, 'try-error'))
   
   # testing known values
   expect_true(inherits(res, 'sf'))
   expect_equivalent(nrow(res), 1)
+  
+})
 
+test_that("SDA_spatialQuery(geomIntersection=TRUE) simple spatial query, spatial results", {
+  
+  
+  skip_if_not_installed("httr")
+  
+  skip_if_offline()
+  
+  skip_on_cran()
+  
+  skip_if_not_installed("sf")
+  
+  # test with default db = "SSURGO"
+  res <- suppressWarnings(
+    SDA_spatialQuery(
+      p,
+      what = 'geom',
+      addFields = "mapunit.muname",
+      geomIntersection = TRUE
+    )
+  )
+  
+  skip_if(inherits(res, 'try-error'))
+  
+  # testing known values
+  expect_true(inherits(res, 'sf'))
+  expect_equivalent(nrow(res), 1)
+  
+  
+  # test with db = "STATSGO"
+  res <- suppressWarnings(
+    SDA_spatialQuery(
+      p,
+      what = 'geom',
+      addFields = "mapunit.muname",
+      geomIntersection = TRUE,
+      db = "STATSGO"
+    )
+  )
+  
+  skip_if(inherits(res, 'try-error'))
+  
+  # testing known values
+  expect_true(inherits(res, 'sf'))
+  expect_equivalent(nrow(res), 1)
+  
+  # test with what = "sapolygon"
+  res <- suppressWarnings(
+    SDA_spatialQuery(
+      p,
+      what = "sapolygon",
+      addFields = "legend.areaname",
+      geomIntersection = TRUE
+    )
+  )
+  
+  skip_if(inherits(res, 'try-error'))
+  
+  # testing known values
+  expect_true(inherits(res, 'sf'))
+  expect_equivalent(nrow(res), 1)
+  
 })
 
 test_that("SDA_spatialQuery() spatial query of MUKEY with multiple features", {


### PR DESCRIPTION
- Fixes for a few combinations of parameters that did not work right in the common table expressions
- Added new tests to cover `geomIntersection` and `addFields` behavior with various geometry sources