### PR TITLE
feat(downloadSSURGO): add `LAPPLY.FUN` argument for parallel unzipping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # soilDB 2.9.2 (development)
  - EDIT base URL (for `get_EDIT_ecoclass_by_geoUnit()` and `make_EDIT_service_URL()`) updated to new USDA-managed server: <https://edit.sc.egov.usda.gov/>
  - SoilWeb-based Web Coverage Services (`soilColor.wcs()`, `ISSR800.wcs()`, `mukey.wcs()`) have been updated with FY26 maps, now including most OCONUS soil surveys (AK, HI, PR, PW, GU, AS, MP)
- - `downloadSSURGO()` gains arguments `include_spatial` and `include_tabular` that are analogous to arguments of the same name from `createSSURGO()`. Thanks to feature request from @dylanbeaudette (#470).
+ - `downloadSSURGO()` gains arguments `include_spatial` and `include_tabular` that are analogous to arguments of the same name from `createSSURGO()`. Also, added `LAPPLY.FUN` to support arbitrary parallel or progress reporting backends. Thanks to feature request from @dylanbeaudette (#470).
 
 # soilDB 2.9.1 (2026-04-01)
  - `ROSETTA()` updates thanks to Todd Skaggs (USDA-ARS):

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -153,7 +153,11 @@ downloadSSURGO <- function(WHERE = NULL,
           "^(mstab|mdstattabs|MetadataTable|mstabcol|mdstattabcol|MetadataColumnLookup|msidxdet|mdstatidxdet|MetadataIndexDetail)$",
           tools::file_path_sans_ext(basename(lz))
         )], exdir = exdir)
-        inv <- .inventory_ssurgo_files(lz, exdir = exdir, include_spatial = include_spatial, include_tabular = include_tabular)
+        
+        # explicitly fetch internal function our namespace to support parallel workers
+        INV.FUN <- get(".inventory_ssurgo_files", envir = asNamespace("soilDB"))
+        inv <- INV.FUN(lz, include_spatial = include_spatial, include_tabular = include_tabular)
+        
         lz <- unlist(c(inv$f.shp.sc, inv$f.txt.grp))
       }
       uz <- utils::unzip(paths2[i], files = lz, exdir = exdir)

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -1,12 +1,9 @@
 #' Get SSURGO ZIP files from Web Soil Survey 'Download Soils Data'
 #'
-#' Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard
-#' SSURGO format; optionally including the corresponding SSURGO Template Database with
-#' `include_template=TRUE`.
-#'
-#' To specify the Soil Survey Areas you would like to obtain data you use a `WHERE` clause for query
-#' of `sacatalog` table such as `areasymbol = 'CA067'`, `"areasymbol IN ('CA628', 'CA067')"` or
-#' `areasymbol LIKE 'CT%'`.
+#' Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files in standard SSURGO
+#' format. To specify the Soil Survey Areas you would like to download, use a `WHERE` clause for
+#' query of `sacatalog` table, for example: `areasymbol = 'CA067'`, `"areasymbol IN ('CA628',
+#' 'CA067')"`, or `areasymbol LIKE 'CT%'`.
 #'
 #' @param WHERE _character_. A SQL `WHERE` clause expression used to filter records in `sacatalog`
 #'   table. Alternately `WHERE` can be any spatial object supported by `SDA_spatialQuery()` for
@@ -18,15 +15,15 @@
 #'   not yet exist. Each ZIP file will extract to a folder labeled with `areasymbol` in this
 #'   directory. Default: `destdir`
 #' @param include_template _logical_. Include the (possibly state-specific) MS Access template
-#' database? Default: `FALSE`
+#'   database? Default: `FALSE`
 #' @param include_spatial _logical_ or _character_. Extract spatial data layers from ZIP file?
 #'   Default: `TRUE` inserts all spatial tables. If `include_spatial` is a _character_ vector
 #'   containing table names, only that set is extracted from the downloaded ZIP files. e.g.
 #'   `include_spatial=c("mupolygon", "featpoint")` extracts only the shapefiles (with side car
 #'   files) for mapunit polygons and special feature points.
