### PR TITLE
feat: update EDIT functions to use new URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.9.1
+Version: 2.9.2
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov", comment=c(ORCID="0009-0008-2780-4785")),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,6 @@
 # soilDB 2.9.2 (development)
-
-## Improvements
- - `soilColor.wcs()` updated with FY26 soil color maps, now including most OCONUS soil surveys (AK, HI, PR, PW, GU, AS, MP)
- - `ISSR800.wcs()` updated with FY26 data, bug fixes related to NA-handling by WCS
- - `mukey.wcs()` updated with FY26 data, bug fixes related to NA-handling, now including most OCONUS soil surveys (AK, HI, PR, PW, GU, AS, MP)
+ - EDIT base URL (for `get_EDIT_ecoclass_by_geoUnit()` and `make_EDIT_service_URL()`) updated to new USDA-managed server: <https://edit.sc.egov.usda.gov/>
+ - SoilWeb-based Web Coverage Services (`soilColor.wcs()`, `ISSR800.wcs()`, `mukey.wcs()`) have been updated with FY26 maps, now including most OCONUS soil surveys (AK, HI, PR, PW, GU, AS, MP)
 
 # soilDB 2.9.1 (2026-04-01)
  - `ROSETTA()` updates thanks to Todd Skaggs (USDA-ARS):

--- a/R/fetchEDIT_tools.R
+++ b/R/fetchEDIT_tools.R
@@ -1,13 +1,9 @@
 # fetchEDIT_tools: tools for getting information from Jornada EDIT web services
-# More information: https://edit.jornada.nmsu.edu/resources/esd
+# More information: https://edit.sc.egov.usda.gov/resources/esd
 
-###
-### New function to build a JSON service URL that matches XYZ criteria
-###
-###
 #' Make Ecological Dynamics Interpretive Tool (EDIT) web services URL
 #'
-#' @description Construct a URL for Ecological Dynamics Interpretive Tool (EDIT) web services (`https://edit.jornada.nmsu.edu/services/...`) to return PDF, TXT or JSON results.
+#' @description Construct a URL for Ecological Dynamics Interpretive Tool (EDIT) web services (`https://edit.sc.egov.usda.gov/services/...`) to return PDF, TXT or JSON results.
 #'
 #' @details See the official EDIT developer resources to see which endpoints are available for Ecological Site Description (ESD) or Ecological Site Group (ESG) catalogs:
 #'
