### PR TITLE
fix: `structure()` usage for R-devel/CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilDB
 Type: Package
 Title: Soil Database Interface
-Version: 2.9.2
+Version: 2.9.3
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut"), email = "dylan.beaudette@usda.gov", comment=c(ORCID="0009-0008-2780-4785")),
              person(given="Jay", family="Skovlin", role = c("aut")), 
              person(given="Stephen", family="Roecker", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# soilDB 2.9.3 (2026-09-05) 
+ - `createSSURGO()` fix bug in logical column handling (introduced in 2.9.2) due to metadata column type enforcement (#483)
+ - Fix `structure()` usage of special argument names (.Label, .Names) in test fixtures for R-devel (#484)
+
 # soilDB 2.9.2 (2026-07-10)
  - EDIT base URL (for `get_EDIT_ecoclass_by_geoUnit()` and `make_EDIT_service_URL()`) updated to new USDA-managed server: <https://edit.sc.egov.usda.gov/>
  - SoilWeb-based Web Coverage Services (`soilColor.wcs()`, `ISSR800.wcs()`, `mukey.wcs()`) have been updated with FY26 maps, now including most OCONUS soil surveys (AK, HI, PR, PW, GU, AS, MP)

--- a/tests/testthat/test-simplifyFragmentData.R
+++ b/tests/testthat/test-simplifyFragmentData.R
@@ -6,11 +6,9 @@ context("Simplification of fragment data (from NASIS)")
 ## some complex data from NASIS phfrags table
 d.single.hz <- structure(
   list(
-    phiid = c(1202607L, 1202607L, 1202607L, 1202607L,
-              1202607L),
+    phiid = c(1202607L, 1202607L, 1202607L, 1202607L, 1202607L),
     fragvol = c(5, 30, 10, 30, 5),
-    fragsize_l = c(2L,
-                   76L, 76L, 2L, 251L),
+    fragsize_l = c(2L, 76L, 76L, 2L, 251L),
     fragsize_r = c(
       NA_integer_,
       NA_integer_,
@@ -18,8 +16,7 @@ d.single.hz <- structure(
       NA_integer_,
       NA_integer_
     ),
-    fragsize_h = c(75L, 250L,
-                   250L, 75L, 600L),
+    fragsize_h = c(75L, 250L, 250L, 75L, 600L),
     fragshp = structure(
       c(
         NA_integer_,
@@ -28,13 +25,12 @@ d.single.hz <- structure(
         NA_integer_,
         NA_integer_
       ),
-      .Label = c("flat", "nonflat"),
+      levels = c("flat", "nonflat"),
       class = "factor"
     ),
     fraghard = structure(
-      c(10L, 2L, 10L, 2L,
-        2L),
-      .Label = c(
+      c(10L, 2L, 10L, 2L, 2L),
+      levels = c(
         "noncemented",
         "indurated",
         "moderately cemented",
@@ -53,7 +49,7 @@ d.single.hz <- structure(
       class = "factor"
     )
   ),
-  .Names = c(
+  names = c(
     "phiid",
     "fragvol",
     "fragsize_l",
@@ -66,14 +62,13 @@ d.single.hz <- structure(
   class = "data.frame"
 )
 
+
 ## data from NASIS phfrags with NA fragvol
 d.missing.fragvol <- structure(
   list(
-    phiid = c(1386592L, 1386592L, 1386592L, 1386592L,
-              1386592L, 1386592L),
+    phiid = c(1386592L, 1386592L, 1386592L, 1386592L, 1386592L, 1386592L),
     fragvol = c(10, 10, 20, 20, 10, NA),
-    fragsize_l = c(2L,
-                   2L, 75L, 75L, 380L, NA),
+    fragsize_l = c(2L, 2L, 75L, 75L, 380L, NA),
     fragsize_r = c(
       NA_integer_,
       NA_integer_,
@@ -82,17 +77,15 @@ d.missing.fragvol <- structure(
       NA_integer_,
       NA_integer_
     ),
-    fragsize_h = c(75L,
-                   75L, 380L, 380L, 600L, NA),
+    fragsize_h = c(75L, 75L, 380L, 380L, 600L, NA),
     fragshp = structure(
-      c(1L, 1L, 1L,
-        1L, 1L, NA),
-      .Label = c("flat", "nonflat"),
+      c(1L, 1L, 1L, 1L, 1L, NA),
+      levels = c("flat", "nonflat"),
       class = "factor"
     ),
     fraghard = structure(
       c(11L, 9L, 11L, 9L, 11L, NA),
-      .Label = c(
+      levels = c(
         "noncemented",
         "indurated",
         "moderately cemented",
@@ -111,7 +104,7 @@ d.missing.fragvol <- structure(
       class = "factor"
     )
   ),
-  .Names = c(
+  names = c(
     "phiid",
     "fragvol",
     "fragsize_l",
@@ -204,7 +197,7 @@ d.missing.size <-
           NA_integer_,
           NA_integer_
         ),
-        .Label = c("flat", "nonflat"),
+        levels = c("flat", "nonflat"),
         class = "factor"
       ),
       fraghard = structure(
@@ -222,7 +215,7 @@ d.missing.size <-
           NA_integer_,
           NA_integer_
         ),
-        .Label = c(
+        levels = c(
           "noncemented",
           "indurated",
           "moderately cemented",
@@ -241,7 +234,7 @@ d.missing.size <-
         class = "factor"
       )
     ),
-    .Names = c(
+    names = c(
       "phiid",
       "fragvol",
       "fragsize_l",

--- a/tests/testthat/test-uncode.R
+++ b/tests/testthat/test-uncode.R
@@ -6,7 +6,7 @@ test_that("uncode() works", {
 test_that("uncode() works w/ NASISDomainsAsFactor(TRUE)", {
   NASISDomainsAsFactor(TRUE)
   x <- data.frame(texcl = 1:10)
-  expect_equivalent(uncode(x)$texcl, structure(1:10, .Label = c("cos", "s", "fs", "vfs", "lcos", "ls", 
+  expect_equivalent(uncode(x)$texcl, structure(1:10, levels = c("cos", "s", "fs", "vfs", "lcos", "ls", 
                                                            "lfs", "lvfs", "cosl", "sl", "fsl", "vfsl", "l", "sil", "si", 
                                                            "scl", "cl", "sicl", "sc", "sic", "c"), class = "factor")) 
   NASISDomainsAsFactor(FALSE)
@@ -30,7 +30,7 @@ test_that("code() works w/ NASISDomainsAsFactor(TRUE)", {
 
 test_that("NASISChoiceList() works", {
   x <- NASISChoiceList(1:3, colnames = "texcl")
-  expect_equivalent(x, structure(c(3L, 12L, 5L), .Label = c("c", "cl", "cos", "cosl", 
+  expect_equivalent(x, structure(c(3L, 12L, 5L), levels = c("c", "cl", "cos", "cosl", 
                                        "fs", "fsl", "l", "lcos", "lfs", "ls", "lvfs", "s", "sc", "scl", 
                                        "si", "sic", "sicl", "sil", "sl", "vfs", "vfsl"), class = "factor"))
   
@@ -43,7 +43,7 @@ test_that("NASISChoiceList() works", {
 
   # ordered factor including obsolete choices
   x <- NASISChoiceList("common", colnames = "flodfreqcl", choice = "ChoiceName", obsolete = TRUE)
-  expect_equivalent(x, structure(5L, .Label = c("none", "very rare", "rare", "occasional", 
+  expect_equivalent(x, structure(5L, levels = c("none", "very rare", "rare", "occasional", 
                                            "common", "frequent", "very frequent"), 
                             class = c("ordered", "factor")))
   


### PR DESCRIPTION
- Fix `structure()` usage of special argument names (.Label, .Names) in test fixtures for R-devel