### PR TITLE
adding geomorphon proportions by soil series to fetchOSD()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # soilDB 2.8.14 (development)
+ - new vignette with details on SoilWeb curated data sources, and related functions in soilDB
  - `fetchOSD(..., extended = TRUE)` gains geomorphon proportions via SoilWeb 
  - `taxaExtent()` updates:
    - Added family mineralogy class grids 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # soilDB 2.8.14 (development)
+ - `fetchOSD(..., extended = TRUE)` gains geomorphon proportions via SoilWeb 
  - `taxaExtent()` updates:
    - Added family mineralogy class grids 
    - Added argument `type` for selecting the type of query; replaces deprecated `formativeElement`

--- a/R/fetchOSD.R
+++ b/R/fetchOSD.R
@@ -5,7 +5,7 @@
 #             * annual.climate is now a data.frame padded with NA when series is outside of CONUS
 #             * eff_class added to horizon data
 
-# 2026-01-10: API change, geomorphon proportions added to 'extended'
+# 2026-01-10: API change, geomorphon proportions added to 'extended' request
 
 
 ## tabulate the number of records within each geomorphic table
@@ -51,9 +51,6 @@
 
 
 
-## TODO: consider adding an argument for "growing" very thin bottom R|Cr|Cd horizons
-# https://github.com/ncss-tech/aqp/issues/173
-
 #' @title Get Official Series Descriptions and summaries from SoilWeb API
 #'
 #' @description This function fetches a variety of data associated with named soil series, extracted from the USDA-NRCS Official Series Description text files and detailed soil survey (SSURGO). These data are updated quarterly and made available via SoilWeb. Set `extended = TRUE` and see the `soilweb.metadata` list element for information on when the source data were last updated. 
@@ -90,7 +87,7 @@
 #'
 #'   \item{pmkind}{empirical probabilities for parent material kind, derived from the current SSURGO snapshot}
 #'   \item{pmorigin}{empirical probabilities for parent material origin, derived from the current SSURGO snapshot}
-#'   \item{geomorphons}{geomorphons landform classification, derived from the current SSURGO snapshot and ...}
+#'   \item{geomorphons}{geomorphons landform classification (CONUS only), derived from the current gSSURGO snapshot and a 30m CONUS geomoprhons grid, details pending}
 #'   \item{mlra}{empirical MLRA membership values, derived from the current SSURGO snapshot}
 #'   \item{ecoclassid}{area cross-tabulation of ecoclassid by soil series name, derived from the current SSURGO snapshot, major components only}
 #'   \item{climate}{climate summaries from PRISM stack (CONUS only)}
@@ -106,7 +103,7 @@
 #'
 #' \describe{
 #'
-#'   \item{1. A query for soil series that exist entirely outside of CONUS (e.g. PALAU).}{ - Climate summaries are empty \code{data.frames} because these summaries are currently generated from PRISM. We are working on a solution that uses DAYMET.}
+#'   \item{1. A query for soil series that exist entirely outside of CONUS (e.g. PALAU).}{ - Climate summaries are empty `data.frame` because these summaries are currently generated from PRISM. We are working on a solution that uses DAYMET.}
 #'
 #'   \item{2. A query for data within CONUS, but OSD morphology missing due to parsing error (e.g. formatting, typos).}{ - Extended summaries are present but morphology missing from `SPC`. A warning is issued.}
 #'
@@ -116,7 +113,7 @@
 #'
 #'}
 #'
-#' @return a `SoilProfileCollection` object containing basic soil morphology and taxonomic information.
+#' @return a `SoilProfileCollection` object containing basic soil morphology and taxonomic information, a `list` when `extended = TRUE`.
 #'
 #' @references USDA-NRCS OSD search tools: \url{https://soilseries.sc.egov.usda.gov/}
 #'

--- a/R/fetchOSD.R
+++ b/R/fetchOSD.R
@@ -5,6 +5,8 @@
 #             * annual.climate is now a data.frame padded with NA when series is outside of CONUS
 #             * eff_class added to horizon data
 
+# 2026-01-10: API change, geomorphon proportions added to 'extended'
+
 
 ## tabulate the number of records within each geomorphic table
 ## there could be some cases where there are no records, resulting in FALSE
@@ -88,6 +90,7 @@
 #'
 #'   \item{pmkind}{empirical probabilities for parent material kind, derived from the current SSURGO snapshot}
 #'   \item{pmorigin}{empirical probabilities for parent material origin, derived from the current SSURGO snapshot}
+#'   \item{geomorphons}{geomorphons landform classification, derived from the current SSURGO snapshot and ...}
 #'   \item{mlra}{empirical MLRA membership values, derived from the current SSURGO snapshot}
 #'   \item{ecoclassid}{area cross-tabulation of ecoclassid by soil series name, derived from the current SSURGO snapshot, major components only}
 #'   \item{climate}{climate summaries from PRISM stack (CONUS only)}
@@ -347,9 +350,9 @@ fetchOSD <- function(soils, colorState = 'moist', extended = FALSE) {
 	if(extended) {
 	  
 	  # unravel nested lists
-	  .tables <- c('competing', 'geog_assoc_soils', 'geomcomp', 'hillpos', 'mtnpos', 'terrace', 'flats', 'shape_across', 'shape_down', 'pmkind', 'pmorigin', 'mlra', 'ecoclassid', 'climate', 'nccpi')
+	  .tables <- c('competing', 'geog_assoc_soils', 'geomcomp', 'hillpos', 'mtnpos', 'terrace', 'flats', 'shape_across', 'shape_down', 'pmkind', 'pmorigin', 'geomorphons', 'mlra', 'ecoclassid', 'climate', 'nccpi')
 	  
-	  # chunk-wise missing tabular data is reported as FALSE
+	  # chunk-wise missing tabular data are reported as FALSE
 	  # cannot rbind(FALSE) or rbind(FALSE, data.frame) -> corruption of data
 	  for(.tab in .tables) {
 	    .tabdata <- lapply(r, '[[', .tab)
@@ -364,22 +367,6 @@ fetchOSD <- function(soils, colorState = 'moist', extended = FALSE) {
 	    }
 	    
 	  }
-	  
-	  # res$competing <- do.call('rbind', lapply(r, '[[', 'competing'))
-	  # res$geog_assoc_soils <- do.call('rbind', lapply(r, '[[', 'geog_assoc_soils'))
-	  # res$geomcomp <- do.call('rbind', lapply(r, '[[', 'geomcomp'))
-	  # res$hillpos <- do.call('rbind', lapply(r, '[[', 'hillpos'))
-	  # res$mtnpos <- do.call('rbind', lapply(r, '[[', 'mtnpos'))
-	  # res$terrace <- do.call('rbind', lapply(r, '[[', 'terrace'))
-	  # res$flats <- do.call('rbind', lapply(r, '[[', 'flats'))
-	  # res$shape_across <- do.call('rbind', lapply(r, '[[', 'shape_across'))
-	  # res$shape_down <- do.call('rbind', lapply(r, '[[', 'shape_down'))
-	  # res$pmkind <- do.call('rbind', lapply(r, '[[', 'pmkind'))
-	  # res$pmorigin <- do.call('rbind', lapply(r, '[[', 'pmorigin'))
-	  # res$mlra <- do.call('rbind', lapply(r, '[[', 'mlra'))
-	  # res$ecoclassid <- do.call('rbind', lapply(r, '[[', 'ecoclassid'))
-	  # res$climate <- do.call('rbind', lapply(r, '[[', 'climate'))
-	  # res$nccpi <- do.call('rbind', lapply(r, '[[', 'nccpi'))
 	  
 	  # metadata are identical across chunks
 	  res$metadata <- unique(do.call('rbind', lapply(r, '[[', 'metadata')))
@@ -464,6 +451,7 @@ fetchOSD <- function(soils, colorState = 'moist', extended = FALSE) {
 	    shape_down = res$shape_down,
 	    pmkind = res$pmkind,
 	    pmorigin = res$pmorigin,
+	    geomorphons = res$geomorphons,
 	    mlra = res$mlra,
 	    ecoclassid = res$ecoclassid,
 	    climate.annual = annual.data,

--- a/R/fetchOSD.R
+++ b/R/fetchOSD.R
@@ -235,15 +235,7 @@ fetchOSD <- function(soils, colorState = 'moist', extended = FALSE) {
   h <- res$hz
 
 	# report missing data
-  # no data condition 2-1/2-2: s and h => FALSE
   # no data condition 4-1/4-2: s and h => structure(list(), dim = 1:0, dimnames = list(NULL, NULL))
-  
-  # only works for 2-1/2-2 php-pgsql
-  # if ((is.logical(s) && length(s) == 1) ||
-  #     (is.logical(h) & length(h) == 1)) {
-  #   message('query returned no data')
-  #   return(NULL)
-  # }
   
   # 4-1/4-2 updated php-pgsql
   # no data condition: either `s` OR `h` are NOT `data.frame`

--- a/man/fetchOSD.Rd
+++ b/man/fetchOSD.Rd
@@ -46,6 +46,7 @@ The standard set of "site" and "horizon" data are returned as a \code{SoilProfil
 
 \item{pmkind}{empirical probabilities for parent material kind, derived from the current SSURGO snapshot}
 \item{pmorigin}{empirical probabilities for parent material origin, derived from the current SSURGO snapshot}
+\item{geomorphons}{geomorphons landform classification, derived from the current SSURGO snapshot and ...}
 \item{mlra}{empirical MLRA membership values, derived from the current SSURGO snapshot}
 \item{ecoclassid}{area cross-tabulation of ecoclassid by soil series name, derived from the current SSURGO snapshot, major components only}
 \item{climate}{climate summaries from PRISM stack (CONUS only)}
@@ -73,7 +74,7 @@ These last two cases are problematic for analysis that makes use of morphology a
 Requests to the SoilWeb API are split into batches of 100 series names from \code{soils} via \code{\link[=makeChunks]{makeChunks()}}.
 }
 \examples{
-\dontshow{if (curl::has_internet() && requireNamespace("httr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (curl::has_internet() && requireNamespace("httr", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 \donttest{
   library(aqp)
   # soils of interest

--- a/man/fetchOSD.Rd
+++ b/man/fetchOSD.Rd
@@ -14,7 +14,7 @@ fetchOSD(soils, colorState = "moist", extended = FALSE)
 \item{extended}{if \code{TRUE} additional soil series summary data are returned, see details}
 }
 \value{
-a \code{SoilProfileCollection} object containing basic soil morphology and taxonomic information.
+a \code{SoilProfileCollection} object containing basic soil morphology and taxonomic information, a \code{list} when \code{extended = TRUE}.
 }
 \description{
 This function fetches a variety of data associated with named soil series, extracted from the USDA-NRCS Official Series Description text files and detailed soil survey (SSURGO). These data are updated quarterly and made available via SoilWeb. Set \code{extended = TRUE} and see the \code{soilweb.metadata} list element for information on when the source data were last updated.
@@ -46,7 +46,7 @@ The standard set of "site" and "horizon" data are returned as a \code{SoilProfil
 
 \item{pmkind}{empirical probabilities for parent material kind, derived from the current SSURGO snapshot}
 \item{pmorigin}{empirical probabilities for parent material origin, derived from the current SSURGO snapshot}
-\item{geomorphons}{geomorphons landform classification, derived from the current SSURGO snapshot and ...}
+\item{geomorphons}{geomorphons landform classification (CONUS only), derived from the current gSSURGO snapshot and a 30m CONUS geomoprhons grid, details pending}
 \item{mlra}{empirical MLRA membership values, derived from the current SSURGO snapshot}
 \item{ecoclassid}{area cross-tabulation of ecoclassid by soil series name, derived from the current SSURGO snapshot, major components only}
 \item{climate}{climate summaries from PRISM stack (CONUS only)}
@@ -60,7 +60,7 @@ When using \code{extended = TRUE}, there are a couple of scenarios in which seri
 
 \describe{
 
-\item{1. A query for soil series that exist entirely outside of CONUS (e.g. PALAU).}{ - Climate summaries are empty \code{data.frames} because these summaries are currently generated from PRISM. We are working on a solution that uses DAYMET.}
+\item{1. A query for soil series that exist entirely outside of CONUS (e.g. PALAU).}{ - Climate summaries are empty \code{data.frame} because these summaries are currently generated from PRISM. We are working on a solution that uses DAYMET.}
 
 \item{2. A query for data within CONUS, but OSD morphology missing due to parsing error (e.g. formatting, typos).}{ - Extended summaries are present but morphology missing from \code{SPC}. A warning is issued.}
 

--- a/misc/soilweb-bbox-to-sketches.R
+++ b/misc/soilweb-bbox-to-sketches.R
@@ -12,6 +12,10 @@ library(soilDB)
 ## press 'b', BBOX is copied to the clipboard
 
 
+## TX Edwards Plateau
+bb <- '-101.1297 30.9521,-101.1297 31.0276,-101.0067 31.0276,-101.0067 30.9521,-101.1297 30.9521'
+
+
 ## TX155: https://casoilresource.lawr.ucdavis.edu/gmap/?loc=34.05629,-99.57999,z14
 bb <- '-99.6431 34.0224,-99.6431 34.0902,-99.5268 34.0902,-99.5268 34.0224,-99.6431 34.0224'
 

--- a/tests/testthat/test-fetchOSD.R
+++ b/tests/testthat/test-fetchOSD.R
@@ -2,7 +2,7 @@ context("fetchOSD() -- requires internet connection")
 
 ## these are the elements of the list returned when extended=TRUE
 ## update here as-needed
-extended.table.names <<- c("SPC", "competing", "geog_assoc_soils" ,"geomcomp", "hillpos", "mtnpos", "terrace", "flats", "shape_across", "shape_down", "pmkind", "pmorigin", "mlra", "ecoclassid", "climate.annual", "climate.monthly", "NCCPI", "soilweb.metadata")
+extended.table.names <<- c("SPC", "competing", "geog_assoc_soils" ,"geomcomp", "hillpos", "mtnpos", "terrace", "flats", "shape_across", "shape_down", "pmkind", "pmorigin", "geomorphons", "mlra", "ecoclassid", "climate.annual", "climate.monthly", "NCCPI", "soilweb.metadata")
 
 test_that("fetchOSD() works", {
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -27,7 +27,7 @@ x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE
 # Summary
 The soilDB package relies on a number of data sources curated as part of the [SoilWeb](https://casoilresource.lawr.ucdavis.edu/soilweb-apps) ecosystem of web applications, APIs, web coverage services (WCS), and internally-used lookup tables. These data are always updated shortly after the beginning of each fiscal year (October 1st) as part of the SSURGO refresh cycle. Within-cycle updates are typically performed quarterly. 
 
-Many of these curated data sources are documented in:
+Many of these curated data sources and their evolution through time have been documented in:
 
   * O'Geen, A., Walkinshaw, M. and Beaudette, D.E. (2017), SoilWeb: A Multifaceted Interface to Soil Survey Information. Soil Sci. Soc. Am. J., 81: 853-862. https://doi.org/10.2136/sssaj2016.11.0386n
   
@@ -50,53 +50,101 @@ Many of these curated data sources are documented in:
 
 
 ## `soilDB` Functions
+The following functions interact with SoilWeb APIs or Web Coverage Service (WCS) to request and download tabular or spatial data. Some functions return `SoilProfileCollection` objects, as defined in the [aqp](https://ncss-tech.github.io/aqp/) package.
+
+
+Tabular data and/or `SoilProfileCollection`:
 
  * `fetchOSD()`: get soil morphology  and many soil series level summaries for one or more soil series names
  * `OSDquery()`: search the OSD records using the postgresql full text query syntax
  * `siblings()`: get names and basic information about soil series that co-occurr within soil map units containing  a given series
  
+Spatia ldata:
+
  * `seriesExtent()`: get vector or raster representations of were soil series have been used in SSURGO
  * `taxaExtent()`: get raster representations of were taxa and formative elements (Soil Taxonomy) have been used in SSURGO
  
+WCS:
+
  * `mukey.wcs()`: get raster data describing map unit keys, from a variety of sources, by bounding-box
  * `ISSR800.wcs()`: get raster data describing generalized patterns in soil property and condition, by bounding-box
  * `soilColor.wcs()`: get raster soil color maps by bounding-box
  
  
+The `fetchOSD()` function, when specified with the `extended = TRUE` argument, will include the last updated date for curated sources. For example:
+
+|product                       |last_update |
+|:-----------------------------|:-----------|
+|ISSR800                       |2024-10-30  |
+|KSSL snapshot                 |2025-01-21  |
+|MLRA membership               |2025-10-07  |
+|OSD fulltext                  |2026-01-02  |
+|OSD morphology                |2026-01-02  |
+|SC database                   |2026-01-02  |
+|series climate summary        |2025-10-08  |
+|series-ESID cross-tabulation  |2025-10-07  |
+|SSURGO geomorphology          |2025-10-06  |
+|SSURGO geomorphon             |2026-01-11  |
+|SSURGO NCCPI Stats            |2025-10-19  |
+|SSURGO parent material        |2025-10-06  |
+|series extent                 |2025-10-04  |
+|taxa extent                   |2025-10-21  |
+
+Details about these data sources are provided below.
 
  
-### Functions Near Retirement
+### Functions with Questionable Future
+Some functions represent temporary solutions to data delivery problems that made sense in the past. `fetchKSSL()` relies on an older snapshot of the NCSS LDM (2020), `fetchRaCA()` relies on a pre-release of the current RaCA database, and `SoilWeb_spatial_query()` has been superseded by soilDB functions which interface with Soil Data Access (see [`SDA_query()`](https://ncss-tech.github.io/soilDB/reference/SDA_query.html) and [`SDA_spatialQuery`](https://ncss-tech.github.io/soilDB/reference/SDA_spatialQuery.html)). 
+
 
  * `fetchKSSL()`: get soil characterization and (limited) morphology data
  * `fetchRaCA()`: get records associated with the RaCA collection
  * `SoilWeb_spatial_query()`: simple interface to spatial intersection between SSURGO polygons and user supplied bounding-box
 
+There are currently no replacements for all of the functionality provided by `fetchKSSL()` and `fetchRaCA()`. See [`fetchLDM()`](https://ncss-tech.github.io/soilDB/reference/fetchLDM.html) for a modern approach to downloading NCSS LDM snapshot data.
 
 
-
-## Related APIs
+## Related Web Applications
+The [`OSDquery()`](https://ncss-tech.github.io/soilDB/reference/OSDquery.html) function provides a convenient interface to the API behind the SoilWeb OSD Search applications:
 
  * https://soilmap4-1.lawr.ucdavis.edu/osd-search/index.php
  * https://casoilresource.lawr.ucdavis.edu/osd-search/search-entire-osd.php
  
+The web-based version of this search is limited to 100 records but `OSDquery()` has no record limit.
 
+The [`seriesExtent()`](https://ncss-tech.github.io/soilDB/reference/seriesExtent.html) function provides an interface to the data behind the [SoilWeb Series Extent Explorer](https://casoilresource.lawr.ucdavis.edu/see/) (SEE) application. The SEE website includes a short description of how the source data were created.
 
+The [`taxaExtent()`](https://ncss-tech.github.io/soilDB/reference/taxaExtent.html) function provides an interface to the data behind the [SoilWeb Soil Taxonomy Explorer](https://casoilresource.lawr.ucdavis.edu/ste/) (STE) application. the STE website includes a short description of how the source data were created.
 
 
 # SoilWeb Curated Data Sources
 
 
+## SC and OSD Derivatives
+
+```{r}
+knitr::kable(head(x$competing))
+
+knitr::kable(head(x$geog_assoc_soils))
+```
+
+
+
+
 ## SSURGO Derivatives
+
+... normalization of SSURGO component names into qualified soil series names via SC database.
 
 
 ### MLRA
-
+... spatial intersection SSURGO map unit polygons x MLRA polygons
 ```{r}
 knitr::kable(head(x$mlra), digits = 2)
 ```
 
 
 ### Geomorphic Summaries
+cross-tabulation component names → series names x geomorphic tables
 
 ```{r}
 knitr::kable(head(x$hillpos), digits = 2)
@@ -135,11 +183,192 @@ knitr::kable(head(x$pmorigin), digits = 2)
 
 ## Climate Data and Derivatives
 
+These maps are derived from the daily, 800m resolution, PRISM data spanning 1981--2010.
+
+  * Mean annual air temperature (deg. C), derived from daily minimum and maximum temperatures.
+  * Mean accumulated annual precipitation (mm), derived from daily totals.
+  * Mean monthly temperature (deg. C), derived from daily minimum and maximum temperatures.
+  * Mean accumulated monthly precipitation (mm), derived from daily totals.
+  * Estimated monthly potential evapotranspiration
+
+
+
+
 ```{r}
 knitr::kable(head(x$climate.annual), digits = 0)
 
 knitr::kable(head(x$climate.monthly), digits = 0)
 ```
+
+
+
+
+### Frost-Free Period
+
+Number of days in the 50%, 80%, and 90% probability frost-free period, derived from daily minimum temperatures greater than 0 degrees C.
+
+These maps are based on 50/80/90 percent probability estimates for the last spring frost and first fall frost (day of year). See the related [algorithm documentation](http://ncss-tech.github.io/AQP/sharpshootR/FFD-estimates.html) for details.
+
+Values have been cross-checked with 300+ weather stations in CA.
+
+
+ <div align=center><strong>Linear Regression Model</strong></div>
+ 
+ <pre>
+ ols(formula = ffd.50 ~ prism_ffd, data = z)
+ </pre>
+ 
+ <table class='gmisc_table' style='border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;' >
+<thead>
+<tr>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; border-left: 1px solid black; border-right: 1px solid black; text-align: center;'></th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; border-right: 1px solid black; text-align: center;'>Model Likelihood<br>Ratio Test</th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; border-right: 1px solid black; text-align: center;'>Discrimination<br>Indexes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style='min-width: 9em; border-left: 1px solid black; border-right: 1px solid black; text-align: center;'>Obs 328</td>
+<td style='min-width: 9em; border-right: 1px solid black; text-align: center;'>LR χ<sup>2</sup> 526.00</td>
+<td style='min-width: 9em; border-right: 1px solid black; text-align: center;'><i>R</i><sup>2</sup> 0.799</td>
+</tr>
+<tr>
+<td style='min-width: 9em; border-left: 1px solid black; border-right: 1px solid black; text-align: center;'>Ïƒ 42.2446</td>
+<td style='min-width: 9em; border-right: 1px solid black; text-align: center;'>d.f. 1</td>
+<td style='min-width: 9em; border-right: 1px solid black; text-align: center;'><i>R</i><sup><span style='font-size: 70%;'>2</span></sup><sub style='position: relative; left: -.47em; bottom: -.4em;'><span style='font-size: 70%;'>adj</span></sub> 0.798</td>
+</tr>
+<tr>
+<td style='min-width: 9em; border-bottom: 2px solid grey; border-left: 1px solid black; border-right: 1px solid black; text-align: center;'>d.f. 326</td>
+<td style='min-width: 9em; border-bottom: 2px solid grey; border-right: 1px solid black; text-align: center;'>Pr(>χ<sup>2</sup>) 0.0000</td>
+<td style='min-width: 9em; border-bottom: 2px solid grey; border-right: 1px solid black; text-align: center;'><i>g</i> 95.935</td>
+</tr>
+</tbody>
+</table>
+
+ 
+ <div align=center>Residuals</div>
+ 
+ <pre>
+      Min       1Q   Median       3Q      Max 
+ -278.344  -16.875    2.436   14.323  274.604 
+ </pre>
+ 
+ 
+ <table class='gmisc_table' style='border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;' >
+<thead>
+<tr>
+<th style='font-weight: 900; border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'></th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: right;'>β</th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: right;'>S.E.</th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: right;'><i>t</i></th>
+<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: right;'>Pr(>|<i>t</i>|)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style='text-align: left;'>Intercept</td>
+<td style='min-width: 7em; text-align: right;'> 15.1397</td>
+<td style='min-width: 7em; text-align: right;'> 5.3455</td>
+<td style='min-width: 7em; text-align: right;'> 2.83</td>
+<td style='min-width: 7em; text-align: right;'>0.0049</td>
+</tr>
+<tr>
+<td style='border-bottom: 2px solid grey; text-align: left;'>prism_ffd</td>
+<td style='min-width: 7em; border-bottom: 2px solid grey; text-align: right;'>  0.9407</td>
+<td style='min-width: 7em; border-bottom: 2px solid grey; text-align: right;'> 0.0261</td>
+<td style='min-width: 7em; border-bottom: 2px solid grey; text-align: right;'>35.98</td>
+<td style='min-width: 7em; border-bottom: 2px solid grey; text-align: right;'><0.0001</td>
+</tr>
+</tbody>
+</table>
+
+
+### Frost-Free Days
+
+   * Frost-free days, 50% probability.
+   * Frost-free days, 80% probability.
+   * Frost-free days, 90% probability.
+
+
+### Design Freeze Index
+
+   * number of degree days below 0 deg C, 90th percentile
+
+From _NSSH Part 618.33 Frost Action, Potential_:
+
+> Part 618, Subpart B, Exhibits, Section 618.85 is a map that shows the design freezing index values in the continental United States. The values **are the number of degree days below 0 deg C for the coldest year in a period of 10 years** . The values indicate duration and intensity of freezing temperatures. The 250 isoline is the approximate boundary below which frost action ceases to be a problem.
+
+
+Methods:
+
+   * using units of degrees Celsius, and daily average air temperature ($Tavg$) 
+   * freezing degree days for a single year: $FI = sum( abs( min(0, Tavg) ) )$
+   * design freezing index, over 30 year record: $DFI = Q90( FI )$ where **FI** is the stack of annual FI
+
+Notes:
+
+   * There is a fairly large difference in where the 250 DFI isoline falls, depending on the temperature units.
+   * The 90th percentile of **FI** seems to track the notion of "coldest year in 10 years".
+   * The "average of 3 coldest years in 30" method gives different results, but spatial patterns are the same.
+   * Related [conversation](https://github.com/ncss-tech/soilReports/issues/84) on the calculation and interpretation.
+
+
+
+### Growing Degree Days (C)
+
+Mean (Celsius) growing degree days, derived from the 800m PRISM daily minimum/maximum temperature data over the interval of 1981--2010.
+
+Calculation reference: http://agron-www.agron.iastate.edu/courses/Agron541/classes/541/lesson02b/2b.1.1.html
+
+$$GDD_i = [ min(T_{max}, upper_{threshold}) + max(Tmin, lower_{threshold}) / 2 ] - T_{base}$$
+
+$$GDD_i = max(GDD_i, 0)$$
+
+
+### Effective Precipitation
+
+Annual sum of monthly (total) precipitation - monthly (estimated) evapotranspiration, averaged over the interval of 1981--2010. Potential evapotranspiration (PET) estimated via [Thornthwaite's method of 1948](https://en.wikipedia.org/wiki/Potential_evaporation). Input sources included:
+
+   * 800m resolution, monthly, total precipitation (PRISM group)
+   * 800m resolution, monthly, mean air temperature (PRISM group)
+   
+Processing in GRASS GIS.
+
+
+### Fraction of Precipitation as Rain
+
+This map contains estimates of the fraction of total (annual) precipitation as rain, derived from 800m daily PRISM Tmax and PPT grids (1981--2010). Calculations were performed using GRASS GIS, with methods and estimated parameters of the conditional snow probability function from Rajagopal and Harpold (2016).
+
+Partition PPT into snow/rain:
+
+$$rain = PPT - snow$$
+
+$$snow = PPT * Pr(snow)$$
+
+compute $Pr(snow)$ as a function of $Tmax$ using [exponential identity for hyperbolic tangent function](https://en.wikipedia.org/wiki/Hyperbolic_function#Standard_analytic_expressions):
+
+Evaluate conditional probability (fraction) of snow on a daily basis:
+
+$$Pr(snow) = a * ( tanh(b * (Tmax - c) ) - d )$$
+
+a:-0.5, b:0.21, c:0.5, d:1
+
+$$tanh(x) = (1 - exp(-2*x)) / (1 + exp(-2*x))$$
+
+$$Pr(snow) = -0.5 * ( (1 - exp(-2 * (0.21 * (Tmax - 0.5) ))) / (1 + exp(-2 * (0.21 * (Tmax - 0.5) ))) - 1 )$$
+
+$$rain = PPT - (PPT * Pr(snow))$$
+
+For each year($i$): 
+
+$$rain fraction_i = sum(rain_i) / sum(PPT_i)$$
+
+Percentages have been converted to integers ranging from 0 to 100.
+
+
+Rajagopal, S. and A.A. Harpold. 2016. Testing and Improving Temperature Thresholds for Snow and Rain Prediction in the Western United States. Journal of the American Water Resources Association, 52: 1142-1154.
+
+
 
 
 
@@ -149,41 +378,26 @@ knitr::kable(head(x$climate.monthly), digits = 0)
 knitr::kable(head(x$geomorphons), digits = 2)
 ```
 
+These maps were generated using the [r.geomorphon GRASS GIS module](https://grass.osgeo.org/grass75/manuals/r.geomorphon.html), with the following parameters: 
 
-## SC and OSD Derivatives
+`r.geomorphon --o dem=elev30_int forms=forms30 search=75 skip=5 flat=1.718`
 
-```{r}
-knitr::kable(head(x$competing))
+The source DEM was a 10m / 30m resolution compilation of USGS NED data, rounded to integers. The "flat" threshold (1.718 deg) is based on a 3% slope break.
 
-knitr::kable(head(x$geog_assoc_soils))
-```
-
+[Jasiewicz, J., Stepinski, T., 2013, Geomorphons - a pattern recognition approach to classification and mapping of landforms, Geomorphology, vol. 182, 147-156.](http://www.sciencedirect.com/science/article/pii/S0169555X12005028)
 
 
-Relevant SoilWeb data metadata, as reported by `fetchOSD(..., extended = TRUE)`:
 
 
-|product                       |last_update |
-|:-----------------------------|:-----------|
-|ISSR800                       |2024-10-30  |
-|KSSL snapshot                 |2025-01-21  |
-|MLRA membership               |2025-10-07  |
-|OSD fulltext                  |2026-01-02  |
-|OSD morphology                |2026-01-02  |
-|SC database                   |2026-01-02  |
-|series climate summary        |2025-10-08  |
-|series-ESID cross-tabulation  |2025-10-07  |
-|SSURGO geomorphology          |2025-10-06  |
-|SSURGO geomorphon             |2026-01-11  |
-|SSURGO NCCPI Stats            |2025-10-19  |
-|SSURGO parent material        |2025-10-06  |
-|series extent                 |2025-10-04  |
-|taxa extent                   |2025-10-21  |
+
+
+
 
 
 
 
 # Relevant Tutorials
+
 
 
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
   fig.height = 7,
   fig.width = 7
 )
+
+# get source data for explanations
+library(soilDB)
+library(aqp)
+
+x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
 ```
 
 # Summary
@@ -43,39 +49,118 @@ Many of these curated data sources are documented in:
   * NRCS [Rapid Carbon Assessment](https://www.nrcs.usda.gov/resources/data-and-reports/rapid-carbon-assessment-raca) (RaCA)
 
 
+## `soilDB` Functions
+
+ * `fetchOSD()`: get soil morphology  and many soil series level summaries for one or more soil series names
+ * `OSDquery()`: search the OSD records using the postgresql full text query syntax
+ * `siblings()`: get names and basic information about soil series that co-occurr within soil map units containing  a given series
+ 
+ * `seriesExtent()`: get vector or raster representations of were soil series have been used in SSURGO
+ * `taxaExtent()`: get raster representations of were taxa and formative elements (Soil Taxonomy) have been used in SSURGO
+ 
+ * `mukey.wcs()`: get raster data describing map unit keys, from a variety of sources, by bounding-box
+ * `ISSR800.wcs()`: get raster data describing generalized patterns in soil property and condition, by bounding-box
+ * `soilColor.wcs()`: get raster soil color maps by bounding-box
+ 
+ 
+
+ 
+### Functions Near Retirement
+
+ * `fetchKSSL()`: get soil characterization and (limited) morphology data
+ * `fetchRaCA()`: get records associated with the RaCA collection
+ * `SoilWeb_spatial_query()`: simple interface to spatial intersection between SSURGO polygons and user supplied bounding-box
+
+
+
+
+## Related APIs
+
+ * https://soilmap4-1.lawr.ucdavis.edu/osd-search/index.php
+ * https://casoilresource.lawr.ucdavis.edu/osd-search/search-entire-osd.php
+ 
+
+
+
 
 # SoilWeb Curated Data Sources
+
 
 ## SSURGO Derivatives
 
 
 ### MLRA
 
+```{r}
+knitr::kable(head(x$mlra), digits = 2)
+```
+
 
 ### Geomorphic Summaries
+
+```{r}
+knitr::kable(head(x$hillpos), digits = 2)
+
+knitr::kable(head(x$geomcomp), digits = 2)
+
+knitr::kable(head(x$mtnpos), digits = 2)
+
+knitr::kable(head(x$terrace), digits = 2)
+
+knitr::kable(head(x$flats), digits = 2)
+
+knitr::kable(head(x$shape_across), digits = 2)
+
+knitr::kable(head(x$shape_down), digits = 2)
+```
+
+### Other
+
+```{r}
+knitr::kable(head(x$NCCPI), digits = 2)
+
+knitr::kable(head(x$ecoclassid), digits = 2)
+```
 
 
 ### Parent Material Summaries
 
+```{r}
+knitr::kable(head(x$pmkind), digits = 2)
 
+knitr::kable(head(x$pmorigin), digits = 2)
+```
 
 
 
 ## Climate Data and Derivatives
 
+```{r}
+knitr::kable(head(x$climate.annual), digits = 0)
+
+knitr::kable(head(x$climate.monthly), digits = 0)
+```
+
+
 
 ## DEM Derivatives
 
+```{r}
+knitr::kable(head(x$geomorphons), digits = 2)
+```
+
+
+## SC and OSD Derivatives
+
+```{r}
+knitr::kable(head(x$competing))
+
+knitr::kable(head(x$geog_assoc_soils))
+```
 
 
 
-## OSD Derivatives
-
-
-
-
-
-
+Relevant SoilWeb data metadata, as reported by `fetchOSD(..., extended = TRUE)`:
 
 
 |product                       |last_update |
@@ -98,72 +183,18 @@ Many of these curated data sources are documented in:
 
 
 
+# Relevant Tutorials
 
 
 
 
-# API Connections
-
-# 
-
- 
- * `fetchOSD()`
- * `OSDquery()`
- * `siblings()`
- 
- * `seriesExtent()`
- * `taxaExtent()`
- 
- * `mukey.wcs()`
- * `ISSR800.wcs()`
- * `soilColor.wcs()`
- 
- 
-
- * `fetchKSSL()`
- * `fetchRaCA()`
- * `SoilWeb_spatial_query()`
-
-
-```{r}
+# Examples
+```{r eval=FALSE}
 library(soilDB)
 library(aqp)
 
 x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
 
-knitr::kable(head(x$competing))
-
-knitr::kable(head(x$geog_assoc_soils))
-
-knitr::kable(head(x$hillpos), digits = 2)
-
-knitr::kable(head(x$geomcomp), digits = 2)
-
-knitr::kable(head(x$mtnpos), digits = 2)
-
-knitr::kable(head(x$terrace), digits = 2)
-
-knitr::kable(head(x$flats), digits = 2)
-
-knitr::kable(head(x$shape_across), digits = 2)
-
-knitr::kable(head(x$shape_down), digits = 2)
-
-knitr::kable(head(x$pmkind), digits = 2)
-
-knitr::kable(head(x$pmorigin), digits = 2)
-
-knitr::kable(head(x$geomorphons), digits = 2)
-
-knitr::kable(head(x$mlra), digits = 2)
-
-knitr::kable(head(x$ecoclassid), digits = 2)
-
-knitr::kable(head(x$climate.annual), digits = 0)
-
-knitr::kable(head(x$climate.monthly), digits = 0)
-
-knitr::kable(head(x$NCCPI), digits = 2)
 
 ```
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -1,0 +1,172 @@
+---
+title: "Functions and Data Sources that Depend on SoilWeb"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{SoilWeb Functions and Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+  
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  echo = TRUE,
+  # eval = !as.logical(Sys.getenv("R_SOILDB_SKIP_LONG_EXAMPLES", unset = "TRUE")),
+  message = FALSE,
+  warning = FALSE,
+  fig.height = 7,
+  fig.width = 7
+)
+```
+
+# Summary
+The soilDB package relies on a number of data sources curated as part of the [SoilWeb](https://casoilresource.lawr.ucdavis.edu/soilweb-apps) ecosystem of web applications, APIs, web coverage services (WCS), and internally-used lookup tables. These data are always updated shortly after the beginning of each fiscal year (October 1st) as part of the SSURGO refresh cycle. Within-cycle updates are typically performed quarterly. 
+
+Many of these curated data sources are documented in:
+
+  * O'Geen, A., Walkinshaw, M. and Beaudette, D.E. (2017), SoilWeb: A Multifaceted Interface to Soil Survey Information. Soil Sci. Soc. Am. J., 81: 853-862. https://doi.org/10.2136/sssaj2016.11.0386n
+  
+  * Beaudette, D.E. and O'Geen, A.T. (2010), An iPhone Application for On-Demand Access to Digital Soil Survey Information. Soil Sci. Soc. Am. J., 74: 1682-1684. https://doi.org/10.2136/sssaj2010.0144N
+  
+  * Beaudette, D.E. and O’Geen, A.T. (2009), Soil-Web: An online soil survey for California, Arizona, and Nevada, Comp. & Geo. Sci., 35:2119-2128, https://doi.org/10.1016/j.cageo.2008.10.016
+
+
+## Primary Data Sources
+
+  * [SSURGO](https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo), the detailed soil survey of the United States
+  * [STATSGO2](https://www.nrcs.usda.gov/resources/data-and-reports/description-of-statsgo2-database), the generalized soil survey of the United States
+  * Official Series Descriptions (OSD) via [SoilKnowledgeBase](https://github.com/ncss-tech/SoilKnowledgeBase/)
+  * Soil Classification database (no public version)
+  * [USDA Ag. Handbook 296 -- Major Land Resource Area (MLRA)](https://www.nrcs.usda.gov/resources/data-and-reports/major-land-resource-area-mlra)
+  * Climate ([PRISM](https://prism.oregonstate.edu/)) data and derivatives
+  * Digital elevation model (DEM) derivatives
+  * [NCSS Lab Data Mart](https://ncsslabdatamart.sc.egov.usda.gov/) snapshot
+  * NRCS [Rapid Carbon Assessment](https://www.nrcs.usda.gov/resources/data-and-reports/rapid-carbon-assessment-raca) (RaCA)
+
+
+
+# SoilWeb Curated Data Sources
+
+## SSURGO Derivatives
+
+
+### MLRA
+
+
+### Geomorphic Summaries
+
+
+### Parent Material Summaries
+
+
+
+
+
+## Climate Data and Derivatives
+
+
+## DEM Derivatives
+
+
+
+
+## OSD Derivatives
+
+
+
+
+
+
+
+
+|product                       |last_update |
+|:-----------------------------|:-----------|
+|ISSR800                       |2024-10-30  |
+|KSSL snapshot                 |2025-01-21  |
+|MLRA membership               |2025-10-07  |
+|OSD fulltext                  |2026-01-02  |
+|OSD morphology                |2026-01-02  |
+|SC database                   |2026-01-02  |
+|series climate summary        |2025-10-08  |
+|series-ESID cross-tabulation  |2025-10-07  |
+|SSURGO geomorphology          |2025-10-06  |
+|SSURGO geomorphon             |2026-01-11  |
+|SSURGO NCCPI Stats            |2025-10-19  |
+|SSURGO parent material        |2025-10-06  |
+|series extent                 |2025-10-04  |
+|taxa extent                   |2025-10-21  |
+
+
+
+
+
+
+
+
+# API Connections
+
+# 
+
+ 
+ * `fetchOSD()`
+ * `OSDquery()`
+ * `siblings()`
+ 
+ * `seriesExtent()`
+ * `taxaExtent()`
+ 
+ * `mukey.wcs()`
+ * `ISSR800.wcs()`
+ * `soilColor.wcs()`
+ 
+ 
+
+ * `fetchKSSL()`
+ * `fetchRaCA()`
+ * `SoilWeb_spatial_query()`
+
+
+```{r}
+library(soilDB)
+library(aqp)
+
+x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
+
+knitr::kable(head(x$competing))
+
+knitr::kable(head(x$geog_assoc_soils))
+
+knitr::kable(head(x$hillpos), digits = 2)
+
+knitr::kable(head(x$geomcomp), digits = 2)
+
+knitr::kable(head(x$mtnpos), digits = 2)
+
+knitr::kable(head(x$terrace), digits = 2)
+
+knitr::kable(head(x$flats), digits = 2)
+
+knitr::kable(head(x$shape_across), digits = 2)
+
+knitr::kable(head(x$shape_down), digits = 2)
+
+knitr::kable(head(x$pmkind), digits = 2)
+
+knitr::kable(head(x$pmorigin), digits = 2)
+
+knitr::kable(head(x$geomorphons), digits = 2)
+
+knitr::kable(head(x$mlra), digits = 2)
+
+knitr::kable(head(x$ecoclassid), digits = 2)
+
+knitr::kable(head(x$climate.annual), digits = 0)
+
+knitr::kable(head(x$climate.monthly), digits = 0)
+
+knitr::kable(head(x$NCCPI), digits = 2)
+
+```
+
+
+
+

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -10,7 +10,7 @@ vignette: >
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   echo = TRUE,
-  # eval = !as.logical(Sys.getenv("R_SOILDB_SKIP_LONG_EXAMPLES", unset = "TRUE")),
+  eval = !as.logical(Sys.getenv("R_SOILDB_SKIP_LONG_EXAMPLES", unset = "TRUE")),
   message = FALSE,
   warning = FALSE,
   fig.height = 7,
@@ -18,6 +18,11 @@ knitr::opts_chunk$set(
   fig.retina = 2
 )
 
+
+igraphAvailable <- FALSE
+```
+
+```{r get-data, echo=FALSE}
 # get source data for explanations
 library(soilDB)
 library(aqp)
@@ -27,6 +32,7 @@ x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE
 # enable more figures when igraph is available
 igraphAvailable <- requireNamespace('igraph')
 ```
+
 
 # Summary
 The soilDB package relies on a number of data sources curated as part of the [SoilWeb](https://casoilresource.lawr.ucdavis.edu/soilweb-apps) ecosystem of web applications, APIs, web coverage services (WCS), and internally-used lookup tables. These data are always updated shortly after the beginning of each fiscal year (October 1st) as part of the SSURGO refresh cycle. Within-cycle updates are typically performed quarterly. 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -40,6 +40,8 @@ Many of these curated data sources and their evolution through time have been do
   * Beaudette, D.E. and O’Geen, A.T. (2009), Soil-Web: An online soil survey for California, Arizona, and Nevada, Comp. & Geo. Sci., 35:2119-2128, https://doi.org/10.1016/j.cageo.2008.10.016
 
 
+Note that this vignette as published on CRAN or from a local R package installation will not contain output from inline code sections. See the Articles tab within the [soilDB package website](https://ncss-tech.github.io/soilDB/) for a more comprehensive version of this document.
+
 ## Primary Data Sources
 
   * [SSURGO](https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo), the detailed soil survey of the United States

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -17,9 +17,6 @@ knitr::opts_chunk$set(
   fig.width = 7,
   fig.retina = 2
 )
-
-
-igraphAvailable <- FALSE
 ```
 
 ```{r get-data, echo=FALSE}
@@ -28,9 +25,6 @@ library(soilDB)
 library(aqp)
 
 x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
-
-# enable more figures when igraph is available
-igraphAvailable <- requireNamespace('igraph')
 ```
 
 
@@ -59,6 +53,7 @@ Many of these curated data sources and their evolution through time have been do
   * NRCS [Rapid Carbon Assessment](https://www.nrcs.usda.gov/resources/data-and-reports/rapid-carbon-assessment-raca) (RaCA)
 
 
+
 ## `soilDB` Functions
 The following functions interact with SoilWeb APIs or Web Coverage Service (WCS) to request and download tabular or spatial data. Some functions return `SoilProfileCollection` objects, as defined in the [aqp](https://ncss-tech.github.io/aqp/) package.
 
@@ -81,7 +76,21 @@ WCS:
  * `soilColor.wcs()`: get raster soil color maps by bounding-box
  
  
-The `fetchOSD()` function, when specified with the `extended = TRUE` argument, will include the last updated date for curated sources. For example:
+The `fetchOSD()` function, when specified with the `extended = TRUE` argument, will include the last updated date for curated sources.
+
+<!-- requires conditional evaluation if vignette -->
+```{r, eval=FALSE}
+# typical invocation
+library(soilDB)
+library(aqp)
+
+x <- fetchOSD(c('lucy'), extended = TRUE)
+
+# access metadata
+x$soilweb.metadata
+```
+
+An abbreviated example of these metadata will look like this:
 
 |product                       |last_update |
 |:-----------------------------|:-----------|
@@ -99,6 +108,7 @@ The `fetchOSD()` function, when specified with the `extended = TRUE` argument, w
 |SSURGO parent material        |2025-10-06  |
 |series extent                 |2025-10-04  |
 |taxa extent                   |2025-10-21  |
+
 
 Details about these data sources are provided below.
 
@@ -127,6 +137,20 @@ The [`seriesExtent()`](https://ncss-tech.github.io/soilDB/reference/seriesExtent
 The [`taxaExtent()`](https://ncss-tech.github.io/soilDB/reference/taxaExtent.html) function provides an interface to the data behind the [SoilWeb Soil Taxonomy Explorer](https://casoilresource.lawr.ucdavis.edu/ste/) (STE) application. the STE website includes a short description of how the source data were created.
 
 
+## Relevant Tutorials
+
+  * [Querying Soil Series Data](https://ncss-tech.github.io/AQP/soilDB/soil-series-query-functions.html)
+  * [Soil Series Co-Occurrence Data](https://ncss-tech.github.io/AQP/soilDB/siblings.html)
+  * [Competing Soil Series](https://ncss-tech.github.io/AQP/soilDB/competing-series.html)
+  * [Exploring Geomorphic Summaries](https://ncss-tech.github.io/AQP/soilDB/exploring-geomorph-summary.html)
+  * [What does a subgroup look like?](https://ncss-tech.github.io/AQP/soilDB/subgroup-series.html)
+  * [Map Unit Key Web Coverage Service](https://ncss-tech.github.io/AQP/soilDB/WCS-demonstration-01.html)
+  * [Investigating Soil Series Extent](https://ncss-tech.github.io/AQP/soilDB/series-extent.html)
+  * [Geographic Extent of Soil Taxa](https://ncss-tech.github.io/AQP/soilDB/taxa-extent.html)
+
+
+
+
 
 # SoilWeb Curated Data Sources
 
@@ -134,30 +158,26 @@ The [`taxaExtent()`](https://ncss-tech.github.io/soilDB/reference/taxaExtent.htm
 ## SC and OSD Derivatives
 Competing (same family classification) soil series information are derived from the Soil Classification database. Geographically associated soils are derived from the OSD records. These data are available via `fetchOSD()`.
 
-```{r}
+Competing soil series.
+```{r eval=FALSE}
 # series names listed in "competing" have the family classification as "series"
-knitr::kable(head(x$competing))
+head(x$competing)
+```
 
+```{r echo=FALSE}
+knitr::kable(head(x$competing))
+```
+
+Geographically associated series. Series in the same region may have several geographically associated series in common, and can be modeled using [directed graphs](https://en.wikipedia.org/wiki/Directed_graph).
+```{r eval=FALSE}
+# series names listed in "gas" are geographically associated with "series"
+head(x$geog_assoc_soils)
+```
+
+```{r echo=FALSE}
 # series names listed in "gas" are geographically associated with "series"
 knitr::kable(head(x$geog_assoc_soils))
 ```
-
-
-One way of visualizing geographically associated soils, requires the igraph package.
-```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="Geographically associated soils of selected soil series."}
-library(igraph)
-
-# create a graph object from source series names and their GAS
-g <- graph_from_data_frame(x$geog_assoc_soils[, 1:2]) 
-
-# find central vertices, make font bold
-ct <- centr_degree(g, mode = 'out')
-V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
-
-par(mar = c(0, 0, 0, 0))
-plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
-```
-
 
 
 
@@ -177,38 +197,19 @@ The [Querying Soil Series Data](https://ncss-tech.github.io/AQP/soilDB/soil-seri
 Derived from the spatial intersection between MLRA and SSURGO polygons, with area computed on the ellipsoid from geographic coordinates. Membership values are area proportions by soil series.
 
 MLRA "membership" for the [LUCY](https://casoilresource.lawr.ucdavis.edu/sde/?series=lucy#osd) soil series.
-```{r}
+```{r eval=FALSE}
+.mlra <- x$mlra[x$mlra$series == 'LUCY', ]
+.mlra[order(.mlra$membership, decreasing = TRUE), ]
+```
+
+```{r echo=FALSE}
 .mlra <- x$mlra[x$mlra$series == 'LUCY', ]
 knitr::kable(.mlra[order(.mlra$membership, decreasing = TRUE), ], digits = 2, row.names = FALSE)
 ```
 
 
-One way of visualizing MLRA membership, requires the igraph package.
-```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="MLRA membership for selected soil series."}
-library(igraph)
+Soil series can be found in multiple MLRA, therefore MLRA membership can be modeled using [directed graphs](https://en.wikipedia.org/wiki/Directed_graph).
 
-# compute a sum of area by series and MLRA for vertex size
-a1 <- aggregate(x$mlra, area_ac ~ series,  FUN = sum)
-a2 <- aggregate(x$mlra, area_ac ~ mlra,  FUN = sum)
-
-# normalize names
-names(a1) <- c('name', 'ac')
-names(a2) <- c('name', 'ac')
-a <- rbind(a1, a2)
-
-# create a graph object from source series names and MLRA members
-g <- graph_from_data_frame(x$mlra[, 1:2], vertices = a) 
-
-# find central vertices, make font bold
-ct <- centr_degree(g, mode = 'out')
-V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
-
-# vertex size is proportional to log(area)
-V(g)$size <- log(V(g)$ac)
-
-par(mar = c(0, 0, 0, 0))
-plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
-```
 
 
 
@@ -226,20 +227,37 @@ There are several associated functions in the [sharpshootR](https://github.com/n
   * surface curvature down-slope
 
 Note that the `n` column in each table is the number of component geomorphic data records associated with each soil series. It is possible for a single component to have multiple geomorphic positions defined.
-```{r}
-knitr::kable(head(x$hillpos), digits = 2)
+```{r eval=FALSE}
+# hillslope position
+head(x$hillpos)
+# geomorphic component: hills
+head(x$geomcomp)
+# geomorphic component: mountains
+head(x$mtnpos)
+# geomorphic component: terraces
+head(x$terrace)
+# geomorphic component: flats
+head(x$flats)
+# surface curvature across slope
+head(x$shape_across)
+# surface curvature down slope
+head(x$shape_down)
+```
 
-knitr::kable(head(x$geomcomp), digits = 2)
+```{r echo=FALSE}
+knitr::kable(head(x$hillpos), digits = 2, caption = 'hillslope position')
 
-knitr::kable(head(x$mtnpos), digits = 2)
+knitr::kable(head(x$geomcomp), digits = 2, caption = 'geomorphic component: hills')
 
-knitr::kable(head(x$terrace), digits = 2)
+knitr::kable(head(x$mtnpos), digits = 2, caption = 'geomorphic component: mountains')
 
-knitr::kable(head(x$flats), digits = 2)
+knitr::kable(head(x$terrace), digits = 2, caption = 'geomorphic component: terraces')
 
-knitr::kable(head(x$shape_across), digits = 2)
+knitr::kable(head(x$flats), digits = 2, caption = 'geomorphic component: flats')
 
-knitr::kable(head(x$shape_down), digits = 2)
+knitr::kable(head(x$shape_across), digits = 2, caption = 'surface curvature across-slope')
+
+knitr::kable(head(x$shape_down), digits = 2, caption = 'surface curvature down-slope')
 ```
 
 
@@ -247,64 +265,52 @@ knitr::kable(head(x$shape_down), digits = 2)
 SoilWeb defines the term "siblings" as those components or soil series that co-occur within map units. The `siblings()` function returns siblings for a single soil series, with a tabulation of how many times each sibling shares a common map unit.
 
 Siblings of the PIERRE soil series, limited to just major components. The `n` column describes how many map units are shared between a sibling and the PIERRE series.
-```{r}
+```{r, eval=FALSE}
 sib <- siblings('PIERRE', only.major = TRUE)
+head(sib$sib)
+```
 
+```{r, echo=FALSE}
+sib <- siblings('PIERRE', only.major = TRUE)
 knitr::kable(sib$sib)
 ```
+
 
 
 ### Other
 Percentiles of the [National Commodity Crop
 Productivity Index](https://www.nrcs.usda.gov/sites/default/files/2023-01/NCCPI-User-Guide.pdf) are computed from SSURGO component records, by soil series name. These include both irrigated and non-irrigated versions of the NCCPI.
 
-```{r}
+```{r eval=FALSE}
+head(x$NCCPI)
+```
+```{r echo=FALSE}
 knitr::kable(head(x$NCCPI), digits = 2)
 ```
 
 
 Ecological classification membership are computed from map unit polygon area and component percentages.
-```{r}
+```{r eval=FALSE}
+head(x$ecoclassid)
+```
+```{r echo=FALSE}
 knitr::kable(head(x$ecoclassid), digits = 2)
 ```
 
-One way of visualizing Ecological classification membership, requires the igraph package.
-```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="Ecological classification membership for selected soil series."}
-library(igraph)
 
-# compute a sum of area by series and MLRA for vertex size
-a1 <- aggregate(x$ecoclassid, area_ac ~ series,  FUN = sum)
-a2 <- aggregate(x$ecoclassid, area_ac ~ ecoclassid,  FUN = sum)
-
-# normalize names
-names(a1) <- c('name', 'ac')
-names(a2) <- c('name', 'ac')
-a <- rbind(a1, a2)
-
-# create a graph object from source series names and MLRA members
-g <- graph_from_data_frame(x$ecoclassid[, 1:2], vertices = a) 
-
-# find central vertices, make font bold
-ct <- centr_degree(g, mode = 'out')
-V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
-
-# vertex size is proportional to log(area)
-V(g)$size <- log(V(g)$ac)
-
-par(mar = c(0, 0, 0, 0))
-plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
-```
 
 
 ### Parent Material Summaries
 Parent material kind and origin, tabulated by soil series name. The `n` column is the number of component parent material records associated with a specific parent material kind or origin. The `total` column is the total number of component parent material records by soil series. The final column, `P`, is the associated proportion.
 
-```{r}
+```{r eval=FALSE}
+head(x$pmkind)
+head(x$pmorigin)
+```
+```{r echo=FALSE}
 knitr::kable(head(x$pmkind), digits = 2)
-
 knitr::kable(head(x$pmorigin), digits = 2)
 ```
-
 
 
 ## Series and Taxa Extent
@@ -330,12 +336,16 @@ These maps are derived from the daily, 800m resolution, PRISM data spanning 1981
 Percentiles of each variable are computed by soil series, from a sampling of one point per SSURGO map unit polygon.
 
 An example of annual and monthly climate percentiles.
-```{r}
+```{r eval=FALSE}
+head(x$climate.annual)
+
+head(x$climate.monthly)
+```
+```{r echo=FALSE}
 knitr::kable(head(x$climate.annual), digits = 0)
 
 knitr::kable(head(x$climate.monthly), digits = 0)
 ```
-
 
 
 
@@ -520,22 +530,14 @@ The source DEM was a 10m / 30m resolution compilation of USGS NED data, rounded 
 
 
 Proportions are weighted by total soil series area (within CONUS) as informed by the component name and associated component percentage.
-```{r}
-knitr::kable(head(x$geomorphons), digits = 2)
+```{r eval=FALSE}
+head(x$geomorphons)
+```
+```{r echo=FALSE}
+knitr::kable(head(x$geomorphons), digits = 2, caption = 'geomorphon summary')
 ```
 
 
-
-# Relevant Tutorials
-
-  * [Querying Soil Series Data](https://ncss-tech.github.io/AQP/soilDB/soil-series-query-functions.html)
-  * [Soil Series Co-Occurrence Data](https://ncss-tech.github.io/AQP/soilDB/siblings.html)
-  * [Competing Soil Series](https://ncss-tech.github.io/AQP/soilDB/competing-series.html)
-  * [Exploring Geomorphic Summaries](https://ncss-tech.github.io/AQP/soilDB/exploring-geomorph-summary.html)
-  * [What does a subgroup look like?](https://ncss-tech.github.io/AQP/soilDB/subgroup-series.html)
-  * [Map Unit Key Web Coverage Service](https://ncss-tech.github.io/AQP/soilDB/WCS-demonstration-01.html)
-  * [Investigating Soil Series Extent](https://ncss-tech.github.io/AQP/soilDB/series-extent.html)
-  * [Geographic Extent of Soil Taxa](https://ncss-tech.github.io/AQP/soilDB/taxa-extent.html)
 
 
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -307,6 +307,16 @@ knitr::kable(head(x$pmorigin), digits = 2)
 
 
 
+## Series and Taxa Extent
+Soil series extent vector data are available for all areas where SSURGO has been completed. Vector extents are described as polygons which generalize the underlying SSURGO map unit polygons (EPSG:4326). Soil series extent raster data are available as 800m grids (EPSG:5070) within CONUS only. Taxonomic classes and formative elements are available as 800m grids (EPSG:5070) within CONUS only. Grids are 
+
+
+
+## Web Coverage Services
+Web Coverage Services (WCS) provided by SoilWeb are still an experimental interface to snapshots of authoritative soil survey and derived data sources. The update cycle is slower than the typical SSURGO refresh. All WCS requests return data as compressed GeoTIFF (EPSG:5070).
+
+
+
 ## Climate Data and Derivatives
 
 These maps are derived from the daily, 800m resolution, PRISM data spanning 1981--2010.
@@ -516,20 +526,16 @@ knitr::kable(head(x$geomorphons), digits = 2)
 
 
 
+# Relevant Tutorials
 
-
-<!-- ## Series and Taxa Extent Maps -->
-
-
-
-
-<!-- ## Web Coverage Services -->
-
-
-
-
-
-<!-- # Relevant Tutorials -->
+  * [Querying Soil Series Data](https://ncss-tech.github.io/AQP/soilDB/soil-series-query-functions.html)
+  * [Soil Series Co-Occurrence Data](https://ncss-tech.github.io/AQP/soilDB/siblings.html)
+  * [Competing Soil Series](https://ncss-tech.github.io/AQP/soilDB/competing-series.html)
+  * [Exploring Geomorphic Summaries](https://ncss-tech.github.io/AQP/soilDB/exploring-geomorph-summary.html)
+  * [What does a subgroup look like?](https://ncss-tech.github.io/AQP/soilDB/subgroup-series.html)
+  * [Map Unit Key Web Coverage Service](https://ncss-tech.github.io/AQP/soilDB/WCS-demonstration-01.html)
+  * [Investigating Soil Series Extent](https://ncss-tech.github.io/AQP/soilDB/series-extent.html)
+  * [Geographic Extent of Soil Taxa](https://ncss-tech.github.io/AQP/soilDB/taxa-extent.html)
 
 
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -14,7 +14,8 @@ knitr::opts_chunk$set(
   message = FALSE,
   warning = FALSE,
   fig.height = 7,
-  fig.width = 7
+  fig.width = 7,
+  fig.retina = 2
 )
 
 # get source data for explanations
@@ -22,6 +23,9 @@ library(soilDB)
 library(aqp)
 
 x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
+
+# enable more figures when igraph is available
+igraphAvailable <- requireNamespace('igraph')
 ```
 
 # Summary
@@ -41,11 +45,11 @@ Many of these curated data sources and their evolution through time have been do
   * [SSURGO](https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo), the detailed soil survey of the United States
   * [STATSGO2](https://www.nrcs.usda.gov/resources/data-and-reports/description-of-statsgo2-database), the generalized soil survey of the United States
   * Official Series Descriptions (OSD) via [SoilKnowledgeBase](https://github.com/ncss-tech/SoilKnowledgeBase/)
-  * Soil Classification database (no public version)
+  * Soil Classification (SC) database (no public version)
   * [USDA Ag. Handbook 296 -- Major Land Resource Area (MLRA)](https://www.nrcs.usda.gov/resources/data-and-reports/major-land-resource-area-mlra)
   * Climate ([PRISM](https://prism.oregonstate.edu/)) data and derivatives
   * Digital elevation model (DEM) derivatives
-  * [NCSS Lab Data Mart](https://ncsslabdatamart.sc.egov.usda.gov/) snapshot
+  * [NCSS Lab Data Mart](https://ncsslabdatamart.sc.egov.usda.gov/) (LDM) snapshot
   * NRCS [Rapid Carbon Assessment](https://www.nrcs.usda.gov/resources/data-and-reports/rapid-carbon-assessment-raca) (RaCA)
 
 
@@ -59,7 +63,7 @@ Tabular data and/or `SoilProfileCollection`:
  * `OSDquery()`: search the OSD records using the postgresql full text query syntax
  * `siblings()`: get names and basic information about soil series that co-occurr within soil map units containing  a given series
  
-Spatia ldata:
+Spatial data:
 
  * `seriesExtent()`: get vector or raster representations of were soil series have been used in SSURGO
  * `taxaExtent()`: get raster representations of were taxa and formative elements (Soil Taxonomy) have been used in SSURGO
@@ -97,11 +101,11 @@ Details about these data sources are provided below.
 Some functions represent temporary solutions to data delivery problems that made sense in the past. `fetchKSSL()` relies on an older snapshot of the NCSS LDM (2020), `fetchRaCA()` relies on a pre-release of the current RaCA database, and `SoilWeb_spatial_query()` has been superseded by soilDB functions which interface with Soil Data Access (see [`SDA_query()`](https://ncss-tech.github.io/soilDB/reference/SDA_query.html) and [`SDA_spatialQuery`](https://ncss-tech.github.io/soilDB/reference/SDA_spatialQuery.html)). 
 
 
- * `fetchKSSL()`: get soil characterization and (limited) morphology data
+ * `fetchKSSL()`: get soil characterization and (limited) morphology data (soil color, structure, redoximorphic features)
  * `fetchRaCA()`: get records associated with the RaCA collection
  * `SoilWeb_spatial_query()`: simple interface to spatial intersection between SSURGO polygons and user supplied bounding-box
 
-There are currently no replacements for all of the functionality provided by `fetchKSSL()` and `fetchRaCA()`. See [`fetchLDM()`](https://ncss-tech.github.io/soilDB/reference/fetchLDM.html) for a modern approach to downloading NCSS LDM snapshot data.
+There are currently no replacements for full functionality provided by `fetchKSSL()` and `fetchRaCA()`. See [`fetchLDM()`](https://ncss-tech.github.io/soilDB/reference/fetchLDM.html) for a modern approach to downloading NCSS LDM snapshot data.
 
 
 ## Related Web Applications
@@ -117,15 +121,35 @@ The [`seriesExtent()`](https://ncss-tech.github.io/soilDB/reference/seriesExtent
 The [`taxaExtent()`](https://ncss-tech.github.io/soilDB/reference/taxaExtent.html) function provides an interface to the data behind the [SoilWeb Soil Taxonomy Explorer](https://casoilresource.lawr.ucdavis.edu/ste/) (STE) application. the STE website includes a short description of how the source data were created.
 
 
+
 # SoilWeb Curated Data Sources
 
 
 ## SC and OSD Derivatives
+Competing (same family classification) soil series information are derived from the Soil Classification database. Geographically associated soils are derived from the OSD records. These data are available via `fetchOSD()`.
 
 ```{r}
+# series names listed in "competing" have the family classification as "series"
 knitr::kable(head(x$competing))
 
+# series names listed in "gas" are geographically associated with "series"
 knitr::kable(head(x$geog_assoc_soils))
+```
+
+
+One way of visualizing geographically associated soils, requires the igraph package.
+```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="Geographically associated soils of selected soil series."}
+library(igraph)
+
+# create a graph object from source series names and their GAS
+g <- graph_from_data_frame(x$geog_assoc_soils[, 1:2]) 
+
+# find central vertices, make font bold
+ct <- centr_degree(g, mode = 'out')
+V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
+
+par(mar = c(0, 0, 0, 0))
+plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
 ```
 
 
@@ -133,19 +157,69 @@ knitr::kable(head(x$geog_assoc_soils))
 
 ## SSURGO Derivatives
 
-... normalization of SSURGO component names into qualified soil series names via SC database.
+SSURGO components are often named for soil series. Soil series summaries derived from SSURGO are coordinated using a normalized form of component name and soil series:
+
+  * names are converted to upper case
+  * component names are stripped of modifiers such as "variant" and "family"
+
+See the [Soil Survey Manual](https://www.nrcs.usda.gov/resources/guides-and-instructions/soil-survey-manual) for more complete definitions of "map unit", "component", and "soil series".
+
+The [Querying Soil Series Data](https://ncss-tech.github.io/AQP/soilDB/soil-series-query-functions.html) tutorial contains additional, relevant examples.
 
 
 ### MLRA
-... spatial intersection SSURGO map unit polygons x MLRA polygons
+Derived from the spatial intersection between MLRA and SSURGO polygons, with area computed on the ellipsoid from geographic coordinates. Membership values are area proportions by soil series.
+
+MLRA "membership" for the [LUCY](https://casoilresource.lawr.ucdavis.edu/sde/?series=lucy#osd) soil series.
 ```{r}
-knitr::kable(head(x$mlra), digits = 2)
+.mlra <- x$mlra[x$mlra$series == 'LUCY', ]
+knitr::kable(.mlra[order(.mlra$membership, decreasing = TRUE), ], digits = 2, row.names = FALSE)
 ```
 
 
-### Geomorphic Summaries
-cross-tabulation component names → series names x geomorphic tables
+One way of visualizing MLRA membership, requires the igraph package.
+```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="MLRA membership for selected soil series."}
+library(igraph)
 
+# compute a sum of area by series and MLRA for vertex size
+a1 <- aggregate(x$mlra, area_ac ~ series,  FUN = sum)
+a2 <- aggregate(x$mlra, area_ac ~ mlra,  FUN = sum)
+
+# normalize names
+names(a1) <- c('name', 'ac')
+names(a2) <- c('name', 'ac')
+a <- rbind(a1, a2)
+
+# create a graph object from source series names and MLRA members
+g <- graph_from_data_frame(x$mlra[, 1:2], vertices = a) 
+
+# find central vertices, make font bold
+ct <- centr_degree(g, mode = 'out')
+V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
+
+# vertex size is proportional to log(area)
+V(g)$size <- log(V(g)$ac)
+
+par(mar = c(0, 0, 0, 0))
+plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
+```
+
+
+
+### Geomorphic Summaries
+Geomorphic summaries are computed from SSURGO component "geomorphology" tables. These represent a cross-tabulation of soil series name x geomorphic position in several landform and surface shape description systems. These systems are defined in the [Field Book for Describing and Sampling Soils](https://www.nrcs.usda.gov/resources/guides-and-instructions/field-book-for-describing-and-sampling-soils).
+
+There are several associated functions in the [sharpshootR](https://github.com/ncss-tech/sharpshootR/) package for visualizing these summaries (e.g. [`vizHillslopePosition()`](http://ncss-tech.github.io/sharpshootR/reference/vizHillslopePosition.html)).
+
+  * hillslope position (2D)
+  * geomorphic component: hills (3D)
+  * geomorphic component: mountains (3D)
+  * geomorphic component: terrace (3D)
+  * geomorphic component: flats (3D)
+  * surface curvature across-slope
+  * surface curvature down-slope
+
+Note that the `n` column in each table is the number of component geomorphic data records associated with each soil series. It is possible for a single component to have multiple geomorphic positions defined.
 ```{r}
 knitr::kable(head(x$hillpos), digits = 2)
 
@@ -162,16 +236,62 @@ knitr::kable(head(x$shape_across), digits = 2)
 knitr::kable(head(x$shape_down), digits = 2)
 ```
 
+
+### Siblings
+SoilWeb defines the term "siblings" as those components or soil series that co-occur within map units. The `siblings()` function returns siblings for a single soil series, with a tabulation of how many times each sibling shares a common map unit.
+
+Siblings of the PIERRE soil series, limited to just major components. The `n` column describes how many map units are shared between a sibling and the PIERRE series.
+```{r}
+sib <- siblings('PIERRE', only.major = TRUE)
+
+knitr::kable(sib$sib)
+```
+
+
 ### Other
+Percentiles of the [National Commodity Crop
+Productivity Index](https://www.nrcs.usda.gov/sites/default/files/2023-01/NCCPI-User-Guide.pdf) are computed from SSURGO component records, by soil series name. These include both irrigated and non-irrigated versions of the NCCPI.
 
 ```{r}
 knitr::kable(head(x$NCCPI), digits = 2)
+```
 
+
+Ecological classification membership are computed from map unit polygon area and component percentages.
+```{r}
 knitr::kable(head(x$ecoclassid), digits = 2)
+```
+
+One way of visualizing Ecological classification membership, requires the igraph package.
+```{r, eval=igraphAvailable, echo=igraphAvailable, fig.cap="Ecological classification membership for selected soil series."}
+library(igraph)
+
+# compute a sum of area by series and MLRA for vertex size
+a1 <- aggregate(x$ecoclassid, area_ac ~ series,  FUN = sum)
+a2 <- aggregate(x$ecoclassid, area_ac ~ ecoclassid,  FUN = sum)
+
+# normalize names
+names(a1) <- c('name', 'ac')
+names(a2) <- c('name', 'ac')
+a <- rbind(a1, a2)
+
+# create a graph object from source series names and MLRA members
+g <- graph_from_data_frame(x$ecoclassid[, 1:2], vertices = a) 
+
+# find central vertices, make font bold
+ct <- centr_degree(g, mode = 'out')
+V(g)$label.font = c(1, 2)[as.integer(ct$res > 0) + 1]
+
+# vertex size is proportional to log(area)
+V(g)$size <- log(V(g)$ac)
+
+par(mar = c(0, 0, 0, 0))
+plot(g, edge.arrow.size = 0.5, vertex.label.cex = 0.5, vertex.label.family = 'sans', vertex.label.color = 'black', vertex.frame.color = NA) 
 ```
 
 
 ### Parent Material Summaries
+Parent material kind and origin, tabulated by soil series name. The `n` column is the number of component parent material records associated with a specific parent material kind or origin. The `total` column is the total number of component parent material records by soil series. The final column, `P`, is the associated proportion.
 
 ```{r}
 knitr::kable(head(x$pmkind), digits = 2)
@@ -189,11 +309,11 @@ These maps are derived from the daily, 800m resolution, PRISM data spanning 1981
   * Mean accumulated annual precipitation (mm), derived from daily totals.
   * Mean monthly temperature (deg. C), derived from daily minimum and maximum temperatures.
   * Mean accumulated monthly precipitation (mm), derived from daily totals.
-  * Estimated monthly potential evapotranspiration
+  * Estimated monthly potential evapotranspiration, [Thornthwaite, 1948](https://en.wikipedia.org/wiki/Potential_evapotranspiration#Thornthwaite_equation_(1948))
 
+Percentiles of each variable are computed by soil series, from a sampling of one point per SSURGO map unit polygon.
 
-
-
+An example of annual and monthly climate percentiles.
 ```{r}
 knitr::kable(head(x$climate.annual), digits = 0)
 
@@ -284,10 +404,7 @@ Values have been cross-checked with 300+ weather stations in CA.
 
 
 ### Frost-Free Days
-
-   * Frost-free days, 50% probability.
-   * Frost-free days, 80% probability.
-   * Frost-free days, 90% probability.
+Percentiles of frost-free days (FFD) at the 50% probability threshold.
 
 
 ### Design Freeze Index
@@ -374,9 +491,8 @@ Rajagopal, S. and A.A. Harpold. 2016. Testing and Improving Temperature Threshol
 
 ## DEM Derivatives
 
-```{r}
-knitr::kable(head(x$geomorphons), digits = 2)
-```
+### Geomorphons
+A cross-tabulation of geomorphon by soil series name was computed from the current gSSURGO (30m) grid and a 30m grid of geomorphons. Currently, these data are only available within CONUS.
 
 These maps were generated using the [r.geomorphon GRASS GIS module](https://grass.osgeo.org/grass75/manuals/r.geomorphon.html), with the following parameters: 
 
@@ -387,30 +503,34 @@ The source DEM was a 10m / 30m resolution compilation of USGS NED data, rounded 
 [Jasiewicz, J., Stepinski, T., 2013, Geomorphons - a pattern recognition approach to classification and mapping of landforms, Geomorphology, vol. 182, 147-156.](http://www.sciencedirect.com/science/article/pii/S0169555X12005028)
 
 
-
-
-
-
-
-
-
-
-
-# Relevant Tutorials
-
-
-
-
-
-# Examples
-```{r eval=FALSE}
-library(soilDB)
-library(aqp)
-
-x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE)
-
-
+Proportions are weighted by total soil series area (within CONUS) as informed by the component name and associated component percentage.
+```{r}
+knitr::kable(head(x$geomorphons), digits = 2)
 ```
+
+
+
+
+
+
+
+
+
+<!-- # Relevant Tutorials -->
+
+
+
+
+
+<!-- # Examples -->
+<!-- ```{r eval=FALSE} -->
+<!-- library(soilDB) -->
+<!-- library(aqp) -->
+
+<!-- x <- fetchOSD(c('miami', 'pierre', 'tristan', 'lucy', 'musick'), extended = TRUE) -->
+
+
+<!-- ``` -->
 
 
 

--- a/vignettes/soilweb-data-functions.Rmd
+++ b/vignettes/soilweb-data-functions.Rmd
@@ -512,6 +512,13 @@ knitr::kable(head(x$geomorphons), digits = 2)
 
 
 
+<!-- ## Series and Taxa Extent Maps -->
+
+
+
+
+<!-- ## Web Coverage Services -->
+
 
 
 


### PR DESCRIPTION
This PR makes available soil series -- geomorphon summaries (area-weighted proportions) available via `fetchOSD()`.

SoilWeb now maintains a snapshot of soil series -- geomorphon cross-tabulation, updated each SSURGO refresh cycle. Currently, this is only available for CONUS and at 30m resolution as defined by the current gSSURGO snapshot.

Geomorphons were derived from a 30m CONUS DEM, using GRASS GIS and the following:
```
r.geomorphon --o dem=elev30_int forms=forms30 search=75 skip=5 flat=1.718
```
Pixel-wise cross-tabulation at 30m resolution was performed using `r.stats` from GRASS GIS.

I plan to document these data and methods soon.

EDIT: This PR will also include a basic vignette outlining the purpose, background, and status of all functions and data sources which depend on SoilWeb. As @brownag pointed out, there are many details hidden behind functions like `fetchOSD()` that could use an explanation within soilDB.