@@ -79,7 +75,7 @@ make_EDIT_service_URL <- function(src = c("descriptions", "downloads",
                                   endpoint = NULL,
                                   querystring = NULL) {
   # base URL
-  base_url <- "https://edit.jornada.nmsu.edu"
+  base_url <- "https://edit.sc.egov.usda.gov"
 
   # root services URL
   service_url <- "services"
@@ -128,7 +124,7 @@ make_EDIT_service_URL <- function(src = c("descriptions", "downloads",
 
 #' Get Ecological Dynamics Information Tool (EDIT) ecological sites by catalog (ESD/ESG) and MLRA 
 #'  
-#' @description  Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.jornada.nmsu.edu/resources/esd. `geoUnit` refers to MLRA codes, possibly with a leading zero and trailing "X" for two digit MLRA symbols.
+#' @description  Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.sc.egov.usda.gov/resources/esd. `geoUnit` refers to MLRA codes, possibly with a leading zero and trailing "X" for two digit MLRA symbols.
 #'
 #' @param geoUnit A character vector of `geoUnit` codes e.g. `c("018X","022A")` for MLRAs 18 and 22A.
 #' @param catalog Catalog ID. One of: `"esd"` or `"esg"`

--- a/R/get_SDA_coecoclass.R
+++ b/R/get_SDA_coecoclass.R
@@ -291,7 +291,7 @@ get_SDA_coecoclass <- function(method = "None",
             isTRUE(x$ecoclassid[i] == not_rated_value | is.na(x$ecoclassid[i])),
             NA_character_,
             paste0(
-              "https://edit.jornada.nmsu.edu/catalogs/esd/",
+              "https://edit.sc.egov.usda.gov/catalogs/esd/",
               substr(x$ecoclassid[i], 2, 5),
               "/",
               x$ecoclassid[i]
@@ -300,7 +300,7 @@ get_SDA_coecoclass <- function(method = "None",
         )
         # sitenpdf = ifelse(isTRUE(x$ecoclassid[i] == "Not assigned"), NA_character_,
         #                   paste0(
-        #                     "https://edit.jornada.nmsu.edu/services/descriptions/esd/",
+        #                     "https://edit.sc.egov.usda.gov/services/descriptions/esd/",
         #                     substr(x$ecoclassid[i], 2, 5), "/", x$ecoclassid[i], ".pdf"
         #                   )))
       }

--- a/man/get_EDIT_ecoclass_by_geoUnit.Rd
+++ b/man/get_EDIT_ecoclass_by_geoUnit.Rd
@@ -15,7 +15,7 @@ get_EDIT_ecoclass_by_geoUnit(geoUnit, catalog = c("esd", "esg"))
 A \code{data.frame} containing: \code{geoUnit}, \code{id}, \code{legacyId}, \code{name}. \code{NULL} if no result.
 }
 \description{
-Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.jornada.nmsu.edu/resources/esd. \code{geoUnit} refers to MLRA codes, possibly with a leading zero and trailing "X" for two digit MLRA symbols.
+Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.sc.egov.usda.gov/resources/esd. \code{geoUnit} refers to MLRA codes, possibly with a leading zero and trailing "X" for two digit MLRA symbols.
 }
 \examples{
 \dontshow{if (curl::has_internet() && requireNamespace("httr", quietly = TRUE)) withAutoprint(\{ # examplesIf}

--- a/man/make_EDIT_service_URL.Rd
+++ b/man/make_EDIT_service_URL.Rd
@@ -42,7 +42,7 @@ make_EDIT_service_URL(
 A character vector containing URLs with specified parameters. This function is vectorized.
 }
 \description{
-Construct a URL for Ecological Dynamics Interpretive Tool (EDIT) web services (\verb{https://edit.jornada.nmsu.edu/services/...}) to return PDF, TXT or JSON results.
+Construct a URL for Ecological Dynamics Interpretive Tool (EDIT) web services (\verb{https://edit.sc.egov.usda.gov/services/...}) to return PDF, TXT or JSON results.
 }
 \details{
 See the official EDIT developer resources to see which endpoints are available for Ecological Site Description (ESD) or Ecological Site Group (ESG) catalogs:

--- a/misc/fetchEDIT_ideas.R
+++ b/misc/fetchEDIT_ideas.R
@@ -5,7 +5,7 @@ library(rvest)
 
 # list all the available /services in the developer documentation
 
-path <- read_html("https://edit.jornada.nmsu.edu/resources/esd/") %>%
+path <- read_html("https://edit.sc.egov.usda.gov/resources/esd/") %>%
   html_nodes("span") %>%
   html_text() %>%
   (function(x) {x[grepl("^/services.*", x)]})()
@@ -154,7 +154,7 @@ make_EDIT_service_URL <- function(src = c("descriptions", "downloads",
                           endpoint = NULL,
                           querystring = NULL) {
   # base URL
-  base_url <- "https://edit.jornada.nmsu.edu"
+  base_url <- "https://edit.sc.egov.usda.gov"
 
   # root services URL
   service_url <- "services"
@@ -204,7 +204,7 @@ make_EDIT_service_URL <- function(src = c("descriptions", "downloads",
 
 #' Get data.frame of all ecoclass for multiple EDIT geoUnit
 #'
-#' Supply a vector of target `geoUnit`. Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.jornada.nmsu.edu/resources/esd
+#' Supply a vector of target `geoUnit`. Data are accessed via Ecological Dynamics Interpretive Tool (EDIT) web services: https://edit.sc.egov.usda.gov/resources/esd
 #'
 #' @param geoUnit A character vector of `geoUnit` codes e.g. `c("018X","022A")` for MLRAs 18 and 22A.
 #'

--- a/tests/testthat/test-fetchEDIT_tools.R
+++ b/tests/testthat/test-fetchEDIT_tools.R
@@ -2,26 +2,26 @@ context("EDIT web services")
 
 test_that("make_EDIT_service_URL works", {
   
-  # test simple construction of URLs for https://edit.jornada.nmsu.edu/services/...
+  # test simple construction of URLs for https://edit.sc.egov.usda.gov/services/...
   #  return PDF, .TXT or JSON result
   
   # url for all geoUnit keys as PDF
   expect_equivalent(make_EDIT_service_URL(src = "descriptions",
                         catalog = "esd",
-                        geoUnit = "039X"), "https://edit.jornada.nmsu.edu/services/descriptions/esd/039X.pdf")
+                        geoUnit = "039X"), "https://edit.sc.egov.usda.gov/services/descriptions/esd/039X.pdf")
   
   # url for a single key within geoUnit as PDF
   expect_equivalent(make_EDIT_service_URL(src = "descriptions",
                         catalog = "esd",
                         geoUnit = "039X",
-                        key = "1"), "https://edit.jornada.nmsu.edu/services/descriptions/esd/039X/1.pdf")
+                        key = "1"), "https://edit.sc.egov.usda.gov/services/descriptions/esd/039X/1.pdf")
   
   # query for ecoclass with endpoint "overview"
   expect_equivalent(make_EDIT_service_URL(src = "descriptions",
                                    catalog = "esd",
                                    geoUnit = "039X",
                                    ecoclass = "R039XA109AZ",
-                                   endpoint = "overview.json"), "https://edit.jornada.nmsu.edu/services/descriptions/esd/039X/R039XA109AZ/overview.json")
+                                   endpoint = "overview.json"), "https://edit.sc.egov.usda.gov/services/descriptions/esd/039X/R039XA109AZ/overview.json")
   
 })
 
@@ -40,7 +40,7 @@ test_that("get_EDIT_ecoclass_by_geoUnit works", {
   # skip on error
   skip_if(is.null(res))
   
-  # verify data.frame result with 4 columns as specified @ https://edit.jornada.nmsu.edu/resources/esd/
+  # verify data.frame result with 4 columns as specified @ https://edit.sc.egov.usda.gov/resources/esd/
   expect_true(all(colnames(res) %in% c("geoUnit", "id", "legacyId", "name")))
   
 })


### PR DESCRIPTION
For `get_EDIT_ecoclass_by_geoUnit()` and `make_EDIT_service_URL()` to use the new USDA-managed server.

Here is an example of using these functions to query web service JSON endpoints for ESD State and Transition Model states and community phases  for 2 MLRAs of interest (16 and 18)
``` r
library(soilDB)

x <- get_EDIT_ecoclass_by_geoUnit(c("016X", "018X"))

u <- make_EDIT_service_URL(
  src = "models",
  catalog = "esd",
  geoUnit = x$geoUnit,
  ecoclass = x$id,
  endpoint = "states.json"
)

names(u) <- x$id
head(u)
#>                                                                      R016XA001CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/016X/R016XA001CA/states.json" 
#>                                                                      R016XA002CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/016X/R016XA002CA/states.json" 
#>                                                                      R016XA004CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/016X/R016XA004CA/states.json" 
#>                                                                      R016XB001CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/016X/R016XB001CA/states.json" 
#>                                                                      R016XB002CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/016X/R016XB002CA/states.json" 
#>                                                                      F018XA201CA 
#> "https://edit.sc.egov.usda.gov/services/models/esd/018X/F018XA201CA/states.json"

res <- lapply(head(u), jsonlite::fromJSON)
```
