### PR TITLE
add remarks argument to OSDquery

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
  - `taxaExtent()` updates:
    - Added family mineralogy class grids 
    - Added argument `type` for selecting the type of query; replaces deprecated `formativeElement`
+ - `OSDquery()` gains `remarks` argument for searching the REMARKS section of OSDs
 
 # soilDB 2.8.13 (2025-09-26)
  - Added `get_SDA_NASIS_key()` for obtaining NASIS record IDs for component and component horizon data from Soil Data Access (#409)

--- a/R/OSDquery.R
+++ b/R/OSDquery.R
@@ -23,7 +23,7 @@
 #' 
 #' @details 
 #' 
-#' Queries including the `taxonomic_class` argument make use of the Soil Classification database, not fulltext seasrch of OSD records. Queries including the `mlra` argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
+#' Queries including the `taxonomic_class` argument make use of the Soil Classification database, not fulltext search of OSD records. Queries including the `mlra` argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
 #' 
 #' The `mlra` argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: `OSDquery(mlra = '18', typical_pedon = '5GY')`. 
 #'

--- a/R/OSDquery.R
+++ b/R/OSDquery.R
@@ -6,11 +6,11 @@
 #' 
 #' @description This is the R interface to [OSD search by Section](https://casoilresource.lawr.ucdavis.edu/osd-search/) and [OSD Search](https://casoilresource.lawr.ucdavis.edu/osd-search/search-entire-osd.php) APIs provided by SoilWeb.
 #' 
-#' OSD records are searched with the [PostgreSQL fulltext indexing](https://www.postgresql.org/docs/9.5/textsearch.html) and query system ([syntax details](https://www.postgresql.org/docs/9.5/datatype-textsearch.html)). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections. 
+#' OSD records are searched with the [PostgreSQL fulltext indexing](https://www.postgresql.org/docs/current/textsearch.html) and query system ([syntax details](https://www.postgresql.org/docs/current/textsearch-controls.html)). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections. 
 #' 
 #' @param everything search entire OSD text (default is NULL), `mlra` may also be specified, all other arguments are ignored
-#' @param mlra a comma-delimited string of MLRA to search ('17,18,22A'), see Details section below
-#' @param taxonomic_class search family level classification
+#' @param mlra a comma-delimited string of MLRA to search ('17,18,22A'), see Details
+#' @param taxonomic_class search family level classification, see Details
 #' @param typical_pedon search typical pedon section
 #' @param brief_narrative search brief narrative
 #' @param ric search range in characteristics section
@@ -23,25 +23,39 @@
 #' 
 #' @details 
 #' 
-#' The `mlra` argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: `OSDquery(mlra = '18', typical_pedon = '5GY')`.
+#' Queries including the `taxonomic_class` argument make use of the Soil Classification database, not fulltext seasrch of OSD records. Queries including the `mlra` argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
 #' 
-#' See [this webpage](https://casoilresource.lawr.ucdavis.edu/osd-search/) for more information.
+#' The `mlra` argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: `OSDquery(mlra = '18', typical_pedon = '5GY')`. 
 #'
-#'  - family level taxa are derived from SC database, not parsed OSD records
+#' ## Syntax Notes:
+#' The PostgreSQL fulltext query syntax is complex, but many common text search concepts are familiar:
+#' 
+#'  - logical AND: `&`
+#'  - logical OR: `|`
+#'  - wildcard, e.g. rhy-something: `rhy:*`
+#'  - search terms with spaces need doubled single quotes: `''san joaquin''`
+#'  - combine search terms into a single expression: `(grano:* | granite)`
 #'  
-#'  - MLRA are derived via spatial intersection (SSURGO x MLRA polygons)
+#'  ## Examples
+#'  Strategies for searching entire OSD records:
 #'  
-#'  - MLRA-filtering is only possible for series used in the current SSURGO snapshot (component name)
+#'  - `iowa & smectitic & verti:* & Cg & ! saturated`
+#'  - `iowa & smectitic & verti:* & Cg & terrace`
+#'  - `(sulfi:* | sulfa:*) & aq:*`
+#'  - `Coarse-loamy & mixed & active & thermic & Mollic & Haploxeralfs`
+#'  - `sierra & nevada & (meta:* | metamorphic) & xer:* & thermic & lithic`
+#'  - `sierra & nevada & foothill & (grano:* | granite) & thermic`
+#'  - `rhyo:* & tuff:* & California & thermic`
+#'  - `paralithic & thermic & !mesic & mollic & epipedon`
+#'  - `(gypsum | gyp:*) (MLRA: 15,17)`
+#'  - `flood & plains & toe & slope`
 #'  
-#'  - logical AND: &
+#' Strategies for search OSD fields:
 #'  
-#'  - logical OR: |
-#'  
-#'  - wildcard, e.g. rhy-something rhy:*
-#'  
-#'  - search terms with spaces need doubled single quotes: ''san joaquin''
-#'  
-#'  - combine search terms into a single expression: (grano:* | granite)
+#'  - `taxonomic_class = 'duri:* & thermic'`: family level classification contains "duri-" prefix and "thermic"
+#'  - `typical_pedon = 'cobbly & ashy & silt & loam'`: "cobbly, ashy, silt, loam", any horizon
+#'  - `geog_location = 'strath & terrace'`: "strath" and "terrace" in geographic setting narrative
+#'   
 #' 
 #' Related documentation can be found in the following tutorials
 #'  - [overview of all soil series query functions](http://ncss-tech.github.io/AQP/soilDB/soil-series-query-functions.html)
@@ -52,7 +66,7 @@
 #'
 #' @author D.E. Beaudette
 #'
-#' @note SoilWeb maintains a snapshot of the Official Series Description data.
+#' @note SoilWeb maintains a snapshot of the Official Series Description data, updated quarterly.
 #'
 #' @seealso [fetchOSD()], [siblings()]
 #'

--- a/R/OSDquery.R
+++ b/R/OSDquery.R
@@ -2,7 +2,7 @@
 # https://www.postgresql.org/docs/9.5/static/textsearch-controls.html
 # these are all parameters expected by the SoilWeb OSD Fulltext search
 
-#' Search full text of Official Series Description on SoilWeb 
+#' @title Search full text of Official Series Description on SoilWeb
 #' 
 #' @description This is the R interface to [OSD search by Section](https://casoilresource.lawr.ucdavis.edu/osd-search/) and [OSD Search](https://casoilresource.lawr.ucdavis.edu/osd-search/search-entire-osd.php) APIs provided by SoilWeb.
 #' 
@@ -18,10 +18,12 @@
 #' @param competing_series search competing series section
 #' @param geog_location search geographic setting section
 #' @param geog_assoc_soils search geographically associated soils section
+#' @param remarks search remarks section (typically contains diagnostic horizons / features)
+#' 
 #' 
 #' @details 
 #' 
-#' The `mlra` argument must be combined with another argument in order to become active. For example, search for series with 5GY hues in the "typical pedon" section, but limit to just MLRA 18: `OSDquery(mlra = '18', typical_pedon = '5GY')`.
+#' The `mlra` argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: `OSDquery(mlra = '18', typical_pedon = '5GY')`.
 #' 
 #' See [this webpage](https://casoilresource.lawr.ucdavis.edu/osd-search/) for more information.
 #'
@@ -52,7 +54,7 @@
 #'
 #' @note SoilWeb maintains a snapshot of the Official Series Description data.
 #'
-#' @seealso [fetchOSD()], [siblings()], [fetchOSD()]
+#' @seealso [fetchOSD()], [siblings()]
 #'
 #' @keywords manip
 #'
@@ -68,15 +70,15 @@
 #'   x <- fetchOSD(s$series, extended = TRUE, colorState = 'dry')
 #'
 #'   # simple figure
-#'   par(mar=c(0,0,1,1))
+#'   par(mar = c(0,0,1,1))
 #'   aqp::plotSPC(x$SPC)
 #' }
 #' 
-OSDquery <- function(everything = NULL, mlra = '', taxonomic_class = '', typical_pedon = '', brief_narrative = '', ric = '', use_and_veg = '', competing_series = '', geog_location = '', geog_assoc_soils = '') {
+OSDquery <- function(everything = NULL, mlra = '', taxonomic_class = '', typical_pedon = '', brief_narrative = '', ric = '', use_and_veg = '', competing_series = '', geog_location = '', geog_assoc_soils = '', remarks = '') {
  
   # check for required packages
-  if(!requireNamespace('httr', quietly=TRUE) | !requireNamespace('jsonlite', quietly=TRUE))
-    stop('please install the `httr` and `jsonlite` packages', call.=FALSE)
+  if(!requireNamespace('httr', quietly = TRUE) | !requireNamespace('jsonlite', quietly = TRUE))
+    stop('please install the `httr` and `jsonlite` packages', call. = FALSE)
 
   # sanity checks
   
@@ -96,7 +98,8 @@ OSDquery <- function(everything = NULL, mlra = '', taxonomic_class = '', typical
       use_and_veg = use_and_veg, 
       competing_series = competing_series, 
       geog_location = geog_location, 
-      geog_assoc_soils = geog_assoc_soils
+      geog_assoc_soils = geog_assoc_soils, 
+      remarks = remarks
     )
     
     # API URL

--- a/man/OSDquery.Rd
+++ b/man/OSDquery.Rd
@@ -14,7 +14,8 @@ OSDquery(
   use_and_veg = "",
   competing_series = "",
   geog_location = "",
-  geog_assoc_soils = ""
+  geog_assoc_soils = "",
+  remarks = ""
 )
 }
 \arguments{
@@ -37,6 +38,8 @@ OSDquery(
 \item{geog_location}{search geographic setting section}
 
 \item{geog_assoc_soils}{search geographically associated soils section}
+
+\item{remarks}{search remarks section (typically contains diagnostic horizons / features)}
 }
 \value{
 a \code{data.frame} object containing soil series names that match patterns supplied as arguments.
@@ -47,7 +50,7 @@ This is the R interface to \href{https://casoilresource.lawr.ucdavis.edu/osd-sea
 OSD records are searched with the \href{https://www.postgresql.org/docs/9.5/textsearch.html}{PostgreSQL fulltext indexing} and query system (\href{https://www.postgresql.org/docs/9.5/datatype-textsearch.html}{syntax details}). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections.
 }
 \details{
-The \code{mlra} argument must be combined with another argument in order to become active. For example, search for series with 5GY hues in the "typical pedon" section, but limit to just MLRA 18: \code{OSDquery(mlra = '18', typical_pedon = '5GY')}.
+The \code{mlra} argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: \code{OSDquery(mlra = '18', typical_pedon = '5GY')}.
 
 See \href{https://casoilresource.lawr.ucdavis.edu/osd-search/}{this webpage} for more information.
 \itemize{
@@ -72,7 +75,7 @@ Related documentation can be found in the following tutorials
 SoilWeb maintains a snapshot of the Official Series Description data.
 }
 \examples{
-\dontshow{if (curl::has_internet() && requireNamespace("httr") && requireNamespace("jsonlite") && require(aqp)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (curl::has_internet() && requireNamespace("httr") && requireNamespace("jsonlite") && require(aqp)) withAutoprint(\{ # examplesIf}
 
 \donttest{
   # find all series that list Pardee as a geographically associated soil.
@@ -82,7 +85,7 @@ SoilWeb maintains a snapshot of the Official Series Description data.
   x <- fetchOSD(s$series, extended = TRUE, colorState = 'dry')
 
   # simple figure
-  par(mar=c(0,0,1,1))
+  par(mar = c(0,0,1,1))
   aqp::plotSPC(x$SPC)
 }
 \dontshow{\}) # examplesIf}
@@ -91,7 +94,7 @@ SoilWeb maintains a snapshot of the Official Series Description data.
 USDA-NRCS OSD search tools: \url{https://soilseries.sc.egov.usda.gov/}
 }
 \seealso{
-\code{\link[=fetchOSD]{fetchOSD()}}, \code{\link[=siblings]{siblings()}}, \code{\link[=fetchOSD]{fetchOSD()}}
+\code{\link[=fetchOSD]{fetchOSD()}}, \code{\link[=siblings]{siblings()}}
 }
 \author{
 D.E. Beaudette

--- a/man/OSDquery.Rd
+++ b/man/OSDquery.Rd
@@ -21,9 +21,9 @@ OSDquery(
 \arguments{
 \item{everything}{search entire OSD text (default is NULL), \code{mlra} may also be specified, all other arguments are ignored}
 
-\item{mlra}{a comma-delimited string of MLRA to search ('17,18,22A'), see Details section below}
+\item{mlra}{a comma-delimited string of MLRA to search ('17,18,22A'), see Details}
 
-\item{taxonomic_class}{search family level classification}
+\item{taxonomic_class}{search family level classification, see Details}
 
 \item{typical_pedon}{search typical pedon section}
 
@@ -47,21 +47,45 @@ a \code{data.frame} object containing soil series names that match patterns supp
 \description{
 This is the R interface to \href{https://casoilresource.lawr.ucdavis.edu/osd-search/}{OSD search by Section} and \href{https://casoilresource.lawr.ucdavis.edu/osd-search/search-entire-osd.php}{OSD Search} APIs provided by SoilWeb.
 
-OSD records are searched with the \href{https://www.postgresql.org/docs/9.5/textsearch.html}{PostgreSQL fulltext indexing} and query system (\href{https://www.postgresql.org/docs/9.5/datatype-textsearch.html}{syntax details}). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections.
+OSD records are searched with the \href{https://www.postgresql.org/docs/current/textsearch.html}{PostgreSQL fulltext indexing} and query system (\href{https://www.postgresql.org/docs/current/textsearch-controls.html}{syntax details}). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections.
 }
 \details{
-The \code{mlra} argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: \code{OSDquery(mlra = '18', typical_pedon = '5GY')}.
+Queries including the \code{taxonomic_class} argument make use of the Soil Classification database, not fulltext seasrch of OSD records. Queries including the \code{mlra} argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
 
-See \href{https://casoilresource.lawr.ucdavis.edu/osd-search/}{this webpage} for more information.
+The \code{mlra} argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: \code{OSDquery(mlra = '18', typical_pedon = '5GY')}.
+\subsection{Syntax Notes:}{
+
+The PostgreSQL fulltext query syntax is complex, but many common text search concepts are familiar:
 \itemize{
-\item family level taxa are derived from SC database, not parsed OSD records
-\item MLRA are derived via spatial intersection (SSURGO x MLRA polygons)
-\item MLRA-filtering is only possible for series used in the current SSURGO snapshot (component name)
-\item logical AND: &
-\item logical OR: |
-\item wildcard, e.g. rhy-something rhy:*
-\item search terms with spaces need doubled single quotes: ''san joaquin''
-\item combine search terms into a single expression: (grano:* | granite)
+\item logical AND: \code{&}
+\item logical OR: \code{|}
+\item wildcard, e.g. rhy-something: \verb{rhy:*}
+\item search terms with spaces need doubled single quotes: \verb{''san joaquin''}
+\item combine search terms into a single expression: \verb{(grano:* | granite)}
+}
+}
+
+\subsection{Examples}{
+
+Strategies for searching entire OSD records:
+\itemize{
+\item \verb{iowa & smectitic & verti:* & Cg & ! saturated}
+\item \verb{iowa & smectitic & verti:* & Cg & terrace}
+\item \verb{(sulfi:* | sulfa:*) & aq:*}
+\item \code{Coarse-loamy & mixed & active & thermic & Mollic & Haploxeralfs}
+\item \verb{sierra & nevada & (meta:* | metamorphic) & xer:* & thermic & lithic}
+\item \verb{sierra & nevada & foothill & (grano:* | granite) & thermic}
+\item \verb{rhyo:* & tuff:* & California & thermic}
+\item \code{paralithic & thermic & !mesic & mollic & epipedon}
+\item \verb{(gypsum | gyp:*) (MLRA: 15,17)}
+\item \code{flood & plains & toe & slope}
+}
+
+Strategies for search OSD fields:
+\itemize{
+\item \code{taxonomic_class = 'duri:* & thermic'}: family level classification contains "duri-" prefix and "thermic"
+\item \code{typical_pedon = 'cobbly & ashy & silt & loam'}: "cobbly, ashy, silt, loam", any horizon
+\item \code{geog_location = 'strath & terrace'}: "strath" and "terrace" in geographic setting narrative
 }
 
 Related documentation can be found in the following tutorials
@@ -71,8 +95,9 @@ Related documentation can be found in the following tutorials
 \item \href{https://ncss-tech.github.io/AQP/soilDB/siblings.html}{siblings}
 }
 }
+}
 \note{
-SoilWeb maintains a snapshot of the Official Series Description data.
+SoilWeb maintains a snapshot of the Official Series Description data, updated quarterly.
 }
 \examples{
 \dontshow{if (curl::has_internet() && requireNamespace("httr") && requireNamespace("jsonlite") && require(aqp)) withAutoprint(\{ # examplesIf}

--- a/man/OSDquery.Rd
+++ b/man/OSDquery.Rd
@@ -50,7 +50,7 @@ This is the R interface to \href{https://casoilresource.lawr.ucdavis.edu/osd-sea
 OSD records are searched with the \href{https://www.postgresql.org/docs/current/textsearch.html}{PostgreSQL fulltext indexing} and query system (\href{https://www.postgresql.org/docs/current/textsearch-controls.html}{syntax details}). Each search field (except for the "brief narrative" and MLRA) corresponds with a section header in an OSD. The results may not include every OSD due to formatting errors and typos. Results are scored based on the number of times search terms match words in associated sections.
 }
 \details{
-Queries including the \code{taxonomic_class} argument make use of the Soil Classification database, not fulltext seasrch of OSD records. Queries including the \code{mlra} argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
+Queries including the \code{taxonomic_class} argument make use of the Soil Classification database, not fulltext search of OSD records. Queries including the \code{mlra} argument make use of a SoilWeb data source based on spatial intersection (SSURGO x MLRA polygons), updated quarterly. MLRA queries are only possible for those soil series used in the current SSURGO snapshot.
 
 The \code{mlra} argument must be combined with another argument in order to become active. For example, search for series with "5GY" hues in the "typical pedon" section, but limit to just MLRA 18: \code{OSDquery(mlra = '18', typical_pedon = '5GY')}.
 \subsection{Syntax Notes:}{


### PR DESCRIPTION
This PR adds a new `remarks` argument to `OSDquery()`. Searching the REMARKS section of an OSD can sometimes be useful for finding diagnostic horizons features. The related SoilWeb API has already been updated.