-#' @param include_tabular _logical_ or _character_. Include tabular data layers in database?
-#'   Default: `TRUE` inserts all tabular tables. If `include_tabular` is a _character_ vector
-#'   containing table names, only that set is extracted from the downloaded ZIP files. e.g.
+#' @param include_tabular _logical_ or _character_. Extract tabular data from ZIP file? Default:
+#'   `TRUE` inserts all tabular tables. If `include_tabular` is a _character_ vector containing
+#'   table names, only that set is extracted from the downloaded ZIP files. e.g.
 #'   `include_tabular=c("mapunit", "muaggatt")` writes only the `mapunit` and `muaggatt` tables.
 #'   Note that special feature descriptions are stored in table `"featdesc"` and metadata for each
 #'   soil survey area are stored in `"soil_metadata"` tables.
@@ -36,6 +33,7 @@
 #' @param LAPPLY.FUN _function_. `lapply()`-like function to use for iteration during `extract`
 #'   phase. Only used if `extract=TRUE`. This allows for the `utils::unzip()` operations to be run
 #'   in parallel instead of sequential, custom progress reporting, or similar.
+#' @param LAPPLY.FUN.ARGS _list_. Optional list of additional arguments to pass to `LAPPLY.FUN`.
 #' @param remove_zip _logical_. Remove ZIP files after extracting? Default: `FALSE`
 #' @param overwrite _logical_. Overwrite by re-extracting if directory already exists? Default:
 #'   `FALSE`
@@ -54,17 +52,17 @@
 #'   have prefix `soilmu_` (mapunit), `soilsa_` (survey area), `soilsf_` (special features). There
 #'   will also be a TXT file with prefix `soilsf_` describing any special features. Shapefile names
 #'   then have an `a_` (polygon), `l_` (line), `p_` (point) followed by the soil survey area symbol.
-#'  When `db="STATSGO"` the `WHERE` argument is not supported. Allowed `areasymbols` include
-#'   `"US"` and two-letter state codes e.g. `"WY"` for the Wyoming general soils map.
+#'   When `db="STATSGO"` the `WHERE` argument is not supported. Allowed `areasymbols` include `"US"`
+#'   and two-letter state codes e.g. `"WY"` for the Wyoming general soils map.
 #'
-#' As in `createSSURGO()`, the `include_spatial` and `include_tabular` arguments either take a
-#' logical value (default `TRUE`) or a character vector of the specific table names to include. Note
-#' that when used in `downloadSSURGO()` the required metadata files are _always_ extracted to
-#' facilitate mapping to user-facing table names. These arguments allow for customizing the files
-#' that get extracted from ZIP files, not just filtering on file names (as is implemented with
-#' pre-existing `pattern` argument). This can dramatically improve efficiency of extraction and the
-#' overall size of the data in `exdir`. These arguments can be used in conjunction with the
-#' `pattern` argument to fine-tune the files included in the generated snapshot database.
+#'   As in `createSSURGO()`, the `include_spatial` and `include_tabular` arguments either take a
+#'   logical value (default `TRUE`) or a character vector of the specific table names to include.
+#'   Note that when used in `downloadSSURGO()` the required metadata files are _always_ extracted to
+#'   facilitate mapping to user-facing table names. These arguments allow for customizing the files
+#'   that get extracted from ZIP files, not just filtering on file names (as is implemented with
+#'   pre-existing `pattern` argument). This can dramatically improve efficiency of extraction and
+#'   the overall size of the data in `exdir`. These arguments can be used in conjunction with the
+#'   `pattern` argument to fine-tune the files included in the generated snapshot database.
 #'
 #' @return _character_. Paths to downloaded ZIP files (invisibly). May not exist if `remove_zip =
 #'   TRUE`.
