### PR TITLE
refactor: `get_SDA_property(method="weighted average")`

### DIFF
--- a/R/get_SDA_property.R
+++ b/R/get_SDA_property.R
@@ -132,22 +132,41 @@ get_SDA_property <-
            miscellaneous_areas = FALSE,
            query_string = FALSE,
            dsn = NULL)
-    {
-
-  q <- .constructPropQuery(method = method,
-                           property = property,
-                           areasymbols = areasymbols,
-                           mukeys = mukeys,
-                           WHERE = WHERE,
-                           top_depth = top_depth,
-                           bottom_depth = bottom_depth,
-                           include_minors = include_minors,
-                           miscellaneous_areas = miscellaneous_areas,
-                           FUN = FUN,
-                           sqlite_dialect = !is.null(dsn))
-
-  if (query_string) return(q)
-
+    {    
+    
+    m <- c(
+      "DOMINANT COMPONENT (CATEGORY)",
+      "WEIGHTED AVERAGE",
+      "MIN/MAX",
+      "DOMINANT COMPONENT (NUMERIC)",
+      "DOMINANT CONDITION",
+      "NONE"
+    )
+    
+    if (missing(method)) {
+      stop("Please specify `method` argument as one of the following:\n", 
+           toString(shQuote(m)), call. = FALSE)
+    }
+    
+    method <- match.arg(toupper(method), m)
+    
+    q <- .constructPropQuery(
+      method = method,
+      property = property,
+      areasymbols = areasymbols,
+      mukeys = mukeys,
+      WHERE = WHERE,
+      top_depth = top_depth,
+      bottom_depth = bottom_depth,
+      include_minors = include_minors,
+      miscellaneous_areas = miscellaneous_areas,
+      FUN = FUN,
+      sqlite_dialect = !is.null(dsn)
+    )
+    
+    if (query_string)
+      return(q)
+    
   # execute query
   res <- SDA_query(q, dsn = dsn)
   
@@ -276,7 +295,9 @@ get_SDA_property <-
   } else if (!is.null(areasymbols)) {
     WHERE <- paste("legend.areasymbol IN", format_SQL_in_statement(areasymbols))
   }
-
+  
+  method <- toupper(method)
+  
   if (method != "NONE" &&
       (grepl("component\\.|chorizon\\.", WHERE)[1] ||
        grepl(paste(.valid_chorizon_columns(), collapse = "|"), WHERE)[1])) {
@@ -314,8 +335,6 @@ get_SDA_property <-
 
   if (!is.character(method))
     stop('argument `method` should be character string containing aggregation method, or `"NONE"` for no aggregation', call. = FALSE)
-
-  method <- toupper(method)
 
   if (method == "NONE") {
     # dput(colnames(SDA_query("SELECT TOP 1 * FROM chorizon"))) # without cokey


### PR DESCRIPTION
This pull request significantly refactors the SQL query generation logic in the `.property_weighted_average_CTE` function within `R/get_SDA_property.R`. Reduces repetition and total number of steps which were carried over from the old temporary table approach. 

Closes #431 which noted a regression in ability to query larger numbers of specific mapunits via `mukeys` argument. On deeper investigation, this seemed to be primarily related to repetition of complex WHERE clause constraints where IN statements contained many thousants of values, but there were several other opportunities for improvement.

With these changes we can comparatively efficiently query larger sets. Of course extremely large numbers of MUKEY will still be an issue and trigger "invalid query" response from server (as shown below), it should be quite a bit more rare.

> Invalid query: The query processor ran out of internal resources and could not produce a query plan. This is a rare event and only expected for extremely complex queries or queries that reference a very large number of tables or partitions. Please simplify the query. If you believe you have received this message in error, contact Customer Support Services for more information.

Example (10000 mapunits, 3 properties):

``` r
library(soilDB)

x <- SDA_query("SELECT TOP 10000 mukey FROM mapunit")
#> single result set, returning a data.frame

vars <- c("om_r", "claytotal_r", "ph1to1h2o_r")

p <- get_SDA_property(
    property = vars,
    method = "Weighted Average", 
    mukeys = x$mukey,
    top_depth = 5,
    bottom_depth = 15,
    include_minors = TRUE, 
    miscellaneous_areas = FALSE
)
#> single result set, returning a data.frame
length(unique(p$mukey))
#> [1] 10000
```