### PR TITLE
SDA / web test cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -424,8 +424,6 @@ and in concatenation of reason string when `wide_reason=TRUE`
    * All  `get_SDA_*()` methods (except `get_SDA_metrics()`) now support input of custom `WHERE` clause in lieu of `mukeys`/`areasymbols` arguments and gain a `dsn` argument for specifying a local SQLite database or DBIConnection.
    * Added `downloadSSURGO()` for downloading/extraction of the SSURGO data by survey area from Web Soil Survey. 
    * Added `createSSURGO()` for building of local databases as SQLite/Geopackage from one or more SSURGO exports.
-      * Exports can be obtained via `downloadSSURGO()`, from NASIS or downloaded from other sources such as  <https://datagateway.nrcs.usda.gov/GDGHome_DirectDownLoad.aspx>. 
- 
 
 # soilDB 2.6.15 (2022-04-13) 
  * `fetchNASIS()`

--- a/R/SoilDataViewer.R
+++ b/R/SoilDataViewer.R
@@ -5,7 +5,7 @@
 #' @param notratedcolor Used to add 'Not rated' color entries where applicable. Default: `"#FFFFFF00"` (transparent white).
 #' @param simplify Return a data.frame when `WHERE` is length 1? Return a list with 1 element per legend when `WHERE` is length > `1`? Default: `TRUE`
 #'
-#' @return A list with a data.frame element for each element of `WHERE` containing `"attributekey"`, `"attributename"`, `"attributetype"`, `"attributetablename"`, `"attributecolumnname"`, `"attributedescription"`, `"nasisrulename"`, `"label"`, `"order"`, `"value"`, `"lower_value"`, `"upper_value"`,`"red"`, `"green"`, `"blue"` and `"hex"` columns.
+#' @return A list with a data.frame element for each element of `WHERE` containing `"attributekey"`, `"attributename"`, `"attributetype"`, `"attributetablename"`, `"attributecolumnname"`, `"attributedescription"`, `"nasisrulename"`, `"label"`, `"order"`, `"value"`, `"lower_value"`, `"upper_value"`,`"red"`, `"green"`, `"blue"` and `"hex"` columns. A `try-error` is returned invisibly, with a message, on error.
 #' @export
 #'
 #' @importFrom grDevices rgb