@@ -79,6 +77,7 @@ downloadSSURGO <- function(WHERE = NULL,
                            db = c('SSURGO', 'STATSGO'),
                            extract = TRUE,
                            LAPPLY.FUN = lapply,
+                           LAPPLY.FUN.ARGS = NULL,
                            remove_zip = FALSE,
                            overwrite = FALSE,
                            quiet = FALSE) {
@@ -142,8 +141,8 @@ downloadSSURGO <- function(WHERE = NULL,
     if (!dir.exists(exdir)) {
       dir.create(exdir, recursive = TRUE)
     }
-    res <- LAPPLY.FUN(seq_along(paths2), function(i) {
-      ssa <- gsub(".*wss_SSA_(.*)_.*", "\\1", paths2[i])
+
+    UNZIP.FUN <- function(i) {
       if (isTRUE(include_spatial) && isTRUE(include_tabular)) {
         lz <- NULL
       } else {
@@ -153,11 +152,11 @@ downloadSSURGO <- function(WHERE = NULL,
           "^(mstab|mdstattabs|MetadataTable|mstabcol|mdstattabcol|MetadataColumnLookup|msidxdet|mdstatidxdet|MetadataIndexDetail)$",
           tools::file_path_sans_ext(basename(lz))
         )], exdir = exdir)
-        
+
         # explicitly fetch internal function our namespace to support parallel workers
         INV.FUN <- get(".inventory_ssurgo_files", envir = asNamespace("soilDB"))
         inv <- INV.FUN(lz, include_spatial = include_spatial, include_tabular = include_tabular)
-        
+
         lz <- unlist(c(inv$f.shp.sc, inv$f.txt.grp))
       }
       uz <- utils::unzip(paths2[i], files = lz, exdir = exdir)
@@ -168,7 +167,9 @@ downloadSSURGO <- function(WHERE = NULL,
           message("Extracted: ", paths2[i])
         }
       }
-    })
+    }
+
+    res <- do.call(LAPPLY.FUN, c(list(seq_along(paths2), UNZIP.FUN), LAPPLY.FUN.ARGS))
 
     if (remove_zip) {
       file.remove(paths2)
@@ -301,7 +302,8 @@ createSSURGO <- function(filename = NULL,
   if ((missing(conn) || is.null(conn)) && !IS_GPKG) {
 
     if (!requireNamespace("RSQLite")) {
-      stop("package 'RSQLite' is required (when `conn` is not specified)", call. = FALSE)
+      stop("package 'RSQLite' is required (when `conn` is not specified)",
+           call. = FALSE)
     }
 
     conn <- DBI::dbConnect(DBI::dbDriver("SQLite"),
@@ -313,7 +315,11 @@ createSSURGO <- function(filename = NULL,
   }
 
   if (nrow(inv$shp.grp) >= 1 && ncol(inv$shp.grp) == 3 && include_spatial) {
-    f.shp.grp <- split(inv$f.shp, list(feature = inv$shp.grp[, 1], geom = inv$shp.grp[, 2]), drop = TRUE)
+
+    f.shp.grp <- split(inv$f.shp,
+                       list(feature = inv$shp.grp[, 1],
+                            geom = inv$shp.grp[, 2]),
+                       drop = TRUE)
 
     if (IS_DUCKDB) {
       DBI::dbExecute(conn, "INSTALL spatial; LOAD spatial;")

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -33,6 +33,9 @@
 #' @param db _character_. Either `"SSURGO"` (default; detailed soil map) or `"STATSGO"` (general
 #'   soil map).
 #' @param extract _logical_. Extract ZIP files to `exdir`? Default: `TRUE`
+#' @param LAPPLY.FUN _function_. `lapply()`-like function to use for iteration during `extract`
+#'   phase. Only used if `extract=TRUE`. This allows for the `utils::unzip()` operations to be run
+#'   in parallel instead of sequential, custom progress reporting, or similar.
 #' @param remove_zip _logical_. Remove ZIP files after extracting? Default: `FALSE`
 #' @param overwrite _logical_. Overwrite by re-extracting if directory already exists? Default:
 #'   `FALSE`
@@ -75,6 +78,7 @@ downloadSSURGO <- function(WHERE = NULL,
                            include_tabular = TRUE,
                            db = c('SSURGO', 'STATSGO'),
                            extract = TRUE,
+                           LAPPLY.FUN = lapply,
                            remove_zip = FALSE,
                            overwrite = FALSE,
                            quiet = FALSE) {
@@ -138,8 +142,7 @@ downloadSSURGO <- function(WHERE = NULL,
     if (!dir.exists(exdir)) {
       dir.create(exdir, recursive = TRUE)
     }
-
-    res <- lapply(seq_along(paths2), function(i) {
+    res <- LAPPLY.FUN(seq_along(paths2), function(i) {
       ssa <- gsub(".*wss_SSA_(.*)_.*", "\\1", paths2[i])
       if (isTRUE(include_spatial) && isTRUE(include_tabular)) {
         lz <- NULL

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -190,15 +190,15 @@ downloadSSURGO <- function(WHERE = NULL,
 #' you encounter issues using specific DBI connection types, please report in the soilDB issue
 #' tracker.
 #'
-#' @param filename _character_. Output file name (e.g. `'db.sqlite'` or `'db.gpkg'`). Only used when `con` is not
-#'   specified by the user.
-#' @param exdir  _character_. Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files,
-#'   downloaded and extracted by `downloadSSURGO()` or similar.
+#' @param filename _character_. Output file name (e.g. `'db.sqlite'` or `'db.gpkg'`). Only used when
+#'   `con` is not specified by the user.
+#' @param exdir  _character_. Path containing containing input SSURGO spatial (.shp) and tabular
+#'   (.txt) files, downloaded and extracted by `downloadSSURGO()` or similar.
 #' @param conn A _DBIConnection_ object. Default is a `SQLiteConnection` used for writing .sqlite or
 #'   .gpkg files. Alternate options are any DBI connection types. When `include_spatial=TRUE`, the
 #'   sf package is used to write spatial data to the database.
-#' @param pattern  _character_. Optional regular expression to use to filter subdirectories of `exdir`.
-#'   Default: `NULL` will search all subdirectories for SSURGO export files.
+#' @param pattern  _character_. Optional regular expression to use to filter subdirectories of
+#'   `exdir`. Default: `NULL` will search all subdirectories for SSURGO export files.
 #' @param include_spatial _logical_ or _character_. Include spatial data layers in database?
 #'   Default: `TRUE` inserts all spatial tables. If `include_spatial` is a _character_ vector
 #'   containing table names, only that set are written to file. e.g. `include_spatial=c("mupolygon",
@@ -210,12 +210,11 @@ downloadSSURGO <- function(WHERE = NULL,
 #'   descriptions are stored in table `"featdesc"` and metadata for each soil survey area are stored
 #'   in `"soil_metadata"` tables.
 #' @param dissolve_field _character_. Dissolve geometries to create MULTIPOLYGON features? Column
-#'   name
-#'   specified is the grouping variable. Default: `NULL` does no aggregation, giving 1 `POLYGON`
-#'   feature per delineation. `"mukey"` aggregates all related delineations within a soil survey
-#'   area.
-#' @param maxruledepth _integer_. Maximum rule depth for `"cointerp"` table. Default `0` includes only
-#'   shallowest ratings for smaller database size.
+#'   name specified is the grouping variable. Default: `NULL` does no aggregation, giving 1
+#'   `POLYGON` feature per delineation. `"mukey"` aggregates all related delineations within a soil
+#'   survey area.
+#' @param maxruledepth _integer_. Maximum rule depth for `"cointerp"` table. Default `0` includes
+#'   only shallowest ratings for smaller database size.
 #' @param overwrite _logical_. Overwrite existing layers? Default: `FALSE`
 #' @param append _logical_. Append to existing layers? Default: `FALSE`
 #' @param header _logical_. Passed to `read.delim()` for reading pipe-delimited (`|`) text files
@@ -223,7 +222,7 @@ downloadSSURGO <- function(WHERE = NULL,
 #' @param quiet _logical_. Suppress messages and other output from database read/write operations?
 #' @param ... Additional arguments passed to `write_sf()` for writing spatial layers.
 #'
-#' @return Character. Vector of layer/table names in `filename`.
+#' @return _character_. Vector of layer/table names in `filename`.
 #' @seealso [downloadSSURGO()]
 #' @export
 #' @examples

--- a/R/createSSURGO.R
+++ b/R/createSSURGO.R
@@ -155,12 +155,12 @@ downloadSSURGO <- function(WHERE = NULL,
 
         # explicitly fetch internal function our namespace to support parallel workers
         INV.FUN <- get(".inventory_ssurgo_files", envir = asNamespace("soilDB"))
-        inv <- INV.FUN(lz, include_spatial = include_spatial, include_tabular = include_tabular)
+        inv <- INV.FUN(lz, exdir = exdir, include_spatial = include_spatial, include_tabular = include_tabular)
 
         lz <- unlist(c(inv$f.shp.sc, inv$f.txt.grp))
       }
       uz <- utils::unzip(paths2[i], files = lz, exdir = exdir)
-      if ((!dir.exists(file.path(exdir, ssa)) || overwrite) && length(uz) == 0) {
+      if (length(uz) == 0) {
         message(paste('Invalid zipfile:', paths2[i]))
       } else {
         if (!quiet) {

--- a/man/createSSURGO.Rd
+++ b/man/createSSURGO.Rd
@@ -21,18 +21,18 @@ createSSURGO(
 )
 }
 \arguments{
-\item{filename}{\emph{character}. Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'}). Only used when \code{con} is not
-specified by the user.}
+\item{filename}{\emph{character}. Output file name (e.g. \code{'db.sqlite'} or \code{'db.gpkg'}). Only used when
+\code{con} is not specified by the user.}
 
-\item{exdir}{\emph{character}. Path containing containing input SSURGO spatial (.shp) and tabular (.txt) files,
-downloaded and extracted by \code{downloadSSURGO()} or similar.}
+\item{exdir}{\emph{character}. Path containing containing input SSURGO spatial (.shp) and tabular
+(.txt) files, downloaded and extracted by \code{downloadSSURGO()} or similar.}
 
 \item{conn}{A \emph{DBIConnection} object. Default is a \code{SQLiteConnection} used for writing .sqlite or
 .gpkg files. Alternate options are any DBI connection types. When \code{include_spatial=TRUE}, the
 sf package is used to write spatial data to the database.}
 
-\item{pattern}{\emph{character}. Optional regular expression to use to filter subdirectories of \code{exdir}.
-Default: \code{NULL} will search all subdirectories for SSURGO export files.}
+\item{pattern}{\emph{character}. Optional regular expression to use to filter subdirectories of
+\code{exdir}. Default: \code{NULL} will search all subdirectories for SSURGO export files.}
 
 \item{include_spatial}{\emph{logical} or \emph{character}. Include spatial data layers in database?
 Default: \code{TRUE} inserts all spatial tables. If \code{include_spatial} is a \emph{character} vector
@@ -45,13 +45,12 @@ descriptions are stored in table \code{"featdesc"} and metadata for each soil su
 in \code{"soil_metadata"} tables.}
 
 \item{dissolve_field}{\emph{character}. Dissolve geometries to create MULTIPOLYGON features? Column
-name
-specified is the grouping variable. Default: \code{NULL} does no aggregation, giving 1 \code{POLYGON}
-feature per delineation. \code{"mukey"} aggregates all related delineations within a soil survey
-area.}
+name specified is the grouping variable. Default: \code{NULL} does no aggregation, giving 1
+\code{POLYGON} feature per delineation. \code{"mukey"} aggregates all related delineations within a soil
+survey area.}
 
-\item{maxruledepth}{\emph{integer}. Maximum rule depth for \code{"cointerp"} table. Default \code{0} includes only
-shallowest ratings for smaller database size.}
+\item{maxruledepth}{\emph{integer}. Maximum rule depth for \code{"cointerp"} table. Default \code{0} includes
+only shallowest ratings for smaller database size.}
 
 \item{overwrite}{\emph{logical}. Overwrite existing layers? Default: \code{FALSE}}
 
@@ -65,7 +64,7 @@ containing tabular data.}
 \item{...}{Additional arguments passed to \code{write_sf()} for writing spatial layers.}
 }
 \value{
-Character. Vector of layer/table names in \code{filename}.
+\emph{character}. Vector of layer/table names in \code{filename}.
 }
 \description{
 The following database types are tested and fully supported:

--- a/man/downloadSSURGO.Rd
+++ b/man/downloadSSURGO.Rd
@@ -15,6 +15,7 @@ downloadSSURGO(
   db = c("SSURGO", "STATSGO"),
   extract = TRUE,
   LAPPLY.FUN = lapply,
+  LAPPLY.FUN.ARGS = NULL,
   remove_zip = FALSE,
   overwrite = FALSE,
   quiet = FALSE
@@ -42,9 +43,9 @@ containing table names, only that set is extracted from the downloaded ZIP files
 \code{include_spatial=c("mupolygon", "featpoint")} extracts only the shapefiles (with side car
 files) for mapunit polygons and special feature points.}
 
-\item{include_tabular}{\emph{logical} or \emph{character}. Include tabular data layers in database?
-Default: \code{TRUE} inserts all tabular tables. If \code{include_tabular} is a \emph{character} vector
-containing table names, only that set is extracted from the downloaded ZIP files. e.g.
+\item{include_tabular}{\emph{logical} or \emph{character}. Extract tabular data from ZIP file? Default:
+\code{TRUE} inserts all tabular tables. If \code{include_tabular} is a \emph{character} vector containing
+table names, only that set is extracted from the downloaded ZIP files. e.g.
 \code{include_tabular=c("mapunit", "muaggatt")} writes only the \code{mapunit} and \code{muaggatt} tables.
 Note that special feature descriptions are stored in table \code{"featdesc"} and metadata for each
 soil survey area are stored in \code{"soil_metadata"} tables.}
@@ -58,6 +59,8 @@ soil map).}
 phase. Only used if \code{extract=TRUE}. This allows for the \code{utils::unzip()} operations to be run
 in parallel instead of sequential, custom progress reporting, or similar.}
 
+\item{LAPPLY.FUN.ARGS}{\emph{list}. Optional list of additional arguments to pass to \code{LAPPLY.FUN}.}
+
 \item{remove_zip}{\emph{logical}. Remove ZIP files after extracting? Default: \code{FALSE}}
 
 \item{overwrite}{\emph{logical}. Overwrite by re-extracting if directory already exists? Default:
@@ -69,15 +72,11 @@ in parallel instead of sequential, custom progress reporting, or similar.}
 \emph{character}. Paths to downloaded ZIP files (invisibly). May not exist if \code{remove_zip = TRUE}.
 }
 \description{
-Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files with standard
-SSURGO format; optionally including the corresponding SSURGO Template Database with
-\code{include_template=TRUE}.
+Download ZIP files containing spatial (ESRI shapefile) and tabular (TXT) files in standard SSURGO
+format. To specify the Soil Survey Areas you would like to download, use a \code{WHERE} clause for
+query of \code{sacatalog} table, for example: \code{areasymbol = 'CA067'}, \code{"areasymbol IN ('CA628', 'CA067')"}, or \verb{areasymbol LIKE 'CT\%'}.
 }
 \details{
-To specify the Soil Survey Areas you would like to obtain data you use a \code{WHERE} clause for query
-of \code{sacatalog} table such as \code{areasymbol = 'CA067'}, \code{"areasymbol IN ('CA628', 'CA067')"} or
-\verb{areasymbol LIKE 'CT\%'}.
-
 Pipe-delimited TXT files are found in \emph{/tabular/} folder extracted from a SSURGO ZIP.
 The files are named for tables in the SSURGO schema. There is no header and the files do not
 have column names. See the \emph{Soil Data Access Tables and Columns Report}:
@@ -89,16 +88,16 @@ Several ESRI shapefiles are found in the \emph{/spatial/} folder extracted from 
 have prefix \code{soilmu_} (mapunit), \code{soilsa_} (survey area), \code{soilsf_} (special features). There
 will also be a TXT file with prefix \code{soilsf_} describing any special features. Shapefile names
 then have an \code{a_} (polygon), \code{l_} (line), \code{p_} (point) followed by the soil survey area symbol.
-When \code{db="STATSGO"} the \code{WHERE} argument is not supported. Allowed \code{areasymbols} include
-\code{"US"} and two-letter state codes e.g. \code{"WY"} for the Wyoming general soils map.
+When \code{db="STATSGO"} the \code{WHERE} argument is not supported. Allowed \code{areasymbols} include \code{"US"}
+and two-letter state codes e.g. \code{"WY"} for the Wyoming general soils map.
 
 As in \code{createSSURGO()}, the \code{include_spatial} and \code{include_tabular} arguments either take a
-logical value (default \code{TRUE}) or a character vector of the specific table names to include. Note
-that when used in \code{downloadSSURGO()} the required metadata files are \emph{always} extracted to
+logical value (default \code{TRUE}) or a character vector of the specific table names to include.
+Note that when used in \code{downloadSSURGO()} the required metadata files are \emph{always} extracted to
 facilitate mapping to user-facing table names. These arguments allow for customizing the files
 that get extracted from ZIP files, not just filtering on file names (as is implemented with
-pre-existing \code{pattern} argument). This can dramatically improve efficiency of extraction and the
-overall size of the data in \code{exdir}. These arguments can be used in conjunction with the
+pre-existing \code{pattern} argument). This can dramatically improve efficiency of extraction and
+the overall size of the data in \code{exdir}. These arguments can be used in conjunction with the
 \code{pattern} argument to fine-tune the files included in the generated snapshot database.
 }
 \seealso{

--- a/man/downloadSSURGO.Rd
+++ b/man/downloadSSURGO.Rd
@@ -14,6 +14,7 @@ downloadSSURGO(
   include_tabular = TRUE,
   db = c("SSURGO", "STATSGO"),
   extract = TRUE,
+  LAPPLY.FUN = lapply,
   remove_zip = FALSE,
   overwrite = FALSE,
   quiet = FALSE
@@ -52,6 +53,10 @@ soil survey area are stored in \code{"soil_metadata"} tables.}
 soil map).}
 
 \item{extract}{\emph{logical}. Extract ZIP files to \code{exdir}? Default: \code{TRUE}}
+
+\item{LAPPLY.FUN}{\emph{function}. \code{lapply()}-like function to use for iteration during \code{extract}
+phase. Only used if \code{extract=TRUE}. This allows for the \code{utils::unzip()} operations to be run
+in parallel instead of sequential, custom progress reporting, or similar.}
 
 \item{remove_zip}{\emph{logical}. Remove ZIP files after extracting? Default: \code{FALSE}}
 


### PR DESCRIPTION
Adds arguments `LAPPLY.FUN` and `LAPPLY.FUN.ARGS` to `downloadSSURGO()`

Closes #470

Using `future.apply::future_lapply()` with a 8-session future plan, the OCONUS example extracts 158 ZIP files in about 3-5 seconds on my GFE. This is a massive improvement over sequential approach where massive latency in I/O for a few different reasons is a major blocker. 

```r
library(soilDB)
library(future)

plan(multisession, workers = 8)

td <- "ssurgo"

AREASYMBOLS <- SDA_query(
  "SELECT areasymbol, saverest 
   FROM sacatalog
   WHERE SUBSTRING(areasymbol, 0, 3) IN ('PR', 'VI', 'HI', 'AK', 'PW', 'GU', 'AS', 'MP');"
)$areasymbol

downloadSSURGO(
  areasymbols = AREASYMBOLS,
  destdir = td,
  include_spatial = "mupolygon",
  include_tabular = c("mapunit", "muaggatt"),
  extract = FALSE, 
  overwrite = TRUE
) |> system.time()

downloadSSURGO(
  areasymbols = AREASYMBOLS,
  destdir = td,
  include_spatial = "mupolygon",
  include_tabular = c("mapunit", "muaggatt"),
  LAPPLY.FUN = future.apply::future_lapply,
  overwrite = TRUE
) |> system.time()

createSSURGO(
  "OCONUS.gpkg",
  exdir = td,
  overwrite = TRUE
) |> system.time()

DBI::dbListTables(con <- NASIS("OCONUS.gpkg"))

con2 <- DBI::dbConnect(duckdb::duckdb("OCONUS.duckdb"))

createSSURGO(
  conn = con2,
  exdir = td, 
  overwrite = TRUE
) |> system.time()

DBI::dbListTables(con2)
DBI::dbDisconnect(con)
DBI::dbDisconnect(con2)
```