### PR TITLE
fix(get_site_data_from_NASIS_db): deduplicate results

### DIFF
--- a/R/get_site_data_from_NASIS_db.R
+++ b/R/get_site_data_from_NASIS_db.R
@@ -39,12 +39,13 @@ get_site_data_from_NASIS_db <- function(SS = TRUE, include_pedon = TRUE, nullFra
   
   .SD <- NULL
   
-	q <- paste0("SELECT siteiid, siteobsiid, usiteid, 
+	q <- paste0("SELECT DISTINCT siteiid, siteobsiid, usiteid, 
   	", ifelse(include_pedon, "peiid, upedonid, ", ""), "
   	obsdate, utmzone, utmeasting, utmnorthing, horizdatnm,
   	longstddecimaldegrees, latstddecimaldegrees, gpspositionalerror, 
     ", ifelse(include_pedon, "descname, pedonpurpose, pedontype, pedlabsampnum, labdatadescflag, 
-    tsectstopnum, tsectinterval, utransectid, tsectkind, tsectselmeth, erocl,", ""), "
+    tsectstopnum, tsectinterval, utransectid, tsectkind, tsectselmeth,
+    erocl,", ""), "
     elev, slope, aspect, 
     ecostatename, ecostateid, commphasename, commphaseid, plantassocnm, 
     siteobs_View_1.earthcovkind1, siteobs_View_1.earthcovkind2, 
@@ -53,19 +54,20 @@ get_site_data_from_NASIS_db <- function(SS = TRUE, include_pedon = TRUE, nullFra
     geomposhill, geomposmntn, geompostrce, geomposflats, swaterdepth,
     flodfreqcl, floddurcl, flodmonthbeg, pondfreqcl, ponddurcl, pondmonthbeg, 
     climstaid, climstanm, climstatype, ffd, map, reannualprecip, airtempa, soiltempa, airtemps, soiltemps, airtempw, soiltempw
-
-  FROM
-  
-  site_View_1 INNER JOIN siteobs_View_1 ON site_View_1.siteiid = siteobs_View_1.siteiidref
-  ", ifelse(include_pedon, "LEFT OUTER JOIN pedon_View_1 ON siteobs_View_1.siteobsiid = pedon_View_1.siteobsiidref
-  LEFT OUTER JOIN transect_View_1 ON pedon_View_1.tsectiidref = transect_View_1.tsectiid", ""),"
+  FROM site_View_1 
+  INNER JOIN siteobs_View_1 ON site_View_1.siteiid = siteobs_View_1.siteiidref
+  ", ifelse(
+    include_pedon,
+    "LEFT OUTER JOIN pedon_View_1 ON siteobs_View_1.siteobsiid = pedon_View_1.siteobsiidref
+     LEFT OUTER JOIN transect_View_1 ON pedon_View_1.tsectiidref = transect_View_1.tsectiid",
+    ""
+  ), "
   LEFT OUTER JOIN
   (
-        SELECT siteiidref, bedrckdepth, bedrckkind, bedrckhardness, ROW_NUMBER() OVER(PARTITION BY siteiidref ORDER BY bedrckdepth ASC) as rn
-        FROM sitebedrock_View_1
+    SELECT siteiidref, bedrckdepth, bedrckkind, bedrckhardness, ROW_NUMBER() OVER(PARTITION BY siteiidref ORDER BY bedrckdepth ASC) as rn
+    FROM sitebedrock_View_1
   ) as sb ON site_View_1.siteiid = sb.siteiidref
-
-WHERE sb.rn IS NULL OR sb.rn = 1
+  WHERE sb.rn IS NULL OR sb.rn = 1
 
 ORDER BY siteobs_View_1.siteobsiid;")
       
@@ -113,7 +115,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	  stop('error in SQL')
 
 	# uncode domain columns
-	d <- uncode(d, dsn = dsn)
+	d <- data.table::data.table(uncode(unique(d), dsn = dsn))
 	
 	# surface fragments
 	sfr <- dbQueryNASIS(channel, q2, close = FALSE)
@@ -216,8 +218,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
   ss.levels <- apply(ss.grid, 1, function(i) { paste(rev(i), collapse = ' / ')})
   d2$slope_shape <- factor(d2$slope_shape, levels = ss.levels)
 
-	# done
-	return(d2)
+	return(data.frame(d2))
 }
 
 #' @description `get_site_association_from_NASIS()`: Get Associated User Site IDs for each Site.

--- a/R/get_site_data_from_NASIS_db.R
+++ b/R/get_site_data_from_NASIS_db.R
@@ -115,7 +115,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	  stop('error in SQL')
 
 	# uncode domain columns
-	d <- data.table::data.table(uncode(unique(d), dsn = dsn))
+	d <- uncode(unique(d), dsn = dsn)
 	
 	# surface fragments
 	sfr <- dbQueryNASIS(channel, q2, close = FALSE)
@@ -218,7 +218,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
   ss.levels <- apply(ss.grid, 1, function(i) { paste(rev(i), collapse = ' / ')})
   d2$slope_shape <- factor(d2$slope_shape, levels = ss.levels)
 
-	return(data.frame(d2))
+	return(d2)
 }
 
 #' @description `get_site_association_from_NASIS()`: Get Associated User Site IDs for each Site.

--- a/R/get_site_data_from_NASIS_db.R
+++ b/R/get_site_data_from_NASIS_db.R
@@ -115,7 +115,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	  stop('error in SQL')
 
 	# uncode domain columns
-	d <- uncode(unique(d), dsn = dsn)
+	d <- uncode(d, dsn = dsn)
 	
 	# surface fragments
 	sfr <- dbQueryNASIS(channel, q2, close = FALSE)
@@ -143,7 +143,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
 	    phs <- phs[seq_len(nrow(d)), ]
 	    phs$siteobsiid <- d$siteobsiid
 	  } else {
-	    phs_null <- phs[0, ][1:sum(ldx), ]
+	    phs_null <- phs[0, ][rep(NA_integer_, sum(ldx)), ]
 	    phs_null$siteobsiid <- d$siteobsiid[ldx]
 	    phs <- rbind(phs, phs_null)
 	  }
@@ -154,7 +154,7 @@ ORDER BY siteobs_View_1.siteobsiid;")
   	} 
   	d2 <- merge(d, phs, by = "siteobsiid", all.x = TRUE, sort = FALSE)
 	} else {
-	  d2 <- cbind(d, phs[0,])
+	  d2 <- cbind(d, phs[0, ])
 	}
 	
 	# short-circuit: 0 rows means nothing in the selected set and thus we stop here


### PR DESCRIPTION
Closes #441

Uses DISTINCT to ensure degenerate cases (most likely due to issues with snapshot databases, but technically possible due to data entry issues or in custom databases mirroring NASIS structure without NASIS controls). <strike>Makes `merge()` pathway used inside `get_site_data_from_NASIS_db()` work efficiently with data.table</strike>. Internal data.table deferred for #443