@@ -26,8 +26,10 @@ get_SDV_legend_elements <- function(WHERE,
                                      nasisrulename, notratedphrase
                                    FROM sdvattribute WHERE ", ak))
     
-    if (inherits(x, 'try-error'))
-      stop("Invalid WHERE clause: ", ak)
+    if (inherits(x, 'try-error')) {
+      message(x[1])
+      return(invisible(x))
+    }
     
     lapply(seq_len(nrow(x)), function(i) {
       res <- .process_SDV_legend_elements(x[i,],

--- a/R/fetchKSSL.R
+++ b/R/fetchKSSL.R
@@ -233,7 +233,7 @@
 #' the link below for the live data.
 #' @author D.E. Beaudette and A.G. Brown
 #' @seealso \code{\link{fetchOSD}}
-#' @references \url{http://ncsslabdatamart.sc.egov.usda.gov/}
+#' @references National Cooperative Soil Survey Soil Characterization Database: <https://ncsslabdatamart.sc.egov.usda.gov/>.
 #' @keywords utilities
 #' @examplesIf curl::has_internet() && requireNamespace("httr", quietly = TRUE) && requireNamespace("aqp", quietly = TRUE) && as.logical(Sys.getenv("R_SOILDB_SKIP_LONG_EXAMPLES", unset = TRUE))
 #' \donttest{

--- a/R/get_SDA_coecoclass.R
+++ b/R/get_SDA_coecoclass.R
@@ -41,7 +41,7 @@
 #'   summary. Used only for `method="all"`.
 #' @param dsn Path to local SQLite database or a DBIConnection object. If `NULL`
 #'   (default) use Soil Data Access API via `SDA_query()`.
-#'
+#' @returns data.frame. `NULL` if no results, and a `try-error` (invisibly) on error.
 #' @export
 #' @examplesIf !as.logical(Sys.getenv("R_SOILDB_SKIP_LONG_EXAMPLES", unset = TRUE)) 
 #' # Basic usage with a vector of mukeys
@@ -132,6 +132,11 @@ get_SDA_coecoclass <- function(method = "None",
   if (length(res) == 0) {
     message('query returned no results')
     return(NULL)
+  }
+  
+  if (inherits(res, 'try-error')) {
+    message(res[1])
+    return(invisible(res))
   }
   
   .I <- NULL

--- a/man/fetchKSSL.Rd
+++ b/man/fetchKSSL.Rd
@@ -120,7 +120,7 @@ the link below for the live data.
 \dontshow{\}) # examplesIf}
 }
 \references{
-\url{http://ncsslabdatamart.sc.egov.usda.gov/}
+National Cooperative Soil Survey Soil Characterization Database: \url{https://ncsslabdatamart.sc.egov.usda.gov/}.
 }
 \seealso{
 \code{\link{fetchOSD}}

--- a/man/get_SDA_coecoclass.Rd
+++ b/man/get_SDA_coecoclass.Rd
@@ -57,6 +57,9 @@ summary. Used only for \code{method="all"}.}
 \item{dsn}{Path to local SQLite database or a DBIConnection object. If \code{NULL}
 (default) use Soil Data Access API via \code{SDA_query()}.}
 }
+\value{
+data.frame. \code{NULL} if no results, and a \code{try-error} (invisibly) on error.
+}
 \description{
 \code{get_SDA_coecoclass()} retrieves ecological site information from the Soil
 Data Access (SDA) database for a given set of map unit keys (mukeys). It

--- a/man/get_SDV_legend_elements.Rd
+++ b/man/get_SDV_legend_elements.Rd
@@ -21,7 +21,7 @@ get_SDV_legend_elements(
 \item{simplify}{Return a data.frame when \code{WHERE} is length 1? Return a list with 1 element per legend when \code{WHERE} is length > \code{1}? Default: \code{TRUE}}
 }
 \value{
-A list with a data.frame element for each element of \code{WHERE} containing \code{"attributekey"}, \code{"attributename"}, \code{"attributetype"}, \code{"attributetablename"}, \code{"attributecolumnname"}, \code{"attributedescription"}, \code{"nasisrulename"}, \code{"label"}, \code{"order"}, \code{"value"}, \code{"lower_value"}, \code{"upper_value"},\code{"red"}, \code{"green"}, \code{"blue"} and \code{"hex"} columns.
+A list with a data.frame element for each element of \code{WHERE} containing \code{"attributekey"}, \code{"attributename"}, \code{"attributetype"}, \code{"attributetablename"}, \code{"attributecolumnname"}, \code{"attributedescription"}, \code{"nasisrulename"}, \code{"label"}, \code{"order"}, \code{"value"}, \code{"lower_value"}, \code{"upper_value"},\code{"red"}, \code{"green"}, \code{"blue"} and \code{"hex"} columns. A \code{try-error} is returned invisibly, with a message, on error.
 }
 \description{
 Get Soil Data Viewer Attribute Information

--- a/tests/testthat/test-fetchLDM.R
+++ b/tests/testthat/test-fetchLDM.R
@@ -6,8 +6,6 @@ test_that("fetchLDM works", {
   
   skip_if_not_installed("aqp")
   
-  skip_if_not_installed("httr")
-  
   # physical and chemical properties tables are 1:1 with lab_layer
   res <- suppressWarnings(
     fetchLDM(

--- a/tests/testthat/test-fetchSCAN.R
+++ b/tests/testthat/test-fetchSCAN.R
@@ -67,7 +67,7 @@ test_that("timezone check", {
   skip_on_cran()
   
   # skip on error
-  skip_if(inherits(x, 'try-error') || is.null(x))
+  skip_if(inherits(z, 'try-error') || is.null(z))
   
   # default target timezone is US/Central, including CDT (-0500) and CST (-0600)
   .tz <- table(format(z$SMS$datetime, format = '%z'))

--- a/tests/testthat/test-fetchSCAN.R
+++ b/tests/testthat/test-fetchSCAN.R
@@ -67,7 +67,7 @@ test_that("timezone check", {
   skip_on_cran()
   
   # skip on error
-  skip_if(inherits(z, 'try-error') || is.null(z))
+  skip_if(inherits(x, 'try-error') || is.null(x))
   
   # default target timezone is US/Central, including CDT (-0500) and CST (-0600)
   .tz <- table(format(z$SMS$datetime, format = '%z'))

--- a/tests/testthat/test-fetchSDA.R
+++ b/tests/testthat/test-fetchSDA.R
@@ -13,8 +13,8 @@ test_that("fetchSDA() works", {
   # single component
   x <<- suppressMessages(fetchSDA(WHERE="nationalmusym = 'kzc4'"))
 
-  # basic test
-  expect_true(inherits(x, 'SoilProfileCollection'))
+  # two possible return types
+  expect_true(inherits(x, c('SoilProfileCollection', 'try-error')))
 })
 
 ## tests
@@ -29,6 +29,8 @@ test_that("fetchSDA() returns an SPC", {
 
   skip_on_cran()
 
+  skip_if(inherits(x, 'try-error'))
+  
   # SPC integrity and expected IDs / hz depths
   expect_equivalent(aqp::idname(x), 'cokey')
   expect_equivalent(aqp::horizonDepths(x), c('hzdept_r', 'hzdepb_r'))
@@ -44,7 +46,9 @@ test_that("fetchSDA() returns expected results", {
   skip_if_offline()
 
   skip_on_cran()
-
+  
+  skip_if(inherits(x, 'try-error'))
+  
   # there should be 2 components and 10 horizons
   expect_equivalent(nrow(aqp::site(x)), 2)
   expect_equivalent(aqp::nrow(x), 10)
@@ -66,7 +70,9 @@ test_that("fetchSDA(duplicates=TRUE) works as expected", {
   skip_if_offline()
 
   skip_on_cran()
-
+  
+  skip_if(inherits(x, 'try-error'))
+  
   x2 <<- suppressWarnings(suppressMessages(fetchSDA(WHERE="nationalmusym = '22787'")))
   x3 <<- suppressWarnings(suppressMessages(fetchSDA(WHERE="nationalmusym = '22787'", duplicates = TRUE)))
 

--- a/tests/testthat/test-fetchSDA.R
+++ b/tests/testthat/test-fetchSDA.R
@@ -4,8 +4,6 @@ test_that("fetchSDA() works", {
   
   skip_if_not_installed("aqp")
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -23,8 +21,6 @@ test_that("fetchSDA() returns an SPC", {
   
   skip_if_not_installed("aqp")
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -40,8 +36,6 @@ test_that("fetchSDA() returns an SPC", {
 test_that("fetchSDA() returns expected results", {
   
   skip_if_not_installed("aqp")
-  
-  skip_if_not_installed("httr")
   
   skip_if_offline()
 
@@ -64,8 +58,6 @@ test_that("fetchSDA() returns expected results", {
 test_that("fetchSDA(duplicates=TRUE) works as expected", {
   
   skip_if_not_installed("aqp")
-  
-  skip_if_not_installed("httr")
   
   skip_if_offline()
 

--- a/tests/testthat/test-fetchSDA_spatial.R
+++ b/tests/testthat/test-fetchSDA_spatial.R
@@ -2,8 +2,6 @@ context("fetchSDA_spatial -- requires internet connection")
 
 test_that("fetchSDA_spatial basic mupolygon functionality", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -33,8 +31,6 @@ test_that("fetchSDA_spatial basic mupolygon functionality", {
 })
 
 test_that("fetchSDA_spatial sapolygon and gsmmupolygon", {
-  
-  skip_if_not_installed("httr")
   
   skip_if_offline()
 

--- a/tests/testthat/test-fetchSDA_spatial.R
+++ b/tests/testthat/test-fetchSDA_spatial.R
@@ -12,6 +12,9 @@ test_that("fetchSDA_spatial basic mupolygon functionality", {
   
   # expect 3, relatively non-extensive join delineations
   single.mukey <- fetchSDA_spatial(x = "2924882", by.col = 'mukey')
+  
+  skip_if(inherits(single.mukey, 'try-error'))
+  
   expect_equivalent(nrow(single.mukey), 3)
 
   # there are currently 3 MUKEY associated with this national musym
@@ -48,6 +51,7 @@ test_that("fetchSDA_spatial sapolygon and gsmmupolygon", {
                                       method = "bbox",
                                       geom.src = "sapolygon",
                                       add.fields = "legend.areaname")
+  skip_if(inherits(by.areasym.bbox, 'try-error'))
   expect_false(is.null(by.areasym.bbox$areaname))
   expect_equivalent(nrow(by.areasym.bbox), 6)
 

--- a/tests/testthat/test-get_SDA_coecoclass.R
+++ b/tests/testthat/test-get_SDA_coecoclass.R
@@ -1,7 +1,5 @@
 test_that("get_SDA_coecoclass works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
   
   skip_on_cran()

--- a/tests/testthat/test-get_SDA_coecoclass.R
+++ b/tests/testthat/test-get_SDA_coecoclass.R
@@ -8,6 +8,7 @@ test_that("get_SDA_coecoclass works", {
   
   res0 <- get_SDA_coecoclass(method = "dominant condition", 
                              areasymbols = "foo")
+  skip_if(inherits(res0, 'try-error'))
   expect_null(res0)
   
   res1 <- get_SDA_coecoclass(method = "dominant condition", 

--- a/tests/testthat/test-get_SDA_cosurfmorph.R
+++ b/tests/testthat/test-get_SDA_cosurfmorph.R
@@ -8,22 +8,19 @@ test_that("get_SDA_cosurfmorph works", {
   
    # Summarize by 3D geomorphic components by component name (default `by='compname'`)
   x <- get_SDA_cosurfmorph(WHERE = "areasymbol = 'CA630'")
-  skip_if(is.null(x))
+  skip_if(inherits(x, 'try-error'))
   expect_true(inherits(x, 'data.frame'))
   
    # Whole Soil Survey Area summary (using `by = 'areasymbol'`)
   x <- get_SDA_cosurfmorph(WHERE = "areasymbol = 'CA630'", by = 'areasymbol')
-  skip_if(is.null(x))
   expect_true(inherits(x, 'data.frame'))
 
    # 2D Hillslope Position summary(using `table = 'cosurfmorphhpp'`)
   x <- get_SDA_cosurfmorph(WHERE = "areasymbol = 'CA630'", table = 'cosurfmorphhpp')
-  skip_if(is.null(x))
   expect_true(inherits(x, 'data.frame'))
 
    # Surface Shape summary (using `table = 'cosurfmorphss'`)
   x <- get_SDA_cosurfmorph(WHERE = "areasymbol = 'CA630'", table = 'cosurfmorphss')
-  skip_if(is.null(x))
   expect_true(inherits(x, 'data.frame'))
   
   x <- get_SDA_cosurfmorph(mukeys = 465186, 

--- a/tests/testthat/test-get_SDA_hydric.R
+++ b/tests/testthat/test-get_SDA_hydric.R
@@ -8,7 +8,7 @@ test_that("get_SDA_hydric works", {
 
   # by areasymbol
   x <- get_SDA_hydric(areasymbols = c("CA077", "CA630"))
-  skip_if(is.null(x))
+  skip_if(inherits(x, 'try-error'))
   expect_length(unique(x$mukey), nrow(x))
 
   # check classification of mapunits
@@ -18,18 +18,14 @@ test_that("get_SDA_hydric works", {
 
   # by mukey
   x <- get_SDA_hydric(mukeys = c(461994, 461995))
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), 2)
   
   x <- get_SDA_hydric(mukeys = c(461994, 461995), method = "none")
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), 11)
   
   x <- get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant component")
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), 2)
   
   x <- get_SDA_hydric(mukeys = c(461994, 461995), method = "dominant condition")
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), 2)
 })

--- a/tests/testthat/test-get_SDA_interpretation.R
+++ b/tests/testthat/test-get_SDA_interpretation.R
@@ -1,4 +1,4 @@
-target_areas <-  c("CA649", "CA630")
+target_areas <- c("CA649", "CA630")
 target_mukeys <- c(463263, 463264)
   
 test_that("dynamically determine target row counts", {
@@ -20,9 +20,7 @@ test_that("dynamically determine target row counts", {
 
   r1 <- SDA_query(sprintf(q, area_in))
   r2a <- SDA_query(sprintf(q, comp_in[1]))
-
-  expect_false(inherits(r1, 'try-error'))
-
+  
   target_area_rows <<- nrow(r1) # 1:1 with mukey
   target_area_rows_all <<- nrow(r2a) # 1:1 with component
 
@@ -37,6 +35,8 @@ test_that("SDA interpretations (dominant component) works", {
 
   skip_on_cran()
 
+  skip_if(is.null(target_area_rows))
+  
   res <- get_SDA_interpretation("FOR - Potential Seedling Mortality",
                                 method = "Dominant Component", areasymbols = target_areas)
   expect_equivalent(nrow(res), target_area_rows)
@@ -54,17 +54,17 @@ test_that("SDA interpretations (dominant condition) works", {
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows))
 
   res <- get_SDA_interpretation("FOR - Potential Seedling Mortality",
                                 method = "Dominant Condition", areasymbols = target_areas)
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), target_area_rows)
 
 
   res <- get_SDA_interpretation(c("FOR - Potential Seedling Mortality",
                                   "FOR - Road Suitability (Natural Surface)"),
                                 method = "Dominant Condition", mukeys = target_mukeys)
-  skip_if(is.null(res))
   expect_equivalent(sort(res$mukey), sort(target_mukeys))
 })
 
@@ -75,17 +75,17 @@ test_that("SDA interpretations (weighted average) works", {
   skip_if_offline()
 
   skip_on_cran()
-
+  
+  skip_if(is.null(target_area_rows))
+  
   res <- get_SDA_interpretation("FOR - Potential Seedling Mortality",
                                 method = "Weighted Average", areasymbols = target_areas)
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), target_area_rows)
 
 
   res <- get_SDA_interpretation(c("FOR - Potential Seedling Mortality",
                                   "FOR - Road Suitability (Natural Surface)"),
                                 method = "Weighted Average", mukeys = target_mukeys)
-  skip_if(is.null(res))
   expect_equivalent(sort(res$mukey), sort(target_mukeys))
 })
 
@@ -96,12 +96,13 @@ test_that("SDA interpretations (no aggregation) works", {
   skip_if_offline()
 
   skip_on_cran()
-
+  
+  skip_if(is.null(target_area_rows_all))
+  
   res <- get_SDA_interpretation(c("FOR - Potential Seedling Mortality",
                                   "FOR - Road Suitability (Natural Surface)"),
                                 method = "NONE",
                                 areasymbols = target_areas)
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), target_area_rows_all)
 
 

--- a/tests/testthat/test-get_SDA_interpretation.R
+++ b/tests/testthat/test-get_SDA_interpretation.R
@@ -19,6 +19,8 @@ test_that("dynamically determine target row counts", {
   r1 <- SDA_query(sprintf(q, area_in))
   r2a <- SDA_query(sprintf(q, comp_in[1]))
   
+  expect_true(inherits(r1, 'data.frame') || is.null(r1))
+  
   target_area_rows <<- nrow(r1) # 1:1 with mukey
   target_area_rows_all <<- nrow(r2a) # 1:1 with component
 

--- a/tests/testthat/test-get_SDA_interpretation.R
+++ b/tests/testthat/test-get_SDA_interpretation.R
@@ -3,8 +3,6 @@ target_mukeys <- c(463263, 463264)
   
 test_that("dynamically determine target row counts", {
 
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -29,8 +27,6 @@ test_that("dynamically determine target row counts", {
 
 test_that("SDA interpretations (dominant component) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -48,8 +44,6 @@ test_that("SDA interpretations (dominant component) works", {
 })
 
 test_that("SDA interpretations (dominant condition) works", {
-  
-  skip_if_not_installed("httr")
   
   skip_if_offline()
 
@@ -70,8 +64,6 @@ test_that("SDA interpretations (dominant condition) works", {
 
 test_that("SDA interpretations (weighted average) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -90,8 +82,6 @@ test_that("SDA interpretations (weighted average) works", {
 })
 
 test_that("SDA interpretations (no aggregation) works", {
-  
-  skip_if_not_installed("httr")
   
   skip_if_offline()
 

--- a/tests/testthat/test-get_SDA_muaggatt.R
+++ b/tests/testthat/test-get_SDA_muaggatt.R
@@ -1,7 +1,5 @@
 test_that("get_SDA_muaggatt works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()

--- a/tests/testthat/test-get_SDA_muaggatt.R
+++ b/tests/testthat/test-get_SDA_muaggatt.R
@@ -8,7 +8,7 @@ test_that("get_SDA_muaggatt works", {
   
   res <- get_SDA_muaggatt(areasymbols = c("CA077", "CA630"))
   
-  skip_if(is.null(res))
+  skip_if(inherits(res, 'try-error'))
   
   expect_length(unique(res$mukey), nrow(res))
   expect_equivalent(nrow(get_SDA_muaggatt(mukeys = c(461994, 461995))), 2)

--- a/tests/testthat/test-get_SDA_pmgroupname.R
+++ b/tests/testthat/test-get_SDA_pmgroupname.R
@@ -7,27 +7,22 @@ test_that("get_SDA_pmgroupname works", {
   skip_on_cran()
   
   res <- get_SDA_pmgroupname(areasymbols = c("CA077", "CA630"))
-  skip_if(is.null(res))
+  skip_if(inherits(res, 'try-error'))
   expect_length(unique(res$mukey), nrow(res))
   
   # some misc areas have geomorph populated (e.g. "Mixed alluvial land", but others, like "Water" are NULL)
   res <- get_SDA_pmgroupname(mukeys = c(462409, 2462630, 465186), simplify = FALSE, method = "dominant condition") # default is miscellaneous_areas=FALSE
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), 3)
   
   res <- get_SDA_pmgroupname(mukeys = c(462409, 2462630, 465186), simplify = FALSE, miscellaneous_areas = TRUE, method = "dominant condition")
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), 3)
   
   res <- get_SDA_pmgroupname(mukeys = c(461994, 461995, 465186), simplify = FALSE, method = "none", miscellaneous_areas = TRUE, include_minors = FALSE)
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), 5)  
   
   res <- get_SDA_pmgroupname(mukeys = c(461994, 461995, 465186), simplify = FALSE, method = "none", miscellaneous_areas = TRUE)
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), 14)
   
   res <- get_SDA_pmgroupname(mukeys = c(461994, 461995, 465186), simplify = FALSE, method = "dominant condition")
-  skip_if(is.null(res))
   expect_equivalent(nrow(res), 3)
 })

--- a/tests/testthat/test-get_SDA_pmgroupname.R
+++ b/tests/testthat/test-get_SDA_pmgroupname.R
@@ -1,7 +1,5 @@
 test_that("get_SDA_pmgroupname works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()

--- a/tests/testthat/test-get_SDA_property.R
+++ b/tests/testthat/test-get_SDA_property.R
@@ -3,8 +3,6 @@ target_mukeys <- c(463263, 463264)
   
 test_that("dynamically determine target row counts", {
 
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
@@ -26,8 +24,6 @@ test_that("dynamically determine target row counts", {
   r3a <- SDA_query(sprintf(q, chor_in[1]))
   r3b <- SDA_query(sprintf(q, chor_in[2]))
 
-  expect_false(inherits(r1, 'try-error'))
-
   target_area_rows <<- nrow(r1) # 1:1 with mukey
   target_area_rows_all <<- nrow(r2a) # 1:1 with component
   target_area_rows_all_chorizon <<- nrow(r3a) # 1:1 with chorizon
@@ -43,11 +39,11 @@ test_that("dynamically determine target row counts", {
 
 test_that("SDA properties (dominant condition) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows))
 
   x <- get_SDA_property(property = "Taxonomic Suborder",
                         method = "Dominant Condition",
@@ -72,32 +68,30 @@ test_that("SDA properties (dominant condition) works", {
 
 test_that("SDA properties (dominant component category) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
   
+  skip_if(is.null(target_area_rows))
+  
   x <- get_SDA_property(property = "Taxonomic Suborder",
                         method = "Dominant Component (Category)",
                         areasymbols = target_areas)
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows - n_misc_area_rows)
 
   x <- get_SDA_property(property = c("Taxonomic Suborder","Taxonomic Order"),
                         method = "Dominant Component (Category)",
                         mukeys = target_mukeys)
-  skip_if(is.null(x))
   expect_equivalent(x$mukey, target_mukeys)
 })
 
 test_that("SDA properties (dominant component numeric) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows))
 
   x <- get_SDA_property(
     property = "Very Coarse Sand - Rep Value",
@@ -106,7 +100,6 @@ test_that("SDA properties (dominant component numeric) works", {
     top_depth = 25,
     bottom_depth = 50
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows)
 
   x <- get_SDA_property(
@@ -116,7 +109,6 @@ test_that("SDA properties (dominant component numeric) works", {
     top_depth = 25,
     bottom_depth = 50
   )
-  skip_if(is.null(x))
   expect_equivalent(x$mukey, target_mukeys)
 
   # dominant component of 1st mapunit is rock outcrop (excluded), pH 5 from Thermalrocks 10-13cm
@@ -134,11 +126,11 @@ test_that("SDA properties (dominant component numeric) works", {
 
 test_that("SDA properties (weighted average) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows))
 
   x <- get_SDA_property(property = 'ph1to1h2o_r',
                    method = "Weighted Average",
@@ -156,7 +148,6 @@ test_that("SDA properties (weighted average) works", {
     top_depth = 25,
     bottom_depth = 50
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows)
 
   x <- get_SDA_property(
@@ -167,7 +158,6 @@ test_that("SDA properties (weighted average) works", {
     bottom_depth = 50
   )
 
-  skip_if(is.null(x))
   expect_equivalent(x$mukey, target_mukeys)
 
   # check miscellaneous areas and NULL data in horizons
@@ -192,8 +182,8 @@ test_that("SDA properties (weighted average) works", {
   noagg <- get_SDA_property(property = c("sandtotal_r","silttotal_r","claytotal_r"),
                             method = "None",
                             mukeys = 545857)
-  skip_if(is.null(agg))
-  skip_if(is.null(noagg))
+  skip_if(inherits(agg, 'try-error'))
+  skip_if(inherits(noagg, 'try-error'))
 
   aqp::depths(noagg) <- cokey ~ hzdept_r + hzdepb_r
   aqp::site(noagg) <- ~ comppct_r
@@ -227,6 +217,10 @@ test_that("SDA properties (weighted average) works", {
     )
 
   noagg <- get_SDA_property("om_r", mukeys = 286248, method = "None", include_minors = TRUE)
+  
+  skip_if(inherits(agg, 'try-error'))
+  skip_if(inherits(noagg, 'try-error'))
+  
   aqp::depths(noagg) <- cokey ~ hzdept_r + hzdepb_r
   aqp::site(noagg) <- ~ comppct_r
 
@@ -253,21 +247,17 @@ test_that("SDA properties (weighted average) works", {
   noagg2 <- get_SDA_property("ph1to1h2o_r", mukeys = 466601, method = "weighted average", include_minors = FALSE, miscellaneous_areas = TRUE)
   noagg3 <- get_SDA_property("ph1to1h2o_r", mukeys = 466601, method = "weighted average", include_minors = TRUE, miscellaneous_areas = TRUE)
 
-  skip_if(is.null(noagg1))
-  skip_if(is.null(noagg2))
-  skip_if(is.null(noagg3))
-
   expect_equal(c(noagg1$ph1to1h2o_r, noagg2$ph1to1h2o_r, noagg3$ph1to1h2o_r),
                rep(7, 3), tolerance = 1e-5)
 })
 
 test_that("SDA properties (min/max) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows))
 
   x <- get_SDA_property(
     property = "Saturated Hydraulic Conductivity - Rep Value",
@@ -276,7 +266,6 @@ test_that("SDA properties (min/max) works", {
     FUN = "MIN",
     miscellaneous_areas = TRUE
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows)
 
   x <- get_SDA_property(
@@ -285,7 +274,6 @@ test_that("SDA properties (min/max) works", {
     areasymbols = target_areas,
     FUN = "MIN"
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows)
   
   # 463263      Daulton loam, 15 to 30 percent slopes
@@ -298,17 +286,16 @@ test_that("SDA properties (min/max) works", {
     FUN = "MAX", 
     miscellaneous_areas = TRUE
   )
-  skip_if(is.null(x))
   expect_equivalent(x$mukey, target_mukeys)
 })
 
 test_that("SDA properties (no aggregation) works", {
   
-  skip_if_not_installed("httr")
-  
   skip_if_offline()
 
   skip_on_cran()
+  
+  skip_if(is.null(target_area_rows_all))
 
   # return results 1:1 with component for component properties
   x <- get_SDA_property(
@@ -317,7 +304,6 @@ test_that("SDA properties (no aggregation) works", {
       areasymbols = target_areas,
       miscellaneous_areas = FALSE
     )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows_all - n_misc_area_rows_all)
 
   x <- get_SDA_property(
@@ -326,7 +312,6 @@ test_that("SDA properties (no aggregation) works", {
     areasymbols = target_areas,
     miscellaneous_areas = TRUE
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows_all)
 
 
@@ -336,7 +321,6 @@ test_that("SDA properties (no aggregation) works", {
     method = "NONE",
     areasymbols = target_areas
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows_all_chorizon - n_misc_area_rows_all_chorizon)
 
   x <- get_SDA_property(
@@ -345,6 +329,5 @@ test_that("SDA properties (no aggregation) works", {
     areasymbols = target_areas,
     miscellaneous_areas = TRUE
   )
-  skip_if(is.null(x))
   expect_equivalent(nrow(x), target_area_rows_all_chorizon)
 })

--- a/tests/testthat/test-get_SDA_property.R
+++ b/tests/testthat/test-get_SDA_property.R
@@ -24,6 +24,8 @@ test_that("dynamically determine target row counts", {
   r3a <- SDA_query(sprintf(q, chor_in[1]))
   r3b <- SDA_query(sprintf(q, chor_in[2]))
 
+  expect_true(inherits(r1, 'data.frame') || is.null(r1))
+  
   target_area_rows <<- nrow(r1) # 1:1 with mukey
   target_area_rows_all <<- nrow(r2a) # 1:1 with component
   target_area_rows_all_chorizon <<- nrow(r3a) # 1:1 with chorizon

--- a/tests/testthat/test-get_SSURGO_utils.R
+++ b/tests/testthat/test-get_SSURGO_utils.R
@@ -6,6 +6,7 @@ test_that(".make_WSS_download_url works", {
   skip_on_cran()
   
   x <- .make_WSS_download_url("areasymbol IN ('NH607', 'VT005', 'VT009', 'VT019')")
+  skip_if(inherits(x, 'try-error'))
   expect_length(x, 4)
   
   # vermont has a state-specific template

--- a/tests/testthat/test-get_SSURGO_utils.R
+++ b/tests/testthat/test-get_SSURGO_utils.R
@@ -1,5 +1,4 @@
 test_that(".make_WSS_download_url works", {
-  skip_if_not_installed("httr")
   
   skip_if_offline()
   


### PR DESCRIPTION
- Fix for error handling in get_SDV_legend_elements and get_SDA_coecoclass
- SDA_query no longer requires httr, so no need to check if installed for tests
- Consistently skip test on `try-error` (bad request or connection) rather than NULL (no result) 
- URL fixes for `tools::check_package_urls